### PR TITLE
handle deadlocks for cleanup jobs

### DIFF
--- a/cartography/intel/aws/cloudwatch.py
+++ b/cartography/intel/aws/cloudwatch.py
@@ -315,7 +315,7 @@ def transform_metrics(mets: List[Dict], account_id: str, region: str) -> List[Di
         console_arn = f"arn:aws:cloudwatch:{region if region else ''}:{account_id if account_id else ''}:metrics/{metric['MetricName']}"
         # metric['consolelink'] = aws_console_link.get_console_link(console_arn)
         metric["consolelink"] = ""
-        metric["arn"] = metric["MetricName"]
+        metric["arn"] = f"arn:aws:cloudwatch:{region}:{account_id}:metrics/{metric['MetricName']}"
         metric["region"] = region
         metrics.append(metric)
 
@@ -342,7 +342,7 @@ def _load_metrics_tx(
 ) -> None:
     query: str = """
     UNWIND $Records as record
-    MERGE (metric:AWSCloudWatchMetric{id: record.MetricName})
+    MERGE (metric:AWSCloudWatchMetric{id: record.arn})
     ON CREATE SET metric.firstseen = timestamp(),
         metric.arn = record.arn
     SET metric.lastupdated = $aws_update_tag,

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -152,6 +152,7 @@ def run_cleanup_job(
         logger.warning(f"Failed to cleanup - {filename}. parameters - {common_job_parameters}, Error - {e}")
         # to handle deadlocks retry transaction
         if retry < 2:
+            retry += 1
             run_cleanup_job(filename=filename, common_job_parameters=common_job_parameters, retry=retry)
 
 


### PR DESCRIPTION
Handled the neo4j error `Failed write transaction for neo4j. Error - {code: Neo.TransientError.Transaction.DeadlockDetected}`
This occurred because multiple operations were performed on same node.
Due to this error the exception `Unhandled error while executing statement in job 'cleanup AWS CloudWatch Metric': AttributeError("'NoneType' object has no attribute 'counters'")` occurred.