### PR TITLE
Cloudfront Bug: Added Logic to map Cloudfront to S3 Buckets

### DIFF
--- a/cartography/intel/aws/cloudfront.py
+++ b/cartography/intel/aws/cloudfront.py
@@ -39,6 +39,12 @@ def get_cloudfront_distributions(boto3_session: boto3.session.Session) -> List[D
 def trtansform_distribution(dists: List[Dict]) -> List[Dict]:
     distributions = []
     for distribution in dists:
+        bucketId = distribution.get("Origins", {}).get("Items", []).get("Id", "")
+
+        if bucketId.startswith("S3-"):
+            bucket_name = bucketId[3:]
+
+        distribution['S3bucketName'] = bucket_name
         distribution['region'] = 'global'
         distribution['arn'] = distribution['ARN']
         distribution['consolelink'] = aws_console_link.get_console_link(arn=distribution['arn'])
@@ -70,12 +76,18 @@ def _load_cloudfront_distributions_tx(tx: neo4j.Transaction, distributions: List
         distribution.viewer_protocol_policy = record.DefaultCacheBehavior.ViewerProtocolPolicy,
         distribution.web_acl_id = record.WebACLId,
         distribution.is_ipv6_enabled = record.IsIPV6Enabled,
-        distribution.http_version = record.HttpVersion
-    WITH distribution
+        distribution.http_version = record.HttpVersion,
+        distribution.s3_bucket_name = record.S3bucketName
+    WITH distribution, record
     MATCH (owner:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (owner)-[r:RESOURCE]->(distribution)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
+    WITH distribution, record
+    MATCH (bucket:S3Bucket {name: record.S3bucketName})
+    MERGE (distribution)-[rel:LINKED_TO]->(bucket)
+    ON CREATE SET rel.firstseen = timestamp()
+    SET rel.lastupdated = $aws_update_tag
     """
 
     tx.run(

--- a/cartography/intel/aws/cloudfront.py
+++ b/cartography/intel/aws/cloudfront.py
@@ -48,7 +48,7 @@ def trtansform_distribution(dists: List[Dict]) -> List[Dict]:
                 bucket_name = bucket_id[3:]
                 bucket_names.append(bucket_name)
 
-        distribution['S3bucketName'] = bucket_names
+        distribution['s3BucketNames'] = bucket_names
         distribution['region'] = 'global'
         distribution['arn'] = distribution['ARN']
         distribution['consolelink'] = aws_console_link.get_console_link(arn=distribution['arn'])
@@ -81,14 +81,14 @@ def _load_cloudfront_distributions_tx(tx: neo4j.Transaction, distributions: List
         distribution.web_acl_id = record.WebACLId,
         distribution.is_ipv6_enabled = record.IsIPV6Enabled,
         distribution.http_version = record.HttpVersion,
-        distribution.s3_bucket_names = record.S3bucketName
+        distribution.s3_bucket_names = record.s3BucketNames
     WITH distribution, record
     MATCH (owner:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (owner)-[r:RESOURCE]->(distribution)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     WITH distribution, record
-    UNWIND record.S3bucketName AS bucket_name
+    UNWIND record.s3BucketNames AS bucket_name
     MATCH (bucket:S3Bucket {name: bucket_name})
     MERGE (distribution)-[rel:LINKED_TO]->(bucket)
     ON CREATE SET rel.firstseen = timestamp()


### PR DESCRIPTION
- Extracted the S3 Bucket name from the API payload.
- Added a new field in the `AWSCloudfrontDistribution` node with the associated S3 Bucket name.
- Created a new relationship `LINKED_TO` through this bucket name between `AWSCloudfrontDistribution` node and `S3Bucket` node.
- Added a new field in the `S3Bucket` node with the associated cloudfront ARN through this newly created relationship.