### PR TITLE
GCP Assets Classification: Predefined or Customer Created

### DIFF
--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -1063,7 +1063,7 @@ def load_gcp_vpcs(neo4j_session: neo4j.Session, vpcs: List[Dict], gcp_update_tag
     vpc.description = $Description,
     vpc.consolelink = $consolelink,
     vpc.lastupdated = $gcp_update_tag,
-    vpc.createdby = $createdBy
+    vpc.created_by = $createdBy
 
     MERGE (p)-[r:RESOURCE]->(vpc)
     ON CREATE SET r.firstseen = timestamp()
@@ -1114,7 +1114,7 @@ def load_gcp_subnets(neo4j_session: neo4j.Session, subnets: List[Dict], gcp_upda
     subnet.vpc_partial_uri = $VpcPartialUri,
     subnet.consolelink = $consolelink,
     subnet.lastupdated = $gcp_update_tag,
-    subnet.createdby = $createdBy
+    subnet.created_by = $createdBy
 
     MERGE (vpc)-[r:RESOURCE]->(subnet)
     ON CREATE SET r.firstseen = timestamp()

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -719,7 +719,7 @@ def transform_gcp_subnets(subnet_res: Dict, projectId: str, compute: Resource) -
         subnet["private_ip_google_access"] = s.get("privateIpGoogleAccess", None)
 
         default_vpc = get_default_vpc(projectId=projectId, compute=compute)
-        if default_vpc.get("selfLink") == s.get("network"):
+        if default_vpc.get("selfLink") == s.get("network") and default_vpc.get("autoCreateSubnetworks"):
             subnet["createdBy"] = "predefined"
         else:
             subnet["createdBy"] = "user"

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -653,12 +653,33 @@ def transform_gcp_vpcs(vpc_res: Dict) -> List[Dict]:
         vpc["description"] = v.get("description", None)
         vpc["routing_config_routing_mode"] = v.get("routingConfig", {}).get("routingMode", None)
 
+        if v.get("name") == "default" and v.get("autoCreateSubnetworks"):
+            vpc["createdBy"] = "predefined"
+        else:
+            vpc["createdBy"] = "user"
+
         vpc_list.append(vpc)
     return vpc_list
 
 
+def get_default_vpc(projectId: str, compute: Resource):
+    vpc_response = get_gcp_vpcs(projectid=projectId, compute=compute)
+
+    if not vpc_response or 'items' not in vpc_response:
+        return None
+
+    default_vpc = next(
+        (network for network in vpc_response['items']
+         if network['name'] == 'default' and
+         network.get('autoCreateSubnetworks', False) == True),
+        None
+    )
+
+    return default_vpc
+
+
 @timeit
-def transform_gcp_subnets(subnet_res: Dict) -> List[Dict]:
+def transform_gcp_subnets(subnet_res: Dict, projectId: str, compute: Resource) -> List[Dict]:
     """
     Add additional fields to the subnet object to make it easier to process in `load_gcp_subnets()`.
     :param subnet_res: The response object returned from compute.subnetworks.list()
@@ -696,6 +717,12 @@ def transform_gcp_subnets(subnet_res: Dict) -> List[Dict]:
             subnet_name=subnet["name"],
         )
         subnet["private_ip_google_access"] = s.get("privateIpGoogleAccess", None)
+
+        default_vpc = get_default_vpc(projectId=projectId, compute=compute)
+        if default_vpc.get("selfLink") == s.get("network"):
+            subnet["createdBy"] = "predefined"
+        else:
+            subnet["createdBy"] = "user"
 
         subnet_list.append(subnet)
     return subnet_list
@@ -1035,7 +1062,8 @@ def load_gcp_vpcs(neo4j_session: neo4j.Session, vpcs: List[Dict], gcp_update_tag
     vpc.routing_config_routing_mode = $RoutingMode,
     vpc.description = $Description,
     vpc.consolelink = $consolelink,
-    vpc.lastupdated = $gcp_update_tag
+    vpc.lastupdated = $gcp_update_tag,
+    vpc.createdby = $createdBy
 
     MERGE (p)-[r:RESOURCE]->(vpc)
     ON CREATE SET r.firstseen = timestamp()
@@ -1054,6 +1082,7 @@ def load_gcp_vpcs(neo4j_session: neo4j.Session, vpcs: List[Dict], gcp_update_tag
             region=vpc.get("region"),
             consolelink=vpc.get("consolelink"),
             gcp_update_tag=gcp_update_tag,
+            createdBy=vpc.get("createdBy"),
         )
 
 
@@ -1084,7 +1113,8 @@ def load_gcp_subnets(neo4j_session: neo4j.Session, subnets: List[Dict], gcp_upda
     subnet.private_ip_google_access = $PrivateIpGoogleAccess,
     subnet.vpc_partial_uri = $VpcPartialUri,
     subnet.consolelink = $consolelink,
-    subnet.lastupdated = $gcp_update_tag
+    subnet.lastupdated = $gcp_update_tag,
+    subnet.createdby = $createdBy
 
     MERGE (vpc)-[r:RESOURCE]->(subnet)
     ON CREATE SET r.firstseen = timestamp()
@@ -1105,6 +1135,7 @@ def load_gcp_subnets(neo4j_session: neo4j.Session, subnets: List[Dict], gcp_upda
             PrivateIpGoogleAccess=s["private_ip_google_access"],
             consolelink=s["consolelink"],
             gcp_update_tag=gcp_update_tag,
+            createdBy=s["createdBy"],
         )
 
 
@@ -1862,7 +1893,7 @@ def sync_gcp_subnets(
     for r in regions:
         logger.info("Subnet Region %s.", r)
         subnet_res = get_gcp_subnets(project_id, r, compute)
-        subnets = transform_gcp_subnets(subnet_res)
+        subnets = transform_gcp_subnets(subnet_res, project_id, compute)
 
         load_gcp_subnets(neo4j_session, subnets, gcp_update_tag)
         # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381


### PR DESCRIPTION
Added the logic for distinguishing the VPCs and Subnets in GCP as customer created & predefined.
@mpurusottamc please let me know if the logic for getting the default VPC is concrete enough...as in GCP APIs we don't have the `isDefault` field that we used to have in AWS APIs.