### PR TITLE
Changed the logic for storing the RDS Database name

### DIFF
--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -487,7 +487,7 @@ def load_rds_instances(
             rds.db_instance_class = rds_instance.DBInstanceClass,
             rds.engine = rds_instance.Engine,
             rds.master_username = rds_instance.MasterUsername,
-            rds.db_name = rds_instance.DBName,
+            rds.db_name = rds_instance.DatabaseName,
             rds.consolelink = rds_instance.consolelink,
             rds.instance_create_time = rds_instance.InstanceCreateTime,
             rds.availability_zone = rds_instance.AvailabilityZone,
@@ -543,6 +543,11 @@ def load_rds_instances(
 
         if rds.get('DBSubnetGroup'):
             subnets.append(rds)
+
+        if rds.get("Engine") in ["aurora-mysql", "mysql", "mariadb", "aurora-postgres", "postgres", "aurora-postgresql", "postgresql"]:
+            arn = rds.get("DBInstanceArn", "")
+            database_name = arn.split(":db:")[-1] if ":db:" in arn else ""
+            rds['DatabaseName'] = rds.get("DBName", database_name)
 
         rds['InstanceCreateTime'] = dict_value_to_str(rds, 'InstanceCreateTime')
         rds['LatestRestorableTime'] = dict_value_to_str(rds, 'LatestRestorableTime')


### PR DESCRIPTION
@mpurusottamc 
1. So there was field named `db_name` already present in the cartography
2. But that field was not present when I checked the data of our QA Account on my local neo4j db. So this field is not present always. 
3. Hence I directly fetched the name of the DB from ARN (this was the ARN for the RDS Instance of our QA Account `arn:aws:rds:ap-south-1:581155127348:db:aurora-mysql-instance1` which is same as the screenshot you shared). 
4. As a fallback I have set the `db_name` field to the value from this ARN if the DBName field comes empty.

No changes needed on the inventory side.