### PR TITLE
added support for storing primary language of repos in bitbucket

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -2,6 +2,8 @@ import enum
 import json
 import logging
 import time
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import Dict
 from typing import List
@@ -16,8 +18,6 @@ from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
-
-from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -2,8 +2,6 @@ import enum
 import json
 import logging
 import time
-from datetime import datetime
-from datetime import timezone
 from typing import Any
 from typing import Dict
 from typing import List
@@ -18,6 +16,8 @@ from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
+
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()

--- a/cartography/intel/bitbucket/repositories.py
+++ b/cartography/intel/bitbucket/repositories.py
@@ -32,14 +32,40 @@ def get_repos(access_token: str, workspace: str) -> List[Dict]:
     return repositories
 
 
-def transform_repos(workspace_repos: List[Dict], workspace: str) -> List[Dict]:
+def _transform_repo_languages(repo_url: str, repo: Dict, repo_languages: List[Dict]) -> None:
+    """
+    Helper function to transform the languages in a Bitbucket repo.
+    :param repo_url: The URL of the repo.
+    :param repo: The repo object from Bitbucket API.
+    :param repo_languages: Output array to append transformed results to.
+    """
+    if repo.get("language"):
+        repo_languages.append(
+            {
+                "repo_id": repo["uuid"],
+                "language_name": repo["language"],
+            },
+        )
+
+
+def transform_repos(workspace_repos: List[Dict], workspace: str) -> Dict:
+    """
+    Transform the repos data including languages
+    """
+    transformed_repo_list = []
+    transformed_repo_languages = []
+
     for repo in workspace_repos:
+        # Existing transformations
         repo["workspace"]["uuid"] = repo["workspace"]["uuid"].replace("{", "").replace("}", "")
         repo["project"]["uuid"] = repo["project"]["uuid"].replace("{", "").replace("}", "")
         repo["uuid"] = repo["uuid"].replace("{", "").replace("}", "")
 
         if repo is not None and repo.get("mainbranch") is not None:
             repo["default_branch"] = repo.get("mainbranch", {}).get("name", None)
+
+         # Transform languages
+        _transform_repo_languages(repo["url"], repo, transformed_repo_languages)
 
         data = {
             "workspace": workspace,
@@ -48,12 +74,46 @@ def transform_repos(workspace_repos: List[Dict], workspace: str) -> List[Dict]:
         }
 
         repo["uniqueId"] = bitbucket_linker.get_unique_id(service="bitbucket", data=data, resource_type="repository")
+        transformed_repo_list.append(repo)
 
-    return workspace_repos
+    return {
+        "repos": transformed_repo_list,
+        "repo_languages": transformed_repo_languages,
+    }
 
 
 def load_repositories_data(session: neo4j.Session, repos_data: List[Dict], common_job_parameters: Dict) -> None:
     session.write_transaction(_load_repositories_data, repos_data, common_job_parameters)
+
+
+@timeit
+def load_languages(neo4j_session: neo4j.Session, update_tag: int, repo_languages: List[Dict]) -> None:
+    """
+    Ingest the relationships for repo languages
+    :param neo4j_session: Neo4J session object for server communication
+    :param update_tag: Timestamp used to determine data freshness
+    :param repo_languages: list of language to repo mappings
+    """
+    ingest_languages = """
+        UNWIND $Languages as lang
+
+        MERGE (pl:ProgrammingLanguage{id: lang.language_name})
+        ON CREATE SET pl.firstseen = timestamp(),
+        pl.name = lang.language_name
+        SET pl.lastupdated = $UpdateTag
+        WITH pl, lang
+
+        MATCH (repo:BitbucketRepository{id: lang.repo_id})
+        MERGE (repo)-[r:LANGUAGE]->(pl)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = $UpdateTag
+    """
+
+    neo4j_session.run(
+        ingest_languages,
+        Languages=repo_languages,
+        UpdateTag=update_tag,
+    )
 
 
 def _load_repositories_data(tx: neo4j.Transaction, repos_data: List[Dict], common_job_parameters: Dict) -> None:
@@ -66,19 +126,30 @@ def _load_repositories_data(tx: neo4j.Transaction, repos_data: List[Dict], commo
     SET re.slug = repo.slug,
     re.type = repo.type,
     re.unique_id = repo.uniqueId,
-    re.name=repo.name,
+    re.name = repo.name,
     re.is_private = repo.is_private,
-    re.description=repo.description,
-    re.full_name=repo.full_name,
-    re.has_issues=repo.has_issues,
-    re.language=repo.language,
-    re.owner=repo.owner.display_name,
-    re.parent=repo.parent.name,
-    re.default_branch=repo.default_branch,
+    re.description = repo.description,
+    re.full_name = repo.full_name,
+    re.has_issues = repo.has_issues,
+    re.language = repo.language,
+    re.owner = repo.owner,
+    re.default_branch = repo.default_branch,
     re.lastupdated = $UpdateTag
+
+
     WITH re,repo
-    MATCH (project:BitbucketProject{id:repo.project.uuid})
-    merge (project)<-[o:RESOURCE]-(re)
+    WHERE repo.language IS NOT NULL
+    MERGE (pl:ProgrammingLanguage{id: repo.language})
+    ON CREATE SET pl.firstseen = timestamp(),
+    pl.name = repo.language
+    SET pl.lastupdated = $UpdateTag
+    MERGE (re)-[lang:PRIMARY_LANGUAGE]->(pl)
+    ON CREATE SET lang.firstseen = timestamp()
+    SET lang.lastupdated = $UpdateTag
+
+    WITH re,repo
+    MATCH (project:BitbucketProject{id:repo.project_uuid})
+    MERGE (project)<-[o:RESOURCE]-(re)
     ON CREATE SET o.firstseen = timestamp()
     SET o.lastupdated = $UpdateTag
     """
@@ -114,8 +185,14 @@ def sync(
 
     logger.info("Syncing Bitbucket All Repositories")
     workspace_repos = get_repos(bitbucket_access_token, workspace_name)
-    workspace_repos = transform_repos(workspace_repos, workspace_name)
-    load_repositories_data(neo4j_session, workspace_repos, common_job_parameters)
+    transformed_data = transform_repos(workspace_repos, workspace_name)
+
+    # Load repositories
+    load_repositories_data(neo4j_session, transformed_data["repos"], common_job_parameters)
+
+    # Load languages
+    load_languages(neo4j_session, common_job_parameters["UPDATE_TAG"], transformed_data["repo_languages"])
+
     cleanup(neo4j_session, common_job_parameters)
 
     toc = time.perf_counter()


### PR DESCRIPTION
### changelog -
- `transform_repo_lanuguages` to associate lanuguage with repos
- changed `transform_repos` similar to that in github
- `load_lanuguage` to load language for repos and have similar relationship with repos as seen in github ( primary lang relationship