### PR TITLE
updated the query to match compliance project

### DIFF
--- a/cartography/data/jobs/analysis/aws_rds_asset_exposure.json
+++ b/cartography/data/jobs/analysis/aws_rds_asset_exposure.json
@@ -10,11 +10,11 @@
 			"iterative": false
 		},
 		{
-			"query": "MATCH (cidr:IpRange{range:'0.0.0.0/0'})—[:MEMBER_OF_IP_RULE]->(:IpPermissionInbound)—[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rds:RDSInstance{publicly_accessible: true})<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})<-[:OWNER]-(:AWSOrganization{id: $ORGANIZATION_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET rds.exposed_internet = true,(CASE WHEN NOT 'direct_ipv4' IN coalesce(rds.exposed_internet_type , []) THEN rds END).exposed_internet_type = coalesce(rds.exposed_internet_type , []) + 'direct_ipv4';",
+			"query": "MATCH (cidr:IpRange{range:'0.0.0.0/0'})—[:MEMBER_OF_IP_RULE]->(:IpPermissionInbound)—[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rds:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})<-[:OWNER]-(:AWSOrganization{id: $ORGANIZATION_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET rds.exposed_internet = true,(CASE WHEN NOT 'direct_ipv4' IN coalesce(rds.exposed_internet_type , []) THEN rds END).exposed_internet_type = coalesce(rds.exposed_internet_type , []) + 'direct_ipv4';",
 			"iterative": false
 		},
 		{
-			"query": "MATCH (cidr:Ipv6Range{range:'::/0'})—[:MEMBER_OF_IP_RULE]->(:IpPermissionInbound)—[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rds:RDSInstance{publicly_accessible: true})<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})<-[:OWNER]-(:AWSOrganization{id: $ORGANIZATION_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET rds.exposed_internet = true,(CASE WHEN NOT 'direct_ipv6' IN coalesce(rds.exposed_internet_type , []) THEN rds END).exposed_internet_type = coalesce(rds.exposed_internet_type , []) + 'direct_ipv6';",
+			"query": "MATCH (cidr:Ipv6Range{range:'::/0'})—[:MEMBER_OF_IP_RULE]->(:IpPermissionInbound)—[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rds:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})<-[:OWNER]-(:AWSOrganization{id: $ORGANIZATION_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET rds.exposed_internet = true,(CASE WHEN NOT 'direct_ipv6' IN coalesce(rds.exposed_internet_type , []) THEN rds END).exposed_internet_type = coalesce(rds.exposed_internet_type , []) + 'direct_ipv6';",
 			"iterative": false
 		},
 		{


### PR DESCRIPTION
Removed the `{publicly_accessible: true}` filter to flag any RDS instance whose security group permits `0.0.0.0/0` or `::/0`—regardless of its `publicly_accessible` status—aligning with the compliance project’s logic.