### PR TITLE
Add: logic for list based ingestion for users, groups and roles

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -240,6 +240,7 @@ def start_azure_ingestion(
 ) -> None:
     common_job_parameters = {
         "WORKSPACE_ID": config.params['workspace']['id_string'],
+        "GROUPS": config.params.get('groups', []),
         "UPDATE_TAG": config.update_tag,
         "permission_relationships_file": config.permission_relationships_file,
         "pagination": {},


### PR DESCRIPTION
## Changes Implemented:
- Introduced a conditional workflow in `async_sync` that checks for a `GROUPS` parameter to determine whether to run a full or scoped sync.
- Created the `sync_scoped_users_and_groups` function to handle the new data fetching logic for the scoped context.
- The scoped sync returns a set of ingested `principal IDs` to ensure data consistency.
- Updated `sync_roles` to accept this set of `IDs` and filter Azure role assignments accordingly. This prevents the creation of incomplete relationships in the graph.

## Known Limitations
The current implementation of the scoped sync handles direct user members of the specified groups only. It does not recursively fetch `members` from `nested groups`, **nor** does it currently ingest other principal types (like `Service Principals`) that may be group members.