### PR TITLE
feature: Add is_spot_instance property to EC2Instance nodes

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -98,7 +98,7 @@ def load_ec2_instances(
     instance.tenancy = {Tenancy}, instance.hostresourcegrouparn = {HostResourceGroupArn},
     instance.platform = {Platform}, instance.architecture = {Architecture}, instance.ebsoptimized = {EbsOptimized},
     instance.bootmode = {BootMode}, instance.instancelifecycle = {InstanceLifecycle},
-    instance.hibernationoptions = {HibernationOptions}
+    instance.hibernationoptions = {HibernationOptions}, instance.is_spot_instance = {IsSpotInstance}
     WITH instance
     MATCH (rez:EC2Reservation{reservationid: {ReservationId}})
     MERGE (instance)-[r:MEMBER_OF_EC2_RESERVATION]->(rez)
@@ -203,6 +203,7 @@ def load_ec2_instances(
                 EbsOptimized=instance.get("EbsOptimized"),
                 BootMode=instance.get("BootMode"),
                 InstanceLifecycle=instance.get("InstanceLifecycle"),
+                IsSpotInstance=instance.get("InstanceLifecycle") == 'spot',
                 HibernationOptions=instance.get("HibernationOptions", {}).get("Configured"),
                 AWS_ACCOUNT_ID=current_aws_account_id,
                 Region=region,


### PR DESCRIPTION
Add a new boolean property is_spot_instance to EC2Instance nodes to indicate whether an instance is a Spot instance. This value is derived from the InstanceLifecycle field returned by AWS Boto3 describe_instances API. If the lifecycle is "spot", the property is set to true, otherwise false.