### PR TITLE
feat: add is_spot_instance support for AWS EC2, Azure, and GCP compute instances

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -201,7 +201,7 @@ def transform_ec2_instances(
 
             vm_os_version = os_details.get("Name", "Unknown")
 
-            is_spot_instance = instance.get("InstanceLifecycle") == "spot"
+            is_spot_instance = str(instance.get("InstanceLifecycle", "")).lower() == "spot"
 
             instance_list.append(
                 {

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -201,6 +201,8 @@ def transform_ec2_instances(
 
             vm_os_version = os_details.get("Name", "Unknown")
 
+            is_spot_instance = instance.get("InstanceLifecycle") == "spot"
+
             instance_list.append(
                 {
                     "InstanceId": instance_id,
@@ -236,6 +238,7 @@ def transform_ec2_instances(
                     "arn": InstanceArn,
                     "IamRoles": iam_roles,
                     "UserData": user_data,
+                    "IsSpotInstance": is_spot_instance,
                 },
             )
 

--- a/cartography/intel/azure/compute.py
+++ b/cartography/intel/azure/compute.py
@@ -69,7 +69,7 @@ def get_vm_list(credentials: Credentials, subscription_id: str, regions: list, c
             os_disk = vm.get("storage_profile", {}).get("os_disk", {})
             vm['os_type'] = os_disk.get('os_type')
             vm['os_disk_name'] = os_disk.get('name')
-            vm['is_spot_instance'] = True if vm.get('priority') == 'Spot' else False
+            vm['is_spot_instance'] = str(vm.get('priority', '')).lower() == 'spot'
             image_reference = vm.get("storage_profile", {}).get("image_reference", {})
             sku = image_reference.get('sku')
             offer = image_reference.get('offer')

--- a/cartography/intel/azure/compute.py
+++ b/cartography/intel/azure/compute.py
@@ -69,6 +69,7 @@ def get_vm_list(credentials: Credentials, subscription_id: str, regions: list, c
             os_disk = vm.get("storage_profile", {}).get("os_disk", {})
             vm['os_type'] = os_disk.get('os_type')
             vm['os_disk_name'] = os_disk.get('name')
+            vm['is_spot_instance'] = True if vm.get('priority') == 'Spot' else False
             image_reference = vm.get("storage_profile", {}).get("image_reference", {})
             sku = image_reference.get('sku')
             offer = image_reference.get('offer')
@@ -117,6 +118,7 @@ def load_vms(neo4j_session: neo4j.Session, subscription_id: str, vm_list: List[D
     v.identity_type=vm.identity.type, v.zones=vm.zones,
     v.ultra_ssd_enabled=vm.additional_capabilities.ultra_ssd_enabled,
     v.priority=vm.priority, v.eviction_policy=vm.eviction_policy,
+    v.is_spot_instance=vm.is_spot_instance,
     v.vm_size=vm.hardware_profile.vm_size,
     v.publisher=vm.storage_profile.image_reference.publisher,
     v.offer=vm.storage_profile.image_reference.offer,

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -545,6 +545,9 @@ def transform_gcp_instances(response_objects: List[Dict], compute: Resource) -> 
         x = res["zone_name"].split("-")
         res["region"] = f"{x[0]}-{x[1]}"
 
+        scheduling = res.get("scheduling", {})
+        res["is_spot_instance"] = scheduling.get("provisioningModel") == "SPOT" or scheduling.get("preemptible") is True
+
         for disk in res.get("disks", []):
             if disk.get("boot"):
                 res["diskName"] = disk.get("initializeParams", {}).get("diskName")
@@ -985,7 +988,8 @@ def load_gcp_instances_tx(tx: neo4j.Transaction, instances: Dict, gcp_update_tag
     i.machine_type = instance.machineType,
     i.source_image = instance.sourceImage,
     i.disk_name = instance.diskName,
-    i.os_features = instance.osFeatures
+    i.os_features = instance.osFeatures,
+    i.is_spot_instance = instance.is_spot_instance
     WITH i, p
 
     MERGE (p)-[r:RESOURCE]->(i)

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -546,7 +546,7 @@ def transform_gcp_instances(response_objects: List[Dict], compute: Resource) -> 
         res["region"] = f"{x[0]}-{x[1]}"
 
         scheduling = res.get("scheduling", {})
-        res["is_spot_instance"] = scheduling.get("provisioningModel") == "SPOT" or scheduling.get("preemptible") is True
+        res["is_spot_instance"] = str(scheduling.get("provisioningModel", "")).lower() == "spot" or scheduling.get("preemptible") is True
 
         for disk in res.get("disks", []):
             if disk.get("boot"):

--- a/cartography/models/aws/ec2/instances.py
+++ b/cartography/models/aws/ec2/instances.py
@@ -45,6 +45,7 @@ class EC2InstanceNodeProperties(CartographyNodeProperties):
     consolelink: PropertyRef = PropertyRef("consolelink")
     arn: PropertyRef = PropertyRef("arn")
     userdata: PropertyRef = PropertyRef("UserData")
+    is_spot_instance: PropertyRef = PropertyRef("IsSpotInstance")
 
 
 #    roleArn: PropertyRef = PropertyRef('RoleArn')


### PR DESCRIPTION
Changes:

- AWS EC2
  Added is_spot_instance field for EC2 instances  
  Value derived from instance lifecycle (spot vs on-demand)

- Azure Virtual Machines
  Added is_spot_instance support for Azure Virtual Machine ingestion  
  Identifies spot (low-priority) VMs

- GCP Compute Engine
  Added is_spot_instance support for GCP Compute Engine ingestion  
  Identifies preemptible (spot) instances