### PR TITLE
feat(oci): refactor OCI ingestion with cloudanix syncs

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -873,6 +873,33 @@ def run_gcp(request):
     return CLI(default_sync, prog="cartography").process(config)
 
 
+def run_oci(request):
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("neo4j").setLevel(logging.WARNING)
+
+    default_sync = cartography.sync.build_oci_sync()
+
+    config = Config(
+        neo4j_uri=request["neo4j"]["uri"],
+        neo4j_user=request["neo4j"]["user"],
+        neo4j_password=request["neo4j"]["pwd"],
+        neo4j_max_connection_lifetime=request["neo4j"]["connection_lifetime"],
+        params=request["params"],
+        oci_requested_syncs=request.get("services", None),
+        update_tag=request.get("updateTag", None),
+        oci_tenancy_id=request.get("params", {}).get("tenancyOCID", ""),
+        oci_compartment_id=request.get("params", {}).get("compartmentOCID", ""),
+    )
+
+    if request["logging"]["mode"] == "verbose":
+        config.verbose = True
+    elif request["logging"]["mode"] == "quiet":
+        config.quiet = True
+
+    return CLI(default_sync, prog="cartography").process(config)
+
+
 def run_github(request):
     logging.basicConfig(level=logging.INFO)
     logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -114,10 +114,13 @@ class Config:
         aws_requested_syncs=None,
         azure_requested_syncs=None,
         gcp_requested_syncs=None,
+        oci_requested_syncs=None,
         analysis_job_directory=None,
         crxcavator_api_base_uri=None,
         crxcavator_api_key=None,
         oci_sync_all_profiles=None,
+        oci_tenancy_id=None,
+        oci_compartment_id=None,
         okta_org_id=None,
         okta_api_key=None,
         okta_saml_role_regex=None,
@@ -178,10 +181,13 @@ class Config:
         self.aws_requested_syncs = aws_requested_syncs
         self.azure_requested_syncs = azure_requested_syncs
         self.gcp_requested_syncs = gcp_requested_syncs
+        self.oci_requested_syncs = oci_requested_syncs
         self.analysis_job_directory = analysis_job_directory
         self.crxcavator_api_base_uri = crxcavator_api_base_uri
         self.crxcavator_api_key = crxcavator_api_key
         self.oci_sync_all_profiles = oci_sync_all_profiles
+        self.oci_tenancy_id = oci_tenancy_id
+        self.oci_compartment_id = oci_compartment_id
         self.okta_org_id = okta_org_id
         self.okta_api_key = okta_api_key
         self.okta_saml_role_regex = okta_saml_role_regex

--- a/cartography/data/jobs/cleanup/oci_import_compartments_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_compartments_cleanup.json
@@ -1,9 +1,16 @@
 {
-  "statements": [{
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCICompartment) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(n:OCICompartment{ocid: $OCI_COMPARTMENT_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup OCICompartment",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/data/jobs/cleanup/oci_import_compute_instances_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_compute_instances_cleanup.json
@@ -1,0 +1,56 @@
+{
+    "statements": [
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCIInstance) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[r:RESOURCE]->(:OCIInstance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(n:OCIVnicAttachment) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[r:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCIImage) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[r:RESOURCE]->(:OCIImage) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[:OCI_BOOT_VOLUME_ATTACHMENT]->(n:OCIBootVolumeAttachment) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[r:OCI_BOOT_VOLUME_ATTACHMENT]->(:OCIBootVolumeAttachment) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[:OCI_VOLUME_ATTACHMENT]->(n:OCIVolumeAttachment) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{ocid: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIInstance)-[r:OCI_VOLUME_ATTACHMENT]->(:OCIVolumeAttachment) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+            "iterative": true,
+            "iterationsize": 100
+        }
+    ],
+    "name": "cleanup OCI Compute resources",
+    "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
+}

--- a/cartography/data/jobs/cleanup/oci_import_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_groups_cleanup.json
@@ -1,14 +1,16 @@
 {
-  "statements": [{
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIGroup) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:RESOURCE]->(:OCIGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIGroup) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:RESOURCE]->(:OCIGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup OCIGroup",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/data/jobs/cleanup/oci_import_groups_membership_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_groups_membership_cleanup.json
@@ -1,9 +1,11 @@
 {
-  "statements": [{
-    "query": "MATCH (:OCITenancy{ocidocid: $OCI_TENANCY_ID})-[:RESOURCE]->(:OCI_User)-[r:MEMBER_OCI_GROUP]->(:OCIGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
-  "name": "cleanup MEMBER_OCI_GROUP",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+  "statements": [
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(:OCIUser)-[r:MEMBER_OCID_GROUP]->(:OCIGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
+  "name": "cleanup MEMBER_OCID_GROUP",
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/data/jobs/cleanup/oci_import_policies_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_policies_cleanup.json
@@ -1,14 +1,16 @@
 {
-  "statements": [{
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OCI_POLICY]->(n:OCIPolicy) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:OCI_POLICY]->(:OCIPolicy) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OCI_POLICY]->(n:OCIPolicy) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:OCI_POLICY]->(:OCIPolicy) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup OCIPolicy",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/data/jobs/cleanup/oci_import_policies_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_policies_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
     {
-      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:OCI_POLICY]->(n:OCIPolicy) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIPolicy) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:OCI_POLICY]->(:OCIPolicy) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:RESOURCE]->(:OCIPolicy) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/oci_import_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_import_users_cleanup.json
@@ -1,9 +1,16 @@
 {
-  "statements": [{
-    "query": "MATCH (:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIUser) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIUser) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID})-[r:RESOURCE]->(:OCIUser) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup OCIUser",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/data/jobs/cleanup/oci_tenancy_cleanup.json
+++ b/cartography/data/jobs/cleanup/oci_tenancy_cleanup.json
@@ -1,10 +1,16 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:OCITenancy) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(n:OCITenancy{ocid: $OCI_TENANCY_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
-  }],
-  "name": "Cleanup OCI Tenancy's",
-  "comment":"Copyright (c) 2020, Oracle and/or its affiliates."
+    },
+    {
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[r:OWNER]->(:OCITenancy{ocid: $OCI_TENANCY_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
+  "name": "Cleanup OCI Tenancy",
+  "comment": "Copyright (c) 2020, Oracle and/or its affiliates."
 }

--- a/cartography/intel/oci/__init__.py
+++ b/cartography/intel/oci/__init__.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2020, Oracle and/or its affiliates.
+import base64
+import json
 import logging
 from collections import namedtuple
 from typing import Any
 from typing import Dict
-from typing import NamedTuple
+from typing import List
 
 import neo4j
 import oci
@@ -11,10 +13,13 @@ from oci.exceptions import ConfigFileNotFound
 from oci.exceptions import InvalidConfig
 from oci.exceptions import ProfileNotFound
 
+from . import compartment
 from . import iam
 from . import organizations
 from . import utils
+from .resources import RESOURCE_FUNCTIONS
 from cartography.config import Config
+from cartography.intel.oci.util.common import parse_and_validate_oci_requested_syncs
 # from cartography.util import run_analysis_job
 # from cartography.util import run_cleanup_job
 # from . import network
@@ -24,62 +29,97 @@ logger = logging.getLogger(__name__)
 Resources = namedtuple('Resources', 'compute iam network')
 
 
-def _sync_one_account(
+def _sync_one_compartment(
     neo4j_session: neo4j.Session,
     resources: Resources,
+    compartment_id: str,
     tenancy_id: str,
+    requested_syncs: List[str],
     oci_sync_tag: int,
     common_job_parameters: Dict[str, Any],
+    regions: List[str],
 ) -> None:
-    logger.info("Syncing OCI IAM client for OCI Tenancy with ID '%s'.", tenancy_id)
-    iam.sync(neo4j_session, resources.iam, tenancy_id, oci_sync_tag, common_job_parameters)
+    """
+    Sync requested services for a single OCI compartment.
+    Similar to Azure's _sync_one_subscription.
 
-    regions = utils.get_regions_in_tenancy(neo4j_session, tenancy_id)
-    for region in regions:
-        logger.info("Syncing OCI region '%s' for OCI Tenancy with ID '%s'.", region["name"], tenancy_id)
-        _change_resources_region(resources, region["name"])
-        # compute.sync(neo4j_session, resources.compute,
-        #   tenancy_id, region["name"], oci_sync_tag, common_job_parameters
-        # )
-        # network.sync(neo4j_session, resources.network,
-        #   tenancy_id, region["name"], oci_sync_tag, common_job_parameters
-        # )
+    If this is the default compartment (compartment_id == tenancy_id), IAM is run first
+    to populate regions. For child compartments, IAM is skipped.
+    """
+    is_default_compartment = (compartment_id == tenancy_id)
 
-    # Look into adding once DNS records are implemented.
-    # NOTE clean up all DNS records, regardless of which job created them
-    # run_cleanup_job('OCI_account_dns_cleanup.json', neo4j_session, common_job_parameters)
+    # For default compartment, run IAM first to populate regions
+    if is_default_compartment and "iam" in requested_syncs:
+        logger.info("Syncing OCI IAM for tenancy '%s'.", tenancy_id)
+        try:
+            iam.sync(
+                neo4j_session, resources.iam, tenancy_id, oci_sync_tag,
+                common_job_parameters, regions,
+            )
+        except Exception as e:
+            logger.error("Error syncing OCI IAM: %s", e, exc_info=True)
+
+    # Get regions from neo4j (populated by IAM region subscriptions)
+    updated_regions = [r["name"] for r in utils.get_regions_in_tenancy(neo4j_session, tenancy_id)]
+    if updated_regions:
+        regions = updated_regions
+
+    # Run remaining resource syncs (skip IAM since it's already handled above)
+    for func_name in requested_syncs:
+        if func_name == "iam":
+            continue
+        if func_name in RESOURCE_FUNCTIONS:
+            logger.info("Syncing OCI %s for compartment '%s'.", func_name, compartment_id)
+            try:
+                RESOURCE_FUNCTIONS[func_name](
+                    neo4j_session, getattr(resources, func_name), tenancy_id, oci_sync_tag,
+                    common_job_parameters, regions,
+                )
+            except Exception as e:
+                logger.error(
+                    "Error syncing OCI %s for compartment '%s': %s", func_name, compartment_id, e, exc_info=True,
+                )
+        else:
+            logger.warning(
+                'OCI sync function "%s" was specified but does not exist. Did you misspell it?', func_name,
+            )
 
 
-def _sync_multiple_accounts(
+def _sync_multiple_compartments(
     neo4j_session: neo4j.Session,
-    accounts: Dict[str, Any],
+    credentials: Dict[str, Any],
+    tenancy_id: str,
+    compartments: List[Dict[str, Any]],
+    requested_syncs: List[str],
     sync_tag: int,
     common_job_parameters: Dict[str, Any],
+    regions: List[str],
 ) -> None:
-    logger.debug("Syncing OCI accounts: %s", ', '.join(accounts.keys()))
-    organizations.sync(neo4j_session, accounts, sync_tag, common_job_parameters)
+    """
+    Sync OCI resources for the requested compartments.
+    Similar to Azure's _sync_multiple_subscriptions.
+    """
+    logger.info("Syncing OCI compartments under tenancy '%s'.", tenancy_id)
 
-    for name in accounts:
-        logger.info("Syncing OCI Tenancy with ID '%s' using configured profile '%s'.", accounts[name]["tenancy"], name)
-        resources = _initialize_resources(accounts[name])
-        tenancy_id = accounts[name]["tenancy"]
-        common_job_parameters["OCI_TENANCY_ID"] = tenancy_id
-        _sync_one_account(neo4j_session, resources, tenancy_id, sync_tag, common_job_parameters)
+    resources = _initialize_resources(credentials)
 
-    del common_job_parameters["OCI_TENANCY_ID"]
+    common_job_parameters["OCI_TENANCY_ID"] = tenancy_id
 
-    # Look into adding cleanup
-    # There may be orphan Users which point outside of known OCI accounts. This job cleans
-    # up those nodes after all OCI accounts have been synced.
-    # run_cleanup_job('oci_post_ingestion_principals_cleanup.json', neo4j_session, common_job_parameters)
-    # There may be orphan DNS entries that point outside of known OCI zones. This job cleans
-    # up those entries after all OCI accounts have been synced.
-    # run_cleanup_job('oci_post_ingestion_dns_cleanup.json', neo4j_session, common_job_parameters)
+    for comp in compartments:
+        compartment_id = comp["compartmentId"]
+        common_job_parameters["OCI_COMPARTMENT_ID"] = compartment_id
 
+        logger.info(
+            "Syncing OCI Compartment with ID '%s'.",
+            compartment_id,
+        )
 
-def _change_resources_region(resources: NamedTuple, region: str) -> None:
-    for resource in resources:
-        resource.base_client.set_region(region)
+        _sync_one_compartment(
+            neo4j_session, resources, compartment_id, tenancy_id,
+            requested_syncs, sync_tag, common_job_parameters, regions,
+        )
+
+        del common_job_parameters["OCI_COMPARTMENT_ID"]
 
 
 def _get_network_resource(credentials: Dict[str, Any]) -> oci.core.virtual_network_client.VirtualNetworkClient:
@@ -127,64 +167,162 @@ def _initialize_resources(credentials: Dict[str, Any]) -> Resources:
 
 def start_oci_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     """
-    Starts the OCI ingestion process by initializing OCI Application Default Credentials, creating the necessary
-    resource objects, listing all OCI organizations and projects available to the OCI identity, and supplying that
-    context to all intel modules.
+    Starts the OCI ingestion process by initializing OCI credentials, creating the necessary
+    resource objects, and syncing data for the specified compartment.
+
+    If config.params["oci_config"] exists, it is used as a base64-encoded JSON string containing:
+    {
+        user_ocid, fingerprint, private_key_content, tenancy_ocid, region,
+        compartment_ocid, is_default_compartment
+    }
+
+    - tenancy_ocid: Always required for OCI SDK auth
+    - compartment_ocid: The compartment to scope resource listing to
+    - is_default_compartment: If true, run IAM sync. If false, skip IAM.
+
+    Otherwise, falls back to reading credentials from ~/.oci/config.
+
     :param neo4j_session: The Neo4j session
     :param config: A `cartography.config` object
     :return: Nothing
     """
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
+        "WORKSPACE_ID": config.params["workspace"]["id_string"] if hasattr(config, 'params') and config.params else "",
     }
-    try:
-        # Explicitly use Application Default Credentials.
-        credentials = oci.config.from_file("~/.oci/config", "DEFAULT")
-        oci.config.validate_config(credentials)
-        # computeClient = oci.core.ComputeClient(credentials)
-    except (ConfigFileNotFound, ProfileNotFound, InvalidConfig) as e:
-        logger.debug("Error occurred calling oci.config.from_file.", exc_info=True)
-        logger.error(
-            (
-                "Unable to initialize OCI creds. If you don't have OCI data or don't want to load "
-                "OCI data then you can ignore this message. Otherwise, the error code is: %s "
-                "Make sure your OCI credentials are configured correctly, your credentials file (if any) is valid, and "
-                "that the identity you are authenticating to has the required Audit policies attached "
-                "(https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/commonpolicies.htm)."
-            ),
-            e,
-        )
-        return
 
-    if config.oci_sync_all_profiles:
-        oci_accounts = organizations.get_oci_accounts_from_config()
+    oci_config_b64 = config.params.get("oci_config") if hasattr(config, 'params') and config.params else None
+
+    if oci_config_b64:
+        # Use base64-encoded JSON config from params
+        logger.info("Using OCI credentials from config.params['oci_config'].")
+        try:
+            oci_config_json = json.loads(base64.b64decode(oci_config_b64).decode())
+        except (ValueError, json.JSONDecodeError) as e:
+            logger.error("Failed to decode OCI config from base64/JSON: %s", e)
+            return
+
+        try:
+            tenancy_ocid = config.oci_tenancy_id or oci_config_json.get("tenancy_ocid", "")
+            compartment_ocid = config.oci_compartment_id or oci_config_json.get("compartment_ocid", tenancy_ocid)
+            credentials = {
+                "user": oci_config_json["user_ocid"],
+                "fingerprint": oci_config_json["fingerprint"],
+                "key_content": oci_config_json["private_key_content"],
+                "tenancy": tenancy_ocid,
+                "region": config.params.get("default_region", "us-phoenix-1"),
+            }
+            oci.config.validate_config(credentials)
+        except (KeyError, InvalidConfig) as e:
+            logger.debug("Error occurred validating OCI config from params.", exc_info=True)
+            logger.error(
+                (
+                    "Unable to initialize OCI creds from config.params. Error: %s "
+                    "Make sure your OCI credentials are configured correctly and "
+                    "that the identity you are authenticating to has the required Audit policies attached "
+                    "(https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/commonpolicies.htm)."
+                ),
+                e,
+            )
+            return
+
+        is_default_compartment = (compartment_ocid == tenancy_ocid)
+
+        common_job_parameters["OCI_TENANCY_ID"] = tenancy_ocid
+        common_job_parameters["OCI_COMPARTMENT_ID"] = compartment_ocid
+        common_job_parameters["IS_DEFAULT_COMPARTMENT"] = is_default_compartment
+
+        # Determine requested syncs
+        requested_syncs: List[str] = list(RESOURCE_FUNCTIONS.keys())
+        if config.oci_requested_syncs:
+            oci_requested_syncs_string = ""
+            for service in config.oci_requested_syncs:
+                oci_requested_syncs_string += f"{service.get('name', ' ')},"
+            requested_syncs = parse_and_validate_oci_requested_syncs(oci_requested_syncs_string[:-1])
+
+        # Initialize resources
+        resources = _initialize_resources(credentials)
+
+        # Create workspace and tenancy nodes
+        organizations.load_oci_accounts(
+            neo4j_session, {"DEFAULT": credentials}, config.update_tag, common_job_parameters,
+            identity_client=resources.iam,
+        )
+
+        # Load compartment nodes into Neo4j
+        compartment_list = compartment.get_current_oci_compartment(resources.iam, compartment_ocid)
+        if not compartment_list:
+            compartment_list = [{"compartmentId": compartment_ocid, "name": compartment_ocid}]
+        compartment.sync(neo4j_session, tenancy_ocid, compartment_list, config.update_tag, common_job_parameters)
+
+        # Get regions from config
+        regions = [oci_config_json.get("region", "")]
+
+        # Sync resources for the requested compartment
+        _sync_multiple_compartments(
+            neo4j_session, credentials, tenancy_ocid, compartment_list,
+            requested_syncs, config.update_tag, common_job_parameters, regions,
+        )
+
     else:
-        oci_accounts = organizations.get_oci_account_default()
+        # Fallback: read from ~/.oci/config file
+        logger.info("No config.params['oci_config'] found, falling back to ~/.oci/config file.")
+        try:
+            credentials = oci.config.from_file("~/.oci/config", "DEFAULT")
+            oci.config.validate_config(credentials)
+        except (ConfigFileNotFound, ProfileNotFound, InvalidConfig) as e:
+            logger.debug("Error occurred calling oci.config.from_file.", exc_info=True)
+            logger.error(
+                (
+                    "Unable to initialize OCI creds. If you don't have OCI data or don't want to load "
+                    "OCI data then you can ignore this message. Otherwise, the error code is: %s "
+                    "Make sure your OCI credentials are configured correctly, your credentials file (if any) is valid, and "
+                    "that the identity you are authenticating to has the required Audit policies attached "
+                    "(https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/commonpolicies.htm)."
+                ),
+                e,
+            )
+            return
 
-    tenancy_list = []
-    for x in oci_accounts:
-        tenancy_list.append(oci_accounts[x]["tenancy"])
+        if config.oci_sync_all_profiles:
+            oci_accounts = organizations.get_oci_accounts_from_config()
+        else:
+            oci_accounts = organizations.get_oci_account_default()
 
-    if len(tenancy_list) != len(set(tenancy_list)):
-        logger.warning(
-            (
-                "There are duplicate OCI tenancy's in your OCI configuration. It is strongly recommended that you run "
-                "cartography with an OCI configuration which has exactly one profile for each OCI tenancy you want to "
-                "sync. Doing otherwise will result in undefined and untested behavior."
-            ),
+        if not oci_accounts:
+            logger.warning(
+                "No valid OCI credentials could be found. No OCI accounts can be synced. Exiting OCI sync stage.",
+            )
+            return
+
+        tenancy_id = list(oci_accounts.values())[0]["tenancy"]
+        compartment_id = config.oci_compartment_id or tenancy_id
+
+        common_job_parameters["OCI_TENANCY_ID"] = tenancy_id
+        common_job_parameters["OCI_COMPARTMENT_ID"] = compartment_id
+
+        # Determine requested syncs
+        requested_syncs: List[str] = list(RESOURCE_FUNCTIONS.keys())
+        if config.oci_requested_syncs:
+            oci_requested_syncs_string = ""
+            for service in config.oci_requested_syncs:
+                oci_requested_syncs_string += f"{service.get('name', ' ')},"
+            requested_syncs = parse_and_validate_oci_requested_syncs(oci_requested_syncs_string[:-1])
+
+        # Create workspace and tenancy nodes
+        organizations.sync(neo4j_session, oci_accounts, config.update_tag, common_job_parameters, resources.iam)
+
+        # Load compartment nodes into Neo4j
+        resources = _initialize_resources(list(oci_accounts.values())[0])
+        compartment_list = compartment.get_current_oci_compartment(resources.iam, compartment_id)
+        if not compartment_list:
+            compartment_list = [{"compartmentId": compartment_id, "name": compartment_id}]
+        compartment.sync(neo4j_session, tenancy_id, compartment_list, config.update_tag, common_job_parameters)
+
+        # Get regions
+        regions = [oci_accounts[list(oci_accounts.keys())[0]].get("region", "")]
+
+        _sync_multiple_compartments(
+            neo4j_session, list(oci_accounts.values())[0], tenancy_id, compartment_list,
+            requested_syncs, config.update_tag, common_job_parameters, regions,
         )
-
-    if not oci_accounts:
-        logger.warning(
-            "No valid OCI credentials could be found. No OCI accounts can be synced. Exiting OCI sync stage.",
-        )
-        return
-
-    _sync_multiple_accounts(neo4j_session, oci_accounts, config.update_tag, common_job_parameters)
-
-    # Look into adding analysis job once compute is implemented.
-    # run_analysis_job(
-    #    'oci_compute_asset_exposure.json',
-    #    neo4j_session,
-    #    common_job_parameters,
-    # )

--- a/cartography/intel/oci/__init__.py
+++ b/cartography/intel/oci/__init__.py
@@ -191,7 +191,7 @@ def start_oci_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         "WORKSPACE_ID": config.params["workspace"]["id_string"] if hasattr(config, 'params') and config.params else "",
     }
 
-    oci_config_b64 = config.params.get("oci_config") if hasattr(config, 'params') and config.params else None
+    oci_config_b64 = config.params.get("ociConfig") if hasattr(config, 'params') and config.params else None
 
     if oci_config_b64:
         # Use base64-encoded JSON config from params
@@ -210,7 +210,7 @@ def start_oci_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
                 "fingerprint": oci_config_json["fingerprint"],
                 "key_content": oci_config_json["private_key_content"],
                 "tenancy": tenancy_ocid,
-                "region": config.params.get("default_region", "us-phoenix-1"),
+                "region": config.params.get("defaultRegion", "us-phoenix-1"),
             }
             oci.config.validate_config(credentials)
         except (KeyError, InvalidConfig) as e:
@@ -263,7 +263,7 @@ def start_oci_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             neo4j_session, credentials, tenancy_ocid, compartment_list,
             requested_syncs, config.update_tag, common_job_parameters, regions,
         )
-
+        return common_job_parameters
     else:
         # Fallback: read from ~/.oci/config file
         logger.info("No config.params['oci_config'] found, falling back to ~/.oci/config file.")

--- a/cartography/intel/oci/compartment.py
+++ b/cartography/intel/oci/compartment.py
@@ -1,0 +1,142 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import neo4j
+import oci
+
+from . import utils
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def get_all_oci_compartments(
+    identity_client: oci.identity.identity_client.IdentityClient,
+    tenancy_id: str,
+) -> List[Dict[str, Any]]:
+    """
+    Get all compartments in the tenancy (recursively).
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            identity_client.list_compartments,
+            tenancy_id,
+            compartment_id_in_subtree=True,
+            access_level="ACCESSIBLE",
+        )
+        compartments = []
+        for comp in response.data:
+            compartments.append({
+                'id': comp.id,
+                'compartmentId': comp.id,
+                'name': comp.name,
+                'description': comp.description,
+                'lifecycleState': comp.lifecycle_state,
+                'timeCreated': str(comp.time_created),
+                'parentCompartmentId': comp.compartment_id,
+            })
+        return compartments
+    except oci.exceptions.ServiceError as e:
+        logger.error(
+            "Failed to fetch compartments for tenancy '%s': %s", tenancy_id, e.message,
+        )
+        return []
+
+
+def get_current_oci_compartment(
+    identity_client: oci.identity.identity_client.IdentityClient,
+    compartment_id: str,
+) -> List[Dict[str, Any]]:
+    """
+    Get a single compartment by its OCID.
+    """
+    try:
+        response = identity_client.get_compartment(compartment_id)
+        comp = response.data
+        return [{
+            'id': comp.id,
+            'compartmentId': comp.id,
+            'name': comp.name,
+            'description': comp.description,
+            'lifecycleState': comp.lifecycle_state,
+            'timeCreated': str(comp.time_created),
+            'parentCompartmentId': comp.compartment_id,
+        }]
+    except oci.exceptions.ServiceError as e:
+        logger.error(
+            "Failed to fetch compartment '%s': %s", compartment_id, e.message,
+        )
+        return []
+
+
+def load_oci_compartments(
+    neo4j_session: neo4j.Session,
+    tenancy_id: str,
+    compartments: List[Dict[str, Any]],
+    update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Ingest OCI compartments into Neo4j and link to tenancy via OWNER relationship.
+    """
+    query = """
+    MERGE (t:OCITenancy{ocid: $TENANCY_ID})
+    ON CREATE SET t.firstseen = timestamp()
+    SET t.lastupdated = $update_tag
+    WITH t
+    MERGE (c:OCICompartment{ocid: $COMPARTMENT_ID})
+    ON CREATE SET c.firstseen = timestamp(),
+    c.createdate = $TIME_CREATED
+    SET c.lastupdated = $update_tag,
+    c.name = $COMPARTMENT_NAME,
+    c.description = $DESCRIPTION,
+    c.lifecycle_state = $LIFECYCLE_STATE,
+    c.compartmentid = $PARENT_COMPARTMENT_ID
+    WITH t, c
+    MERGE (t)-[r:OWNER]->(c)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $update_tag
+    """
+    for comp in compartments:
+        neo4j_session.run(
+            query,
+            TENANCY_ID=tenancy_id,
+            COMPARTMENT_ID=comp['compartmentId'],
+            COMPARTMENT_NAME=comp['name'],
+            DESCRIPTION=comp.get('description', ''),
+            LIFECYCLE_STATE=comp.get('lifecycleState', ''),
+            TIME_CREATED=comp.get('timeCreated', ''),
+            PARENT_COMPARTMENT_ID=comp.get('parentCompartmentId', tenancy_id),
+            update_tag=update_tag,
+        )
+
+
+def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]) -> None:
+    run_cleanup_job('oci_import_compartments_cleanup.json', neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    tenancy_id: str,
+    compartments: List[Dict[str, Any]],
+    update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Sync OCI compartments into Neo4j.
+    Similar to Azure's subscription.sync.
+    """
+    load_oci_compartments(neo4j_session, tenancy_id, compartments, update_tag, common_job_parameters)
+
+    for comp in compartments:
+        common_job_parameters['OCI_COMPARTMENT_ID'] = comp['compartmentId']
+        common_job_parameters['OCI_TENANCY_ID'] = tenancy_id
+
+        cleanup(neo4j_session, common_job_parameters)
+
+    del common_job_parameters['OCI_COMPARTMENT_ID']
+    del common_job_parameters['OCI_TENANCY_ID']

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# OCI Compute API-centric functions
+# https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import neo4j
+import oci
+
+from . import utils
+from cartography.util import run_cleanup_job
+
+logger = logging.getLogger(__name__)
+
+
+def get_instance_list_data(
+    compute: oci.core.compute_client.ComputeClient,
+    compartment_id: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Get all compute instances in a compartment.
+    See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/ListInstances
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            compute.list_instances, compartment_id=compartment_id,
+        )
+        return {'Instances': utils.oci_object_to_json(response.data)}
+    except oci.exceptions.ServiceError as e:
+        logger.warning(
+            "Could not retrieve compute instances for compartment '%s': %s", compartment_id, e.message,
+        )
+        return {'Instances': []}
+
+
+def load_instances(
+    neo4j_session: neo4j.Session,
+    instances: List[Dict[str, Any]],
+    tenancy_id: str,
+    compartment_id: str,
+    region: str,
+    oci_update_tag: int,
+) -> None:
+    """
+    Ingest OCI Compute Instance data into Neo4j.
+    """
+    ingest_instance = """
+    MERGE (inode:OCIInstance{ocid: $OCID})
+    ON CREATE SET inode.firstseen = timestamp(),
+    inode.createdate = $TIME_CREATED
+    SET inode.display_name = $DISPLAY_NAME,
+    inode.compartment_id = $COMPARTMENT_ID,
+    inode.availability_domain = $AVAILABILITY_DOMAIN,
+    inode.fault_domain = $FAULT_DOMAIN,
+    inode.shape = $SHAPE,
+    inode.lifecycle_state = $LIFECYCLE_STATE,
+    inode.region = $REGION,
+    inode.image_id = $IMAGE_ID,
+    inode.lastupdated = $oci_update_tag
+    WITH inode
+    MATCH (cc) WHERE (cc:OCICompartment OR cc:OCITenancy) AND cc.ocid=$COMPARTMENT_ID
+    MERGE (cc)-[r:RESOURCE]->(inode)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
+    """
+
+    for instance in instances:
+        neo4j_session.run(
+            ingest_instance,
+            OCID=instance.get("id"),
+            DISPLAY_NAME=instance.get("display-name"),
+            COMPARTMENT_ID=instance.get("compartment-id", compartment_id),
+            AVAILABILITY_DOMAIN=instance.get("availability-domain"),
+            FAULT_DOMAIN=instance.get("fault-domain"),
+            SHAPE=instance.get("shape"),
+            LIFECYCLE_STATE=instance.get("lifecycle-state"),
+            REGION=region,
+            IMAGE_ID=instance.get("image-id"),
+            TIME_CREATED=str(instance.get("time-created", "")),
+            oci_update_tag=oci_update_tag,
+        )
+
+
+def get_vnic_attachment_list_data(
+    compute: oci.core.compute_client.ComputeClient,
+    compartment_id: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Get all VNIC attachments in a compartment.
+    See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/VnicAttachment/ListVnicAttachments
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            compute.list_vnic_attachments, compartment_id=compartment_id,
+        )
+        return {'VnicAttachments': utils.oci_object_to_json(response.data)}
+    except oci.exceptions.ServiceError as e:
+        logger.warning(
+            "Could not retrieve VNIC attachments for compartment '%s': %s", compartment_id, e.message,
+        )
+        return {'VnicAttachments': []}
+
+
+def load_vnic_attachments(
+    neo4j_session: neo4j.Session,
+    vnic_attachments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+) -> None:
+    """
+    Ingest OCI VNIC Attachment data into Neo4j and link to instances.
+    """
+    ingest_vnic_attachment = """
+    MERGE (vnic:OCIVnicAttachment{ocid: $OCID})
+    ON CREATE SET vnic.firstseen = timestamp(),
+    vnic.createdate = $TIME_CREATED
+    SET vnic.display_name = $DISPLAY_NAME,
+    vnic.compartment_id = $COMPARTMENT_ID,
+    vnic.availability_domain = $AVAILABILITY_DOMAIN,
+    vnic.lifecycle_state = $LIFECYCLE_STATE,
+    vnic.vnic_id = $VNIC_ID,
+    vnic.subnet_id = $SUBNET_ID,
+    vnic.nic_index = $NIC_INDEX,
+    vnic.lastupdated = $oci_update_tag
+    WITH vnic
+    MATCH (inode:OCIInstance{ocid: $INSTANCE_ID})
+    MERGE (inode)-[r:OCI_VNIC_ATTACHMENT]->(vnic)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
+    """
+
+    for attachment in vnic_attachments:
+        neo4j_session.run(
+            ingest_vnic_attachment,
+            OCID=attachment.get("id"),
+            DISPLAY_NAME=attachment.get("display-name"),
+            COMPARTMENT_ID=attachment.get("compartment-id"),
+            AVAILABILITY_DOMAIN=attachment.get("availability-domain"),
+            LIFECYCLE_STATE=attachment.get("lifecycle-state"),
+            VNIC_ID=attachment.get("vnic-id"),
+            SUBNET_ID=attachment.get("subnet-id"),
+            NIC_INDEX=attachment.get("nic-index"),
+            INSTANCE_ID=attachment.get("instance-id"),
+            TIME_CREATED=str(attachment.get("time-created", "")),
+            oci_update_tag=oci_update_tag,
+        )
+
+
+def get_image_list_data(
+    compute: oci.core.compute_client.ComputeClient,
+    compartment_id: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Get all images in a compartment.
+    See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Image/ListImages
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            compute.list_images, compartment_id=compartment_id,
+        )
+        return {'Images': utils.oci_object_to_json(response.data)}
+    except oci.exceptions.ServiceError as e:
+        logger.warning(
+            "Could not retrieve images for compartment '%s': %s", compartment_id, e.message,
+        )
+        return {'Images': []}
+
+
+def load_images(
+    neo4j_session: neo4j.Session,
+    images: List[Dict[str, Any]],
+    tenancy_id: str,
+    compartment_id: str,
+    oci_update_tag: int,
+) -> None:
+    """
+    Ingest OCI Image data into Neo4j.
+    """
+    ingest_image = """
+    MERGE (img:OCIImage{ocid: $OCID})
+    ON CREATE SET img.firstseen = timestamp(),
+    img.createdate = $TIME_CREATED
+    SET img.display_name = $DISPLAY_NAME,
+    img.compartment_id = $COMPARTMENT_ID,
+    img.operating_system = $OPERATING_SYSTEM,
+    img.operating_system_version = $OPERATING_SYSTEM_VERSION,
+    img.lifecycle_state = $LIFECYCLE_STATE,
+    img.size_in_mbs = $SIZE_IN_MBS,
+    img.lastupdated = $oci_update_tag
+    WITH img
+    MATCH (cc) WHERE (cc:OCICompartment OR cc:OCITenancy) AND cc.ocid=$COMPARTMENT_ID
+    MERGE (cc)-[r:RESOURCE]->(img)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
+    """
+
+    for image in images:
+        neo4j_session.run(
+            ingest_image,
+            OCID=image.get("id"),
+            DISPLAY_NAME=image.get("display-name"),
+            COMPARTMENT_ID=image.get("compartment-id", compartment_id),
+            OPERATING_SYSTEM=image.get("operating-system"),
+            OPERATING_SYSTEM_VERSION=image.get("operating-system-version"),
+            LIFECYCLE_STATE=image.get("lifecycle-state"),
+            SIZE_IN_MBS=image.get("size-in-mbs"),
+            TIME_CREATED=str(image.get("time-created", "")),
+            oci_update_tag=oci_update_tag,
+        )
+
+
+def get_boot_volume_attachment_list_data(
+    compute: oci.core.compute_client.ComputeClient,
+    availability_domain: str,
+    compartment_id: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Get all boot volume attachments in a compartment for a given availability domain.
+    See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/BootVolumeAttachment/ListBootVolumeAttachments
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            compute.list_boot_volume_attachments,
+            availability_domain=availability_domain,
+            compartment_id=compartment_id,
+        )
+        return {'BootVolumeAttachments': utils.oci_object_to_json(response.data)}
+    except oci.exceptions.ServiceError as e:
+        logger.warning(
+            "Could not retrieve boot volume attachments for compartment '%s', AD '%s': %s",
+            compartment_id, availability_domain, e.message,
+        )
+        return {'BootVolumeAttachments': []}
+
+
+def load_boot_volume_attachments(
+    neo4j_session: neo4j.Session,
+    boot_volume_attachments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+) -> None:
+    """
+    Ingest OCI Boot Volume Attachment data into Neo4j and link to instances.
+    """
+    ingest_boot_volume_attachment = """
+    MERGE (bva:OCIBootVolumeAttachment{ocid: $OCID})
+    ON CREATE SET bva.firstseen = timestamp(),
+    bva.createdate = $TIME_CREATED
+    SET bva.display_name = $DISPLAY_NAME,
+    bva.compartment_id = $COMPARTMENT_ID,
+    bva.availability_domain = $AVAILABILITY_DOMAIN,
+    bva.lifecycle_state = $LIFECYCLE_STATE,
+    bva.boot_volume_id = $BOOT_VOLUME_ID,
+    bva.lastupdated = $oci_update_tag
+    WITH bva
+    MATCH (inode:OCIInstance{ocid: $INSTANCE_ID})
+    MERGE (inode)-[r:OCI_BOOT_VOLUME_ATTACHMENT]->(bva)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
+    """
+
+    for attachment in boot_volume_attachments:
+        neo4j_session.run(
+            ingest_boot_volume_attachment,
+            OCID=attachment.get("id"),
+            DISPLAY_NAME=attachment.get("display-name"),
+            COMPARTMENT_ID=attachment.get("compartment-id"),
+            AVAILABILITY_DOMAIN=attachment.get("availability-domain"),
+            LIFECYCLE_STATE=attachment.get("lifecycle-state"),
+            BOOT_VOLUME_ID=attachment.get("boot-volume-id"),
+            INSTANCE_ID=attachment.get("instance-id"),
+            TIME_CREATED=str(attachment.get("time-created", "")),
+            oci_update_tag=oci_update_tag,
+        )
+
+
+def get_volume_attachment_list_data(
+    compute: oci.core.compute_client.ComputeClient,
+    compartment_id: str,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Get all volume attachments in a compartment.
+    See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/VolumeAttachment/ListVolumeAttachments
+    """
+    try:
+        response = oci.pagination.list_call_get_all_results(
+            compute.list_volume_attachments, compartment_id=compartment_id,
+        )
+        return {'VolumeAttachments': utils.oci_object_to_json(response.data)}
+    except oci.exceptions.ServiceError as e:
+        logger.warning(
+            "Could not retrieve volume attachments for compartment '%s': %s", compartment_id, e.message,
+        )
+        return {'VolumeAttachments': []}
+
+
+def load_volume_attachments(
+    neo4j_session: neo4j.Session,
+    volume_attachments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+) -> None:
+    """
+    Ingest OCI Volume Attachment data into Neo4j and link to instances.
+    """
+    ingest_volume_attachment = """
+    MERGE (va:OCIVolumeAttachment{ocid: $OCID})
+    ON CREATE SET va.firstseen = timestamp(),
+    va.createdate = $TIME_CREATED
+    SET va.display_name = $DISPLAY_NAME,
+    va.compartment_id = $COMPARTMENT_ID,
+    va.availability_domain = $AVAILABILITY_DOMAIN,
+    va.lifecycle_state = $LIFECYCLE_STATE,
+    va.volume_id = $VOLUME_ID,
+    va.attachment_type = $ATTACHMENT_TYPE,
+    va.is_read_only = $IS_READ_ONLY,
+    va.lastupdated = $oci_update_tag
+    WITH va
+    MATCH (inode:OCIInstance{ocid: $INSTANCE_ID})
+    MERGE (inode)-[r:OCI_VOLUME_ATTACHMENT]->(va)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
+    """
+
+    for attachment in volume_attachments:
+        neo4j_session.run(
+            ingest_volume_attachment,
+            OCID=attachment.get("id"),
+            DISPLAY_NAME=attachment.get("display-name"),
+            COMPARTMENT_ID=attachment.get("compartment-id"),
+            AVAILABILITY_DOMAIN=attachment.get("availability-domain"),
+            LIFECYCLE_STATE=attachment.get("lifecycle-state"),
+            VOLUME_ID=attachment.get("volume-id"),
+            ATTACHMENT_TYPE=attachment.get("attachment-type"),
+            IS_READ_ONLY=attachment.get("is-read-only"),
+            INSTANCE_ID=attachment.get("instance-id"),
+            TIME_CREATED=str(attachment.get("time-created", "")),
+            oci_update_tag=oci_update_tag,
+        )
+
+
+def sync_instances(
+    neo4j_session: neo4j.Session,
+    compute: oci.core.compute_client.ComputeClient,
+    compartments: List[Dict[str, Any]],
+    tenancy_id: str,
+    region: str,
+    oci_update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Sync all compute instances across all compartments in the tenancy.
+    """
+    logger.debug("Syncing OCI compute instances for tenancy '%s', region '%s'.", tenancy_id, region)
+    for compartment in compartments:
+        data = get_instance_list_data(compute, compartment["ocid"])
+        if data["Instances"]:
+            load_instances(neo4j_session, data["Instances"], tenancy_id, compartment["ocid"], region, oci_update_tag)
+
+
+def sync_vnic_attachments(
+    neo4j_session: neo4j.Session,
+    compute: oci.core.compute_client.ComputeClient,
+    compartments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Sync all VNIC attachments across all compartments in the tenancy.
+    """
+    logger.debug("Syncing OCI VNIC attachments for tenancy '%s'.", tenancy_id)
+    for compartment in compartments:
+        data = get_vnic_attachment_list_data(compute, compartment["ocid"])
+        if data["VnicAttachments"]:
+            load_vnic_attachments(neo4j_session, data["VnicAttachments"], tenancy_id, oci_update_tag)
+
+
+def sync_images(
+    neo4j_session: neo4j.Session,
+    compute: oci.core.compute_client.ComputeClient,
+    compartments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Sync all images across all compartments in the tenancy.
+    """
+    logger.debug("Syncing OCI images for tenancy '%s'.", tenancy_id)
+    for compartment in compartments:
+        data = get_image_list_data(compute, compartment["ocid"])
+        if data["Images"]:
+            load_images(neo4j_session, data["Images"], tenancy_id, compartment["ocid"], oci_update_tag)
+
+
+def sync_volume_attachments(
+    neo4j_session: neo4j.Session,
+    compute: oci.core.compute_client.ComputeClient,
+    compartments: List[Dict[str, Any]],
+    tenancy_id: str,
+    oci_update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Sync all volume attachments across all compartments in the tenancy.
+    """
+    logger.debug("Syncing OCI volume attachments for tenancy '%s'.", tenancy_id)
+    for compartment in compartments:
+        data = get_volume_attachment_list_data(compute, compartment["ocid"])
+        if data["VolumeAttachments"]:
+            load_volume_attachments(neo4j_session, data["VolumeAttachments"], tenancy_id, oci_update_tag)
+
+
+def sync(
+    neo4j_session: neo4j.Session,
+    compute: oci.core.compute_client.ComputeClient,
+    tenancy_id: str,
+    oci_update_tag: int,
+    common_job_parameters: Dict[str, Any],
+    regions: List[str] = None,
+) -> None:
+    """
+    Sync OCI Compute resources for the compartment specified in common_job_parameters.
+    """
+    compartment_ocid = common_job_parameters.get("OCI_COMPARTMENT_ID", tenancy_id)
+    logger.info("Syncing OCI Compute for compartment '%s'.", compartment_ocid)
+
+    # Use only the target compartment for resource listing
+    compartments = [{"ocid": compartment_ocid, "name": "target", "compartmentid": tenancy_id}]
+
+    # If no regions provided, use the compute client's current region
+    if not regions:
+        regions = [compute.base_client.region or ""]
+
+    for region in regions:
+        logger.info("Syncing OCI Compute in region '%s' for compartment '%s'.", region, compartment_ocid)
+        compute.base_client.set_region(region)
+
+        # Sync instances
+        sync_instances(neo4j_session, compute, compartments, tenancy_id, region, oci_update_tag, common_job_parameters)
+
+        # Sync VNIC attachments (links instances to network interfaces)
+        sync_vnic_attachments(neo4j_session, compute, compartments, tenancy_id, oci_update_tag, common_job_parameters)
+
+        # Sync images
+        sync_images(neo4j_session, compute, compartments, tenancy_id, oci_update_tag, common_job_parameters)
+
+        # Sync volume attachments (block volumes attached to instances)
+        sync_volume_attachments(neo4j_session, compute, compartments, tenancy_id, oci_update_tag, common_job_parameters)
+
+    # Cleanup stale nodes
+    run_cleanup_job('oci_import_compute_instances_cleanup.json', neo4j_session, common_job_parameters)

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -60,7 +60,7 @@ def load_instances(
     inode.image_id = $IMAGE_ID,
     inode.lastupdated = $oci_update_tag
     WITH inode
-    MATCH (cc) WHERE (cc:OCICompartment OR cc:OCITenancy) AND cc.ocid=$COMPARTMENT_ID
+    MATCH (cc:OCICompartment{ocid: $COMPARTMENT_ID})
     MERGE (cc)-[r:RESOURCE]->(inode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
@@ -190,7 +190,7 @@ def load_images(
     img.size_in_mbs = $SIZE_IN_MBS,
     img.lastupdated = $oci_update_tag
     WITH img
-    MATCH (cc) WHERE (cc:OCICompartment OR cc:OCITenancy) AND cc.ocid=$COMPARTMENT_ID
+    MATCH (cc:OCICompartment{ocid: $COMPARTMENT_ID})
     MERGE (cc)-[r:RESOURCE]->(img)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
@@ -201,7 +201,7 @@ def load_images(
             ingest_image,
             OCID=image.get("id"),
             DISPLAY_NAME=image.get("display-name"),
-            COMPARTMENT_ID=image.get("compartment-id", compartment_id),
+            COMPARTMENT_ID=image.get("compartment-id") if image.get("compartment-id") else compartment_id,
             OPERATING_SYSTEM=image.get("operating-system"),
             OPERATING_SYSTEM_VERSION=image.get("operating-system-version"),
             LIFECYCLE_STATE=image.get("lifecycle-state"),

--- a/cartography/intel/oci/iam.py
+++ b/cartography/intel/oci/iam.py
@@ -64,10 +64,11 @@ def load_compartments(
     MERGE (cnode:OCICompartment{ocid: $OCID})
     ON CREATE SET cnode:OCICompartment, cnode.firstseen = timestamp(),
     cnode.createdate = $CREATE_DATE
-    SET cnode.name = $NAME, cnode.compartmentid = $COMPARTMENT_ID
+    SET cnode.name = $NAME, cnode.compartmentid = $COMPARTMENT_ID,
+    cnode.lastupdated = $oci_update_tag
     WITH cnode
-    MATCH (aa) WHERE (aa:OCITenancy OR aa:OCICompartment) AND aa.ocid=$COMPARTMENT_ID
-    MERGE (aa)-[r:OCI_COMPARTMENT]->(cnode)
+    MATCH (tenancy:OCITenancy{ocid: $OCI_TENANCY_ID})
+    MERGE (tenancy)-[r:OWNER]->(cnode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """
@@ -450,12 +451,14 @@ def sync(
     tenancy_id: str,
     oci_update_tag: int,
     common_job_parameters: Dict[str, Any],
+    regions: List[str] = None,
 ) -> None:
     logger.info("Syncing IAM for account '%s'.", tenancy_id)
     sync_users(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
     sync_groups(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
     sync_group_memberships(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
-    sync_compartments(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
+    # Compartment sync is handled by compartment.py in __init__.py, not here
+    # sync_compartments(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
     sync_policies(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)
     sync_oci_policy_references(neo4j_session, tenancy_id, oci_update_tag, common_job_parameters)
     sync_region_subscriptions(neo4j_session, iam, tenancy_id, oci_update_tag, common_job_parameters)

--- a/cartography/intel/oci/iam.py
+++ b/cartography/intel/oci/iam.py
@@ -274,8 +274,8 @@ def load_policies(
     pnode.statements = $STATEMENTS,
     pnode.updatedate = $POLICY_UPDATE, pnode.lastupdated = $oci_update_tag
     WITH pnode
-    MATCH (aa) WHERE (aa:OCITenancy OR aa:OCICompartment) AND aa.ocid=$COMPARTMENT_ID
-    MERGE (aa)-[r:OCI_POLICY]->(pnode)
+    MATCH (aa:OCITenancy{ocid: $OCI_TENANCY_ID})
+    MERGE (aa)-[r:RESOURCE]->(pnode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """

--- a/cartography/intel/oci/organizations.py
+++ b/cartography/intel/oci/organizations.py
@@ -84,22 +84,60 @@ def get_oci_accounts_from_config() -> Dict[str, Any]:
     return d
 
 
+def get_tenancy_details(
+    identity_client: oci.identity.identity_client.IdentityClient,
+    tenancy_id: str,
+) -> Dict[str, Any]:
+    """
+    Get tenancy details (name, home region, etc.) from the OCI API.
+    """
+    try:
+        response = identity_client.get_tenancy(tenancy_id)
+        tenancy = response.data
+        return {
+            "id": tenancy.id,
+            "name": tenancy.name,
+            "description": tenancy.description,
+            "home_region_key": tenancy.home_region_key,
+        }
+    except oci.exceptions.ServiceError as e:
+        logger.warning("Could not fetch tenancy details for '%s': %s", tenancy_id, e.message)
+        return {"id": tenancy_id, "name": tenancy_id}
+
+
 def load_oci_accounts(
     neo4j_session: neo4j.Session,
     oci_accounts: Dict[str, Any],
     oci_update_tag: int,
     common_job_parameters: Dict[str, Any],
+    identity_client: oci.identity.identity_client.IdentityClient = None,
 ) -> None:
     query = """
+    MERGE (w:CloudanixWorkspace{id: $WORKSPACE_ID})
+    SET w.lastupdated = $oci_update_tag
+    WITH w
     MERGE (aa:OCITenancy{ocid: $TENANCY_ID})
     ON CREATE SET aa.firstseen = timestamp()
     SET aa.lastupdated = $oci_update_tag, aa.name = $ACCOUNT_NAME
+    WITH w, aa
+    MERGE (w)-[r:OWNER]->(aa)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $oci_update_tag
     """
     for name in oci_accounts:
+        tenancy_id = oci_accounts[name]["tenancy"]
+
+        # Get real tenancy name from API if identity_client is available
+        account_name = name
+        if identity_client:
+            tenancy_details = get_tenancy_details(identity_client, tenancy_id)
+            account_name = tenancy_details.get("name", name)
+
         neo4j_session.run(
             query,
-            TENANCY_ID=oci_accounts[name]["tenancy"],
-            ACCOUNT_NAME=name,
+            WORKSPACE_ID=common_job_parameters.get("WORKSPACE_ID", ""),
+            TENANCY_ID=tenancy_id,
+            ACCOUNT_NAME=account_name,
             oci_update_tag=oci_update_tag,
         )
 
@@ -113,6 +151,7 @@ def sync(
     accounts: Dict[str, Any],
     oci_update_tag: int,
     common_job_parameters: Dict[str, Any],
+    identity_client: oci.identity.identity_client.IdentityClient = None,
 ) -> None:
-    load_oci_accounts(neo4j_session, accounts, oci_update_tag, common_job_parameters)
+    load_oci_accounts(neo4j_session, accounts, oci_update_tag, common_job_parameters, identity_client)
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/oci/resources.py
+++ b/cartography/intel/oci/resources.py
@@ -1,0 +1,10 @@
+from typing import Dict
+
+from . import compute
+from . import iam
+
+
+RESOURCE_FUNCTIONS: Dict = {
+    "iam": iam.sync,
+    "compute": compute.sync,
+}

--- a/cartography/intel/oci/util/common.py
+++ b/cartography/intel/oci/util/common.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from cartography.intel.oci.resources import RESOURCE_FUNCTIONS
+
+
+def parse_and_validate_oci_requested_syncs(oci_requested_syncs: str) -> List[str]:
+    validated_resources: List[str] = []
+    for resource in oci_requested_syncs.split(','):
+        resource = resource.strip()
+
+        if resource in RESOURCE_FUNCTIONS:
+            validated_resources.append(resource)
+        else:
+            valid_syncs: str = ', '.join(RESOURCE_FUNCTIONS.keys())
+            raise ValueError(
+                f'Error parsing `oci-requested-syncs`. You specified "{oci_requested_syncs}". '
+                f'Please check that your string is formatted properly. '
+                f'Example valid input looks like "iam". '
+                f'Our full list of valid values is: {valid_syncs}.',
+            )
+    return validated_resources

--- a/cartography/intel/oci/utils.py
+++ b/cartography/intel/oci/utils.py
@@ -28,7 +28,7 @@ def replace_char_in_dict(in_dict: Dict[str, Any]) -> Dict[str, Any]:
 
 # Grab list of all compartments and sub-compartments in neo4j already populated by iam.
 def get_compartments_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
-    query = "MATCH (OCITenancy{ocid: $OCI_TENANCY_ID})-[*]->(compartment:OCICompartment) " \
+    query = "MATCH (OCITenancy{ocid: $OCI_TENANCY_ID})-[:OWNER]->(compartment:OCICompartment) " \
             "return DISTINCT compartment.name as name, compartment.ocid as ocid, " \
             "compartment.compartmentid as compartmentid;"
     return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id)

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -119,6 +119,7 @@ class Sync:
                         "bitbucket",
                         "gitlab",
                         "azuredevops",
+                        "oci",
                     ]:
                         response = stage_func(neo4j_session, config)
                     else:
@@ -285,6 +286,27 @@ def build_gcp_sync():
     stages = []
     stages.append(("cloudanix-workspace", cloudanix.run))
     stages.append(("gcp", cartography.intel.gcp.start_gcp_ingestion))
+    stages.append(("analysis", cartography.intel.analysis.run))
+
+    sync.add_stages(stages)
+
+    return sync
+
+
+def build_oci_sync():
+    """
+    Build the default cartography sync, which runs all intelligence modules shipped with the cartography package.
+
+    :rtype: cartography.sync.Sync
+    :return: The default cartography sync object.
+    """
+    import cartography.intel.oci
+
+    sync = Sync()
+
+    stages = []
+    stages.append(("cloudanix-workspace", cloudanix.run))
+    stages.append(("oci", cartography.intel.oci.start_oci_ingestion))
     stages.append(("analysis", cartography.intel.analysis.run))
 
     sync.add_stages(stages)

--- a/main.py
+++ b/main.py
@@ -86,6 +86,8 @@ def gcp_cartography_worker(event, ctx):
         gitlab_process_request(logger, params)
     elif params.get("templateType") == "AZUREDEVOPSINVENTORYVIEWS":
         azure_devops_process_request(logger, params)
+    elif params.get("templateType") == "OCIINVENTORYVIEWS":
+        oci_process_request(logger, params)
 
     return {
         "statusCode": 200,
@@ -142,6 +144,81 @@ def gcp_process_request(logger, params):
     }
 
     resp = cartography.cli.run_gcp(body)
+
+    if "status" in resp and resp["status"] == "success":
+        if resp.get("pagination", None):
+            services = []
+            for service, pagination in resp.get("pagination", {}).items():
+                if pagination.get("hasNextPage", False):
+                    services.append(
+                        {
+                            "name": service,
+                            "pagination": {
+                                "pageSize": pagination.get("pageSize", 1),
+                                "pageNo": pagination.get("pageNo", 0) + 1,
+                            },
+                        },
+                    )
+            if len(services) > 0:
+                resp["services"] = services
+
+            else:
+                del resp["updateTag"]
+
+            del resp["pagination"]
+
+        logger.info(f"successfully processed cartography: {resp}")
+
+    else:
+        logger.info(f"failed to process cartography: {resp['message']}")
+
+    publish_response(logger, body, resp, params)
+
+    logger.info(f"inventory sync gcp response - {params.get('eventId')}: {json.dumps(resp)}")
+
+
+def oci_process_request(logger, params):
+    logger.info(f"request - {params.get('templateType')} - {params.get('eventId')} - {params.get('workspace')}")
+
+    svcs = []
+    for svc in params.get("services", []):
+        page = svc.get("pagination", {}).get("pageSize")
+        if page:
+            svc["pagination"]["pageSize"] = 10000
+
+        svcs.append(svc)
+
+    body = {
+        "neo4j": {
+            "uri": params.get("neo4j", {}).get("uri", ""),
+            "user": params.get("neo4j", {}).get("user", ""),
+            "pwd": params.get("neo4j", {}).get("pwd", ""),
+            "connection_lifetime": 200,
+        },
+        "logging": {
+            "mode": "verbose",
+        },
+        "params": {
+            "sessionString": params.get("sessionString"),
+            "eventId": params.get("eventId"),
+            "templateType": params.get("templateType"),
+            "workspace": params.get("workspace"),
+            "groups": params.get("groups", []),
+            "actions": params.get("actions"),
+            "resultTopic": params.get("resultTopic"),
+            "requestTopic": params.get("requestTopic"),
+            "partial": params.get("partial"),
+            "services": params.get("services"),
+            "ociConfig": os.environ["OCI_CONFIG"],
+            "tenancyOCID": params.get("tenancyOCID"),
+            "compartmentOCID": params.get("compartmentOCID"),
+            "defaultRegion": params.get("defaultRegion", "us-phoenix-1"),
+        },
+        "services": svcs,
+        "updateTag": params.get("runTimestamp"),
+    }
+
+    resp = cartography.cli.run_oci(body)
 
     if "status" in resp and resp["status"] == "success":
         if resp.get("pagination", None):

--- a/oci.requirements.txt
+++ b/oci.requirements.txt
@@ -1,0 +1,30 @@
+setuptools<81
+backoff>=2.1.2
+boto3>=1.15.1
+botocore>=1.18.1
+dnspython>=1.15.0
+neo4j>=5.0.0,<6.0.0
+policyuniverse>=1.1.0.0
+google-api-python-client>=1.7.8
+oauth2client>=4.1.3
+marshmallow>=3.0.0rc7
+pyyaml>=5.3.1
+requests>=2.22.0
+statsd~=3.3.0
+packaging~=21.3
+netaddr~=0.8.0
+maya~=0.6.1
+pytz~=2022.6
+
+cloudconsolelink~=1.0.24
+sentry_sdk~=2.35.0
+clouduniqueid~=1.0.3
+
+# GCP Cloud Function specific packages
+# flask~=2.2.2
+google-cloud-pubsub~=2.3.0
+google-cloud-storage~=1.36.0
+google-cloud-compute~=1.11.0
+
+# OCI
+oci>=2.71.0


### PR DESCRIPTION
- Read OCI credentials from config.params["oci_config"] (base64 JSON)
  with fallback to ~/.oci/config file
- Add config.oci_tenancy_id and config.oci_compartment_id
- Implement requested_syncs for OCI (RESOURCE_FUNCTIONS pattern)
- Add compute.py module (instances, VNICs, images, volume attachments)
- Add compartment.py module for compartment node management
- Restructure graph hierarchy:
  CloudanixWorkspace -> OCITenancy -> OCICompartment -> resources
- Every OCICompartment has direct OWNER relationship with OCITenancy
- IAM runs only for default compartment (tenancy == compartment)
- Refactor to _sync_multiple_compartments/_sync_one_compartment pattern
- Fetch tenancy name from OCI API instead of using "DEFAULT"
- Update all cleanup jobs with full path from CloudanixWorkspace
  and paired node/relationship deletion statements
- Pass regions to every service sync function
- Compute iterates over all regions per compartment