### PR TITLE
feat(oci): add analysis jobs for networking, compute, IAM, encryption, monitoring, logging and container registry analysis jobs

### DIFF
--- a/cartography/data/jobs/analysis/oci_containerregistry_asset_exposure.json
+++ b/cartography/data/jobs/analysis/oci_containerregistry_asset_exposure.json
@@ -1,0 +1,26 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset exposed_internet properties on all OCI container repositories in scope",
+      "query": "MATCH (n:OCIContainerRepository)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE n.exposed_internet IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.exposed_internet, n.exposed_internet_type, n.publicContext RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Mark container repositories as exposed if they are public (anonymous pull allowed)",
+      "query": "MATCH (repo:OCIContainerRepository{is_public: true})<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET repo.exposed_internet = true, (CASE WHEN NOT 'public_repository' IN coalesce(repo.exposed_internet_type, []) THEN repo END).exposed_internet_type = coalesce(repo.exposed_internet_type, []) + 'public_repository'",
+      "iterative": false
+    },
+    {
+      "__comment": "Additionally flag public repositories that are mutable (tags can be overwritten - image tampering risk)",
+      "query": "MATCH (repo:OCIContainerRepository{is_public: true, is_immutable: false})<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET repo.exposed_internet = true, (CASE WHEN NOT 'mutable_public_repository' IN coalesce(repo.exposed_internet_type, []) THEN repo END).exposed_internet_type = coalesce(repo.exposed_internet_type, []) + 'mutable_public_repository'",
+      "iterative": false
+    },
+    {
+      "__comment": "Build publicContext JSON for exposed container repositories with image details",
+      "query": "MATCH (repo:OCIContainerRepository)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE repo.exposed_internet = true WITH repo OPTIONAL MATCH (repo)-[:OCI_CONTAINER_IMAGE]->(img:OCIContainerImage) WITH repo, collect(DISTINCT {imageId: img.ocid, digest: img.digest, version: img.version}) as images SET repo.publicContext = apoc.convert.toJson([{resource: repo.ocid, resourceType: 'oci-containerregistry-repository', context: [{repositoryId: repo.ocid, repositoryName: repo.display_name, namespace: repo.namespace, isPublic: repo.is_public, isImmutable: repo.is_immutable, imageCount: repo.image_count, lifecycleState: repo.lifecycle_state, exposureTypes: repo.exposed_internet_type, images: images, region: repo.region}]}])",
+      "iterative": false
+    }
+  ],
+  "name": "OCI container registry asset internet exposure"
+}

--- a/cartography/data/jobs/analysis/oci_encryption_analysis.json
+++ b/cartography/data/jobs/analysis/oci_encryption_analysis.json
@@ -1,0 +1,47 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset encryption analysis properties on all OCI KMS vaults in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCIKmsVault) WHERE n.encryption_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.encryption_risk, n.encryption_risk_type, n.key_count, n.has_active_keys RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Reset encryption analysis properties on all OCI KMS keys in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIKmsVault)-[:OCI_KMS_KEY]->(n:OCIKmsKey) WHERE n.encryption_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.encryption_risk, n.encryption_risk_type RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Flag vaults that are not in ACTIVE state (deleted, pending deletion, etc.)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(v:OCIKmsVault) WHERE v.lifecycle_state <> 'ACTIVE' SET v.encryption_risk = true, (CASE WHEN NOT 'vault_not_active' IN coalesce(v.encryption_risk_type, []) THEN v END).encryption_risk_type = coalesce(v.encryption_risk_type, []) + 'vault_not_active'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag DEFAULT vault type (less secure than VIRTUAL_PRIVATE — shared HSM partition)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(v:OCIKmsVault{vault_type: 'DEFAULT'}) WHERE v.lifecycle_state = 'ACTIVE' SET v.encryption_risk = true, (CASE WHEN NOT 'shared_hsm_partition' IN coalesce(v.encryption_risk_type, []) THEN v END).encryption_risk_type = coalesce(v.encryption_risk_type, []) + 'shared_hsm_partition'",
+      "iterative": false
+    },
+    {
+      "__comment": "Count keys per vault and flag vaults with no active keys",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(v:OCIKmsVault) OPTIONAL MATCH (v)-[:OCI_KMS_KEY]->(k:OCIKmsKey{lifecycle_state: 'ENABLED'}) WITH v, count(k) as activeKeyCount SET v.key_count = activeKeyCount, v.has_active_keys = (activeKeyCount > 0)",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag active vaults with zero keys (unused vault — potential configuration gap)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(v:OCIKmsVault) WHERE v.lifecycle_state = 'ACTIVE' AND v.has_active_keys = false SET v.encryption_risk = true, (CASE WHEN NOT 'no_active_keys' IN coalesce(v.encryption_risk_type, []) THEN v END).encryption_risk_type = coalesce(v.encryption_risk_type, []) + 'no_active_keys'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag keys using SOFTWARE protection mode (less secure than HSM)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIKmsVault)-[:OCI_KMS_KEY]->(k:OCIKmsKey{protection_mode: 'SOFTWARE'}) SET k.encryption_risk = true, (CASE WHEN NOT 'software_protection' IN coalesce(k.encryption_risk_type, []) THEN k END).encryption_risk_type = coalesce(k.encryption_risk_type, []) + 'software_protection'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag keys that are not in ENABLED state (disabled, pending deletion, scheduled deletion)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCIKmsVault)-[:OCI_KMS_KEY]->(k:OCIKmsKey) WHERE k.lifecycle_state <> 'ENABLED' SET k.encryption_risk = true, (CASE WHEN NOT 'key_not_enabled' IN coalesce(k.encryption_risk_type, []) THEN k END).encryption_risk_type = coalesce(k.encryption_risk_type, []) + 'key_not_enabled'",
+      "iterative": false
+    }
+  ],
+  "name": "OCI encryption (KMS) analysis"
+}

--- a/cartography/data/jobs/analysis/oci_iam_policy_analysis.json
+++ b/cartography/data/jobs/analysis/oci_iam_policy_analysis.json
@@ -1,0 +1,31 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset IAM policy analysis properties on all OCI policies in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIPolicy) WHERE n.policy_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.policy_risk, n.policy_risk_type, n.is_overly_permissive, n.allows_all_resources RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Flag policies with overly broad 'manage all-resources' statements",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(p:OCIPolicy) WHERE ANY(stmt IN p.statements WHERE toLower(stmt) CONTAINS 'manage all-resources') SET p.policy_risk = true, p.is_overly_permissive = true, p.allows_all_resources = true, (CASE WHEN NOT 'manage_all_resources' IN coalesce(p.policy_risk_type, []) THEN p END).policy_risk_type = coalesce(p.policy_risk_type, []) + 'manage_all_resources'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag policies that grant broad 'manage' verb in tenancy scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(p:OCIPolicy) WHERE ANY(stmt IN p.statements WHERE toLower(stmt) CONTAINS 'manage' AND toLower(stmt) CONTAINS 'in tenancy') AND p.managed_type = 'custom' SET p.policy_risk = true, p.is_overly_permissive = true, (CASE WHEN NOT 'manage_in_tenancy' IN coalesce(p.policy_risk_type, []) THEN p END).policy_risk_type = coalesce(p.policy_risk_type, []) + 'manage_in_tenancy'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag policies that allow use/manage of users or groups (identity risk)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(p:OCIPolicy) WHERE ANY(stmt IN p.statements WHERE (toLower(stmt) CONTAINS 'manage users' OR toLower(stmt) CONTAINS 'manage groups' OR toLower(stmt) CONTAINS 'manage identity')) AND p.managed_type = 'custom' SET p.policy_risk = true, (CASE WHEN NOT 'identity_management' IN coalesce(p.policy_risk_type, []) THEN p END).policy_risk_type = coalesce(p.policy_risk_type, []) + 'identity_management'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag custom policies that reference 'any-user' (overly permissive principal)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(p:OCIPolicy) WHERE ANY(stmt IN p.statements WHERE toLower(stmt) CONTAINS 'any-user') AND p.managed_type = 'custom' SET p.policy_risk = true, (CASE WHEN NOT 'any_user_principal' IN coalesce(p.policy_risk_type, []) THEN p END).policy_risk_type = coalesce(p.policy_risk_type, []) + 'any_user_principal'",
+      "iterative": false
+    }
+  ],
+  "name": "OCI IAM policy analysis"
+}

--- a/cartography/data/jobs/analysis/oci_iam_user_analysis.json
+++ b/cartography/data/jobs/analysis/oci_iam_user_analysis.json
@@ -1,0 +1,41 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset IAM analysis properties on all OCI users in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(n:OCIUser) WHERE n.iam_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.iam_risk, n.iam_risk_type, n.group_count, n.policy_count, n.admin_access RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Flag users without MFA enabled who can use console password",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser) WHERE u.is_mfa_activated = false AND u.can_use_console_password = true AND u.lifecycle_state = 'ACTIVE' SET u.iam_risk = true, (CASE WHEN NOT 'mfa_not_enabled' IN coalesce(u.iam_risk_type, []) THEN u END).iam_risk_type = coalesce(u.iam_risk_type, []) + 'mfa_not_enabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag users who have API keys enabled (potential credential exposure risk)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser) WHERE u.can_use_api_keys = true AND u.lifecycle_state = 'ACTIVE' SET u.iam_risk = true, (CASE WHEN NOT 'api_keys_enabled' IN coalesce(u.iam_risk_type, []) THEN u END).iam_risk_type = coalesce(u.iam_risk_type, []) + 'api_keys_enabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag users who are members of the Administrators group (admin access)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser)-[:MEMBER_OCID_GROUP]->(g:OCIGroup{name: 'Administrators'}) WHERE u.lifecycle_state = 'ACTIVE' SET u.admin_access = true, u.iam_risk = true, (CASE WHEN NOT 'admin_group_member' IN coalesce(u.iam_risk_type, []) THEN u END).iam_risk_type = coalesce(u.iam_risk_type, []) + 'admin_group_member'",
+      "iterative": false
+    },
+    {
+      "__comment": "Count group memberships per user",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser) OPTIONAL MATCH (u)-[:MEMBER_OCID_GROUP]->(g:OCIGroup) WITH u, count(g) as groupCount SET u.group_count = groupCount",
+      "iterative": false
+    },
+    {
+      "__comment": "Count policies that reference each user's groups",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser)-[:MEMBER_OCID_GROUP]->(g:OCIGroup)<-[:OCI_POLICY_REFERENCE]-(p:OCIPolicy) WITH u, count(DISTINCT p) as policyCount SET u.policy_count = policyCount",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag users with excessive permissions (member of 3+ groups with policies)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:RESOURCE]->(u:OCIUser) WHERE u.group_count >= 3 AND u.policy_count >= 3 AND u.lifecycle_state = 'ACTIVE' SET u.iam_risk = true, (CASE WHEN NOT 'excessive_permissions' IN coalesce(u.iam_risk_type, []) THEN u END).iam_risk_type = coalesce(u.iam_risk_type, []) + 'excessive_permissions'",
+      "iterative": false
+    }
+  ],
+  "name": "OCI IAM user analysis"
+}

--- a/cartography/data/jobs/analysis/oci_instance_asset_exposure.json
+++ b/cartography/data/jobs/analysis/oci_instance_asset_exposure.json
@@ -1,0 +1,41 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset exposed_internet properties on all OCI instances in scope",
+      "query": "MATCH (n:OCIInstance)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE n.exposed_internet IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.exposed_internet, n.exposed_internet_type, n.publicContext RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Mark instances as exposed if they have a VNIC with a public IP",
+      "query": "MATCH (inst:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) MATCH (inst)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE vnic.public_ip IS NOT NULL AND vnic.public_ip <> '' SET inst.exposed_internet = true, (CASE WHEN NOT 'public_ip_direct' IN coalesce(inst.exposed_internet_type, []) THEN inst END).exposed_internet_type = coalesce(inst.exposed_internet_type, []) + 'public_ip_direct'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark instances as exposed if their VNIC is in a public subnet with an enabled Internet Gateway",
+      "query": "MATCH (inst:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) MATCH (subnet:OCISubnet{ocid: vnic.subnet_id, prohibit_public_ip_on_vnic: false})<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_INTERNET_GATEWAY]->(igw:OCIInternetGateway{is_enabled: true}) MATCH (inst)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET inst.exposed_internet = true, (CASE WHEN NOT 'public_subnet_with_igw' IN coalesce(inst.exposed_internet_type, []) THEN inst END).exposed_internet_type = coalesce(inst.exposed_internet_type, []) + 'public_subnet_with_igw'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark instances as exposed if their VCN has NSG rules allowing unrestricted ingress from 0.0.0.0/0",
+      "query": "MATCH (inst:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) MATCH (subnet:OCISubnet{ocid: vnic.subnet_id})<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_NETWORK_SECURITY_GROUP]->(nsg:OCINetworkSecurityGroup)-[:OCI_NSG_RULE]->(rule:OCINsgSecurityRule{direction: 'INGRESS', source: '0.0.0.0/0'}) MATCH (inst)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET inst.exposed_internet = true, (CASE WHEN NOT 'unrestricted_nsg_ingress' IN coalesce(inst.exposed_internet_type, []) THEN inst END).exposed_internet_type = coalesce(inst.exposed_internet_type, []) + 'unrestricted_nsg_ingress'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark instances as exposed if their subnet has a security list allowing unrestricted ingress from 0.0.0.0/0",
+      "query": "MATCH (inst:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) MATCH (subnet:OCISubnet{ocid: vnic.subnet_id})<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_SECURITY_LIST]->(sl:OCISecurityList) MATCH (inst)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE sl.ingress_security_rules CONTAINS '0.0.0.0/0' SET inst.exposed_internet = true, (CASE WHEN NOT 'unrestricted_securitylist_ingress' IN coalesce(inst.exposed_internet_type, []) THEN inst END).exposed_internet_type = coalesce(inst.exposed_internet_type, []) + 'unrestricted_securitylist_ingress'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark instances as exposed via IPv6 unrestricted NSG ingress (::/0)",
+      "query": "MATCH (inst:OCIInstance)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) MATCH (subnet:OCISubnet{ocid: vnic.subnet_id})<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_NETWORK_SECURITY_GROUP]->(nsg:OCINetworkSecurityGroup)-[:OCI_NSG_RULE]->(rule:OCINsgSecurityRule{direction: 'INGRESS', source: '::/0'}) MATCH (inst)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET inst.exposed_internet = true, (CASE WHEN NOT 'unrestricted_nsg_ingress_ipv6' IN coalesce(inst.exposed_internet_type, []) THEN inst END).exposed_internet_type = coalesce(inst.exposed_internet_type, []) + 'unrestricted_nsg_ingress_ipv6'",
+      "iterative": false
+    },
+    {
+      "__comment": "Build publicContext JSON for exposed instances with VNIC, subnet, and security details",
+      "query": "MATCH (inst:OCIInstance)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE inst.exposed_internet = true WITH inst OPTIONAL MATCH (inst)-[:OCI_VNIC_ATTACHMENT]->(:OCIVnicAttachment)-[:OCI_VNIC]->(vnic:OCIVnic) OPTIONAL MATCH (subnet:OCISubnet{ocid: vnic.subnet_id})<-[:OCI_SUBNET]-(vcn:OCIVcn) OPTIONAL MATCH (vcn)-[:OCI_NETWORK_SECURITY_GROUP]->(nsg:OCINetworkSecurityGroup)-[:OCI_NSG_RULE]->(rule:OCINsgSecurityRule{direction: 'INGRESS'}) WHERE rule.source IN ['0.0.0.0/0', '::/0'] WITH inst, vnic, subnet, vcn, collect(DISTINCT {nsgId: nsg.ocid, ruleId: rule.ocid, protocol: rule.protocol, source: rule.source, tcpPortMin: rule.tcp_dest_port_min, tcpPortMax: rule.tcp_dest_port_max}) as nsgRules SET inst.publicContext = apoc.convert.toJson([{resource: inst.ocid, resourceType: 'oci-compute-vm-instance', context: [{instanceId: inst.ocid, instanceName: inst.display_name, publicIp: vnic.public_ip, privateIp: vnic.private_ip, shape: inst.shape, region: inst.region, subnetId: subnet.ocid, vcnId: vcn.ocid, prohibitPublicIp: subnet.prohibit_public_ip_on_vnic, exposureTypes: inst.exposed_internet_type, nsgRules: nsgRules}]}])",
+      "iterative": false
+    }
+  ],
+  "name": "OCI compute instance asset internet exposure"
+}

--- a/cartography/data/jobs/analysis/oci_logging_analysis.json
+++ b/cartography/data/jobs/analysis/oci_logging_analysis.json
@@ -1,0 +1,52 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset logging analysis properties on OCI audit configuration in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCIAuditConfiguration) WHERE n.logging_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.logging_risk, n.logging_risk_type RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Reset logging analysis properties on OCI logging configuration in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCILoggingConfiguration) WHERE n.logging_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.logging_risk, n.logging_risk_type RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Flag audit configuration with retention period less than 365 days (CIS 3.1)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(ac:OCIAuditConfiguration) WHERE ac.retention_period_days < 365 SET ac.logging_risk = true, (CASE WHEN NOT 'audit_retention_insufficient' IN coalesce(ac.logging_risk_type, []) THEN ac END).logging_risk_type = coalesce(ac.logging_risk_type, []) + 'audit_retention_insufficient'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag logging configuration with no log groups configured",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(lc:OCILoggingConfiguration{has_log_groups: false}) SET lc.logging_risk = true, (CASE WHEN NOT 'no_log_groups' IN coalesce(lc.logging_risk_type, []) THEN lc END).logging_risk_type = coalesce(lc.logging_risk_type, []) + 'no_log_groups'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag logging configuration with no enabled logs",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(lc:OCILoggingConfiguration{has_enabled_logs: false}) SET lc.logging_risk = true, (CASE WHEN NOT 'no_enabled_logs' IN coalesce(lc.logging_risk_type, []) THEN lc END).logging_risk_type = coalesce(lc.logging_risk_type, []) + 'no_enabled_logs'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag individual logs that are disabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(:OCILogGroup)-[:OCI_LOG]->(l:OCILog{is_enabled: false}) SET l.logging_risk = true, (CASE WHEN NOT 'log_disabled' IN coalesce(l.logging_risk_type, []) THEN l END).logging_risk_type = coalesce(l.logging_risk_type, []) + 'log_disabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag Object Storage buckets with write logging not enabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(b:OCIStorageBucket{write_logging_enabled: false}) SET b.logging_risk = true, (CASE WHEN NOT 'bucket_write_logging_missing' IN coalesce(b.logging_risk_type, []) THEN b END).logging_risk_type = coalesce(b.logging_risk_type, []) + 'bucket_write_logging_missing'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag Object Storage buckets with read logging not enabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(b:OCIStorageBucket{read_logging_enabled: false}) SET b.logging_risk = true, (CASE WHEN NOT 'bucket_read_logging_missing' IN coalesce(b.logging_risk_type, []) THEN b END).logging_risk_type = coalesce(b.logging_risk_type, []) + 'bucket_read_logging_missing'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag compartments with no log groups (logging gap)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(comp:OCICompartment{id: $OCI_COMPARTMENT_ID}) WHERE NOT (comp)-[:RESOURCE]->(:OCILogGroup) SET comp.logging_gap = true",
+      "iterative": false
+    }
+  ],
+  "name": "OCI logging and audit analysis"
+}

--- a/cartography/data/jobs/analysis/oci_monitoring_analysis.json
+++ b/cartography/data/jobs/analysis/oci_monitoring_analysis.json
@@ -1,0 +1,52 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset monitoring analysis properties on all OCI alarms in scope",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCIMonitoringAlarm) WHERE n.monitoring_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.monitoring_risk, n.monitoring_risk_type RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Reset monitoring analysis on Cloud Guard",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(n:OCICloudGuard) WHERE n.monitoring_risk IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.monitoring_risk, n.monitoring_risk_type RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Flag alarms that are disabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(a:OCIMonitoringAlarm{is_enabled: false}) SET a.monitoring_risk = true, (CASE WHEN NOT 'alarm_disabled' IN coalesce(a.monitoring_risk_type, []) THEN a END).monitoring_risk_type = coalesce(a.monitoring_risk_type, []) + 'alarm_disabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag alarms with no notification destinations configured",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(a:OCIMonitoringAlarm) WHERE a.destinations IS NULL OR size(a.destinations) = 0 SET a.monitoring_risk = true, (CASE WHEN NOT 'no_destinations' IN coalesce(a.monitoring_risk_type, []) THEN a END).monitoring_risk_type = coalesce(a.monitoring_risk_type, []) + 'no_destinations'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag alarms in non-active lifecycle state",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(a:OCIMonitoringAlarm) WHERE a.lifecycle_state <> 'ACTIVE' SET a.monitoring_risk = true, (CASE WHEN NOT 'alarm_not_active' IN coalesce(a.monitoring_risk_type, []) THEN a END).monitoring_risk_type = coalesce(a.monitoring_risk_type, []) + 'alarm_not_active'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag Cloud Guard if it is disabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(cg:OCICloudGuard) WHERE cg.status = 'DISABLED' SET cg.monitoring_risk = true, (CASE WHEN NOT 'cloud_guard_disabled' IN coalesce(cg.monitoring_risk_type, []) THEN cg END).monitoring_risk_type = coalesce(cg.monitoring_risk_type, []) + 'cloud_guard_disabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag event rules that are disabled",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(:OCICompartment{id: $OCI_COMPARTMENT_ID})-[:RESOURCE]->(er:OCIEventRule{is_enabled: false}) SET er.monitoring_risk = true, (CASE WHEN NOT 'event_rule_disabled' IN coalesce(er.monitoring_risk_type, []) THEN er END).monitoring_risk_type = coalesce(er.monitoring_risk_type, []) + 'event_rule_disabled'",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag compartments with no monitoring alarms configured (monitoring gap)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(comp:OCICompartment{id: $OCI_COMPARTMENT_ID}) WHERE NOT (comp)-[:RESOURCE]->(:OCIMonitoringAlarm) SET comp.monitoring_gap = true, comp.no_alarms_configured = true",
+      "iterative": false
+    },
+    {
+      "__comment": "Flag compartments with no event rules configured (event monitoring gap)",
+      "query": "MATCH (:CloudanixWorkspace{id: $WORKSPACE_ID})-[:OWNER]->(:OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(comp:OCICompartment{id: $OCI_COMPARTMENT_ID}) WHERE NOT (comp)-[:RESOURCE]->(:OCIEventRule) SET comp.event_monitoring_gap = true, comp.no_event_rules_configured = true",
+      "iterative": false
+    }
+  ],
+  "name": "OCI monitoring and observability analysis"
+}

--- a/cartography/data/jobs/analysis/oci_subnet_asset_exposure.json
+++ b/cartography/data/jobs/analysis/oci_subnet_asset_exposure.json
@@ -1,0 +1,31 @@
+{
+  "statements": [
+    {
+      "__comment": "Reset exposed_internet properties on all OCI subnets in scope",
+      "query": "MATCH (n:OCISubnet)<-[:OCI_SUBNET]-(:OCIVcn)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE n.exposed_internet IS NOT NULL WITH n LIMIT $LIMIT_SIZE REMOVE n.exposed_internet, n.exposed_internet_type, n.publicContext RETURN COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "__comment": "Mark subnets as exposed if they allow public IPs on VNICs (public subnet)",
+      "query": "MATCH (subnet:OCISubnet{prohibit_public_ip_on_vnic: false})<-[:OCI_SUBNET]-(:OCIVcn)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) SET subnet.exposed_internet = true, (CASE WHEN NOT 'public_subnet' IN coalesce(subnet.exposed_internet_type, []) THEN subnet END).exposed_internet_type = coalesce(subnet.exposed_internet_type, []) + 'public_subnet'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark subnets as exposed if their VCN has an enabled Internet Gateway",
+      "query": "MATCH (subnet:OCISubnet)<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_INTERNET_GATEWAY]->(igw:OCIInternetGateway{is_enabled: true}) MATCH (vcn)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE subnet.prohibit_public_ip_on_vnic = false SET subnet.exposed_internet = true, (CASE WHEN NOT 'internet_gateway_route' IN coalesce(subnet.exposed_internet_type, []) THEN subnet END).exposed_internet_type = coalesce(subnet.exposed_internet_type, []) + 'internet_gateway_route'",
+      "iterative": false
+    },
+    {
+      "__comment": "Mark subnets as exposed if their route table has a route targeting an Internet Gateway",
+      "query": "MATCH (subnet:OCISubnet)<-[:OCI_SUBNET]-(vcn:OCIVcn)-[:OCI_ROUTE_TABLE]->(rt:OCIRouteTable) MATCH (vcn)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE subnet.route_table_id = rt.ocid AND rt.route_rules CONTAINS 'internet-gateway' SET subnet.exposed_internet = true, (CASE WHEN NOT 'igw_route_rule' IN coalesce(subnet.exposed_internet_type, []) THEN subnet END).exposed_internet_type = coalesce(subnet.exposed_internet_type, []) + 'igw_route_rule'",
+      "iterative": false
+    },
+    {
+      "__comment": "Build publicContext JSON for exposed subnets",
+      "query": "MATCH (subnet:OCISubnet)<-[:OCI_SUBNET]-(vcn:OCIVcn)<-[:RESOURCE]-(:OCICompartment{id: $OCI_COMPARTMENT_ID})<-[:OWNER]-(:OCITenancy{id: $OCI_TENANCY_ID})<-[:OWNER]-(:CloudanixWorkspace{id: $WORKSPACE_ID}) WHERE subnet.exposed_internet = true OPTIONAL MATCH (vcn)-[:OCI_INTERNET_GATEWAY]->(igw:OCIInternetGateway{is_enabled: true}) OPTIONAL MATCH (vcn)-[:OCI_ROUTE_TABLE]->(rt:OCIRouteTable) WHERE subnet.route_table_id = rt.ocid WITH subnet, vcn, collect(DISTINCT igw.ocid) as igwIds, rt SET subnet.publicContext = apoc.convert.toJson([{resource: subnet.ocid, resourceType: 'oci-subnet', context: [{subnetId: subnet.ocid, subnetName: subnet.display_name, cidrBlock: subnet.cidr_block, vcnId: vcn.ocid, vcnName: vcn.display_name, prohibitPublicIp: subnet.prohibit_public_ip_on_vnic, routeTableId: rt.ocid, internetGateways: igwIds, exposureTypes: subnet.exposed_internet_type, region: subnet.region}]}])",
+      "iterative": false
+    }
+  ],
+  "name": "OCI subnet asset internet exposure"
+}

--- a/cartography/intel/oci/__init__.py
+++ b/cartography/intel/oci/__init__.py
@@ -141,6 +141,10 @@ def _sync_one_compartment(
         'oci_iam_policy_analysis.json',
         'oci_encryption_analysis.json',
         'oci_monitoring_analysis.json',
+        'oci_containerregistry_asset_exposure.json',
+        'oci_object_storage_asset_exposure.json',
+        'oci_file_storage_asset_exposure.json',
+        'oci_logging_analysis.json',
     ]
     for job_file in _oci_analysis_jobs:
         try:

--- a/cartography/intel/oci/__init__.py
+++ b/cartography/intel/oci/__init__.py
@@ -26,7 +26,7 @@ from . import utils
 from .resources import RESOURCE_FUNCTIONS
 from cartography.config import Config
 from cartography.intel.oci.util.common import parse_and_validate_oci_requested_syncs
-# from cartography.util import run_analysis_job
+from cartography.util import run_analysis_job
 # from cartography.util import run_cleanup_job
 
 logger = logging.getLogger(__name__)
@@ -132,6 +132,22 @@ def _sync_one_compartment(
             logger.warning(
                 'OCI sync function "%s" was specified but does not exist. Did you misspell it?', func_name,
             )
+
+    # Run analysis jobs after all resource syncs complete
+    _oci_analysis_jobs = [
+        'oci_subnet_asset_exposure.json',
+        'oci_instance_asset_exposure.json',
+        'oci_iam_user_analysis.json',
+        'oci_iam_policy_analysis.json',
+        'oci_encryption_analysis.json',
+        'oci_monitoring_analysis.json',
+    ]
+    for job_file in _oci_analysis_jobs:
+        try:
+            run_analysis_job(job_file, neo4j_session, common_job_parameters)
+        except Exception as e:
+            logger.error("Error running OCI analysis job '%s': %s", job_file, e, exc_info=True)
+
     logger.info(
         json.dumps({
             "event": "oci_compartment_timing_summary",


### PR DESCRIPTION
## Summary
Adds post-sync analysis jobs for OCI that enrich graph nodes with security posture
properties (exposed_internet, iam_risk, policy_risk, encryption_risk, monitoring_risk).
Follows the same pattern as AWS/Azure analysis jobs — iterative reset, tag conditions,
publicContext JSON via apoc.

## Analysis Jobs Added

| File | Target Nodes | Checks |
|---|---|---|
| `oci_subnet_asset_exposure.json` | OCISubnet | public subnet, IGW route, route table rules |
| `oci_instance_asset_exposure.json` | OCIInstance | public IP, public subnet + IGW, unrestricted NSG/SecurityList ingress (IPv4 + IPv6) |
| `oci_iam_user_analysis.json` | OCIUser | MFA not enabled, API keys, admin group, excessive permissions |
| `oci_iam_policy_analysis.json` | OCIPolicy | manage all-resources, manage in tenancy, identity management, any-user principal |
| `oci_encryption_analysis.json` | OCIKmsVault, OCIKmsKey | vault not active, shared HSM, no active keys, software protection, key not enabled |
| `oci_monitoring_analysis.json` | OCIMonitoringAlarm, OCICloudGuard, OCIEventRule, OCICompartment | disabled alarms, no destinations, Cloud Guard disabled, disabled event rules, monitoring gaps |

## Wiring
- Uncommented `from cartography.util import run_analysis_job` in `intel/oci/__init__.py`
- Added analysis loop at tail of `_sync_one_compartment` (after resource syncs, before timing summary)
- Each job wrapped in try/except to avoid blocking other jobs on failure