### PR TITLE
Limit inventory sync to live/active resources

### DIFF
--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -44,14 +44,25 @@ def get_images_in_use(neo4j_session: neo4j.Session, region: str, current_aws_acc
     return images
 
 
+def filter_available_ec2_images(images: List[Dict]) -> List[Dict]:
+    """Keep only available AMIs (drop pending/failed/invalid)."""
+    return [image for image in images if image.get('State') == 'available']
+
+
 @timeit
 @aws_handle_regions
 def get_images(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
     images = []
     try:
-        self_images = client.describe_images(Owners=['self'])['Images']
-        images.extend(self_images)
+        self_images = client.describe_images(
+            Owners=['self'],
+            Filters=[{
+                'Name': 'state',
+                'Values': ['available'],
+            }],
+        )['Images']
+        images.extend(filter_available_ec2_images(self_images))
     except ClientError as e:
         logger.warning(f"Failed retrieve images for region - {region}. Error - {e}")
     return images

--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -20,6 +20,12 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
+# Applied at describe_images so non-available AMIs never leave the API.
+EC2_IMAGE_FILTERS = [{
+    'Name': 'state',
+    'Values': ['available'],
+}]
+
 
 def get_images_in_use(neo4j_session: neo4j.Session, region: str, current_aws_account_id: str) -> List[str]:
     # We use OPTIONAL here to allow query chaining with queries that may not match.
@@ -44,11 +50,6 @@ def get_images_in_use(neo4j_session: neo4j.Session, region: str, current_aws_acc
     return images
 
 
-def filter_available_ec2_images(images: List[Dict]) -> List[Dict]:
-    """Keep only available AMIs (drop pending/failed/invalid)."""
-    return [image for image in images if image.get('State') == 'available']
-
-
 @timeit
 @aws_handle_regions
 def get_images(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
@@ -57,12 +58,9 @@ def get_images(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     try:
         self_images = client.describe_images(
             Owners=['self'],
-            Filters=[{
-                'Name': 'state',
-                'Values': ['available'],
-            }],
+            Filters=EC2_IMAGE_FILTERS,
         )['Images']
-        images.extend(filter_available_ec2_images(self_images))
+        images.extend(self_images)
     except ClientError as e:
         logger.warning(f"Failed retrieve images for region - {region}. Error - {e}")
     return images

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -15,16 +15,8 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
-
-def filter_current_launch_template_versions(versions: List[Dict]) -> List[Dict]:
-    """Keep default and/or latest launch template versions only."""
-    if not versions:
-        return []
-    latest_number = max(v.get('VersionNumber', 0) for v in versions)
-    return [
-        v for v in versions
-        if v.get('DefaultVersion') is True or v.get('VersionNumber') == latest_number
-    ]
+# Applied at describe_launch_template_versions — historical versions stay at the API.
+LAUNCH_TEMPLATE_VERSIONS = ['$Latest', '$Default']
 
 
 @timeit
@@ -42,10 +34,10 @@ def get_launch_templates(boto3_session: boto3.session.Session, region: str) -> L
             v_paginator = client.get_paginator('describe_launch_template_versions')
             for versions in v_paginator.paginate(
                 LaunchTemplateId=template['LaunchTemplateId'],
-                Versions=['$Latest', '$Default'],
+                Versions=LAUNCH_TEMPLATE_VERSIONS,
             ):
                 template_versions.extend(versions["LaunchTemplateVersions"])
-            template["_template_versions"] = filter_current_launch_template_versions(template_versions)
+            template["_template_versions"] = template_versions
 
     except Exception as e:
         logger.warning(f"Failed retrieve address for region - {region}. Error - {e}")

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -16,6 +16,17 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
+def filter_current_launch_template_versions(versions: List[Dict]) -> List[Dict]:
+    """Keep default and/or latest launch template versions only."""
+    if not versions:
+        return []
+    latest_number = max(v.get('VersionNumber', 0) for v in versions)
+    return [
+        v for v in versions
+        if v.get('DefaultVersion') is True or v.get('VersionNumber') == latest_number
+    ]
+
+
 @timeit
 @aws_handle_regions
 def get_launch_templates(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
@@ -29,9 +40,12 @@ def get_launch_templates(boto3_session: boto3.session.Session, region: str) -> L
         for template in templates:
             template_versions: List[Dict] = []
             v_paginator = client.get_paginator('describe_launch_template_versions')
-            for versions in v_paginator.paginate(LaunchTemplateId=template['LaunchTemplateId']):
+            for versions in v_paginator.paginate(
+                LaunchTemplateId=template['LaunchTemplateId'],
+                Versions=['$Latest', '$Default'],
+            ):
                 template_versions.extend(versions["LaunchTemplateVersions"])
-            template["_template_versions"] = template_versions
+            template["_template_versions"] = filter_current_launch_template_versions(template_versions)
 
     except Exception as e:
         logger.warning(f"Failed retrieve address for region - {region}. Error - {e}")

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
+def filter_completed_ebs_snapshots(snapshots: List[Dict]) -> List[Dict]:
+    """Keep only completed EBS snapshots (drop pending/error)."""
+    return [snapshot for snapshot in snapshots if snapshot.get('State') == 'completed']
+
+
 @timeit
 @aws_handle_regions
 def get_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
@@ -33,10 +38,15 @@ def get_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Dic
                     "Name": "owner-alias",
                     "Values": ["self"],
                 },
+                {
+                    "Name": "state",
+                    "Values": ["completed"],
+                },
             ],
         )
         for page in page_iterator:
             snapshots.extend(page['Snapshots'])
+        snapshots = filter_completed_ebs_snapshots(snapshots)
         for snapshot in snapshots:
             snapshot['region'] = region
             volume_permissions = get_snapshot_attribute(client=client, attribute_name='createVolumePermissions', snapshot_id=snapshot['SnapshotId'])

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -16,10 +16,17 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
-
-def filter_completed_ebs_snapshots(snapshots: List[Dict]) -> List[Dict]:
-    """Keep only completed EBS snapshots (drop pending/error)."""
-    return [snapshot for snapshot in snapshots if snapshot.get('State') == 'completed']
+# Applied at describe_snapshots so pending/error never leave the API.
+EBS_SNAPSHOT_FILTERS = [
+    {
+        "Name": "owner-alias",
+        "Values": ["self"],
+    },
+    {
+        "Name": "state",
+        "Values": ["completed"],
+    },
+]
 
 
 @timeit
@@ -32,21 +39,9 @@ def get_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Dic
 
         snapshots: List[Dict] = []
 
-        page_iterator = paginator.paginate(
-            Filters=[
-                {
-                    "Name": "owner-alias",
-                    "Values": ["self"],
-                },
-                {
-                    "Name": "state",
-                    "Values": ["completed"],
-                },
-            ],
-        )
+        page_iterator = paginator.paginate(Filters=EBS_SNAPSHOT_FILTERS)
         for page in page_iterator:
             snapshots.extend(page['Snapshots'])
-        snapshots = filter_completed_ebs_snapshots(snapshots)
         for snapshot in snapshots:
             snapshot['region'] = region
             volume_permissions = get_snapshot_attribute(client=client, attribute_name='createVolumePermissions', snapshot_id=snapshot['SnapshotId'])

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -71,8 +71,8 @@ def get_snapshot_attribute(client, snapshot_id, attribute_name):
                 'ec2:describe_snapshot_attribute failed with AccessDeniedException; continuing sync.',
                 exc_info=True,
             )
-    else:
-        raise
+        else:
+            raise
 
     return response
 

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -221,6 +221,11 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     )
 
 
+def filter_active_elasticsearch_reserved_instances(reserved_instances: List[Dict]) -> List[Dict]:
+    """Keep only reserved Elasticsearch instances in active state."""
+    return [ri for ri in reserved_instances if ri.get('State') == 'active']
+
+
 @timeit
 @aws_handle_regions
 def get_elasticsearch_reserved_instances(client: botocore.client.BaseClient, region: str, current_aws_account_id: str) -> List[Dict]:
@@ -231,6 +236,7 @@ def get_elasticsearch_reserved_instances(client: botocore.client.BaseClient, reg
         page_iterator = paginator.paginate()
         for page in page_iterator:
             reserved_instances.extend(page.get('ReservedElasticsearchInstances', []))
+        reserved_instances = filter_active_elasticsearch_reserved_instances(reserved_instances)
         for reserved_instance in reserved_instances:
             reserved_instance['arn'] = f"arn:aws:es:{region}:{current_aws_account_id}:reserved-instances/{reserved_instance['ReservedElasticsearchInstanceId']}"
             reserved_instance['region'] = region

--- a/cartography/intel/aws/kms.py
+++ b/cartography/intel/aws/kms.py
@@ -24,6 +24,11 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
+def filter_live_kms_keys(keys: List[Dict]) -> List[Dict]:
+    """Drop keys pending deletion; keep Enabled/Disabled (still security-relevant)."""
+    return [key for key in keys if key.get('KeyState') != 'PendingDeletion']
+
+
 @timeit
 @aws_handle_regions
 def get_kms_key_list(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
@@ -43,7 +48,7 @@ def get_kms_key_list(boto3_session: boto3.session.Session, region: str) -> List[
         response['region'] = region
         described_key_list.append(response)
 
-    return described_key_list
+    return filter_live_kms_keys(described_key_list)
 
 
 @timeit

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -267,6 +267,11 @@ def sync_rds_security_groups(
     cleanup_rds_security_groups(neo4j_session, common_job_parameters)
 
 
+def filter_available_rds_snapshots(snapshots: List[Dict]) -> List[Dict]:
+    """Keep only available RDS snapshots (drop creating/error)."""
+    return [snapshot for snapshot in snapshots if snapshot.get('Status') == 'available']
+
+
 @timeit
 @aws_handle_regions
 def get_rds_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Any]:
@@ -275,7 +280,7 @@ def get_rds_snapshots(boto3_session: boto3.session.Session, region: str) -> List
     snapshots: List[Any] = []
     for page in paginator.paginate():
         snapshots.extend(page['DBSnapshots'])
-    return snapshots
+    return filter_available_rds_snapshots(snapshots)
 
 
 @timeit

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -63,17 +63,23 @@ def dns_lookup_with_ip_type(hostname: str) -> List[Dict[str, bool]]:
     return [check_ip_type(ip) for ip in ips]
 
 
+def filter_active_rds_reserved_db_instances(instances: List[Dict]) -> List[Dict]:
+    """Keep only reserved DB instances in active state (drop retired/payment-*)."""
+    return [instance for instance in instances if instance.get('State') == 'active']
+
+
 @timeit
 @aws_handle_regions
 def get_rds_reserved_db_instances_data(boto3_session: boto3.session.Session, region: str) -> List[Any]:
     """
-    Create an RDS boto3 client and grab all the reserved db instances.
+    Create an RDS boto3 client and grab active reserved db instances.
     """
     client = boto3_session.client('rds', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('describe_reserved_db_instances')
     instances: List[Any] = []
     for page in paginator.paginate():
         instances.extend(page['ReservedDBInstances'])
+    instances = filter_active_rds_reserved_db_instances(instances)
     for instance in instances:
         instance['region'] = region
         instance['name'] = instance['ReservedDBInstanceArn'].split(':')[-1]

--- a/cartography/intel/aws/redshift.py
+++ b/cartography/intel/aws/redshift.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
+def filter_active_redshift_reserved_nodes(reserved_nodes: List[Dict]) -> List[Dict]:
+    """Keep only reserved Redshift nodes in active state."""
+    return [node for node in reserved_nodes if node.get("State") == "active"]
+
+
 @timeit
 @aws_handle_regions
 def get_redshift_reserved_node(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
@@ -26,7 +31,7 @@ def get_redshift_reserved_node(boto3_session: boto3.session.Session, region: str
         reserved_nodes: List = []
         for page in paginator.paginate():
             reserved_nodes.extend(page["ReservedNodes"])
-        return reserved_nodes
+        return filter_active_redshift_reserved_nodes(reserved_nodes)
 
     except ClientError as e:
         logger.error(f"Failed to call redshift describe_reserved_nodes: {region} - {e}")

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -17,20 +17,17 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
-def filter_active_secrets(secrets: List[Dict]) -> List[Dict]:
-    """Exclude secrets scheduled for deletion."""
-    return [secret for secret in secrets if not secret.get('DeletedDate')]
-
-
 @timeit
 @aws_handle_regions
 def get_secret_list(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     client = boto3_session.client('secretsmanager', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('list_secrets')
     secrets: List[Dict] = []
+    # IncludePlannedDeletion=False is the API default; pass explicitly so
+    # secrets scheduled for deletion never leave Secrets Manager.
     for page in paginator.paginate(IncludePlannedDeletion=False):
         secrets.extend(page['SecretList'])
-    return filter_active_secrets(secrets)
+    return secrets
 
 
 @timeit

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -17,15 +17,20 @@ logger = logging.getLogger(__name__)
 aws_console_link = AWSLinker()
 
 
+def filter_active_secrets(secrets: List[Dict]) -> List[Dict]:
+    """Exclude secrets scheduled for deletion."""
+    return [secret for secret in secrets if not secret.get('DeletedDate')]
+
+
 @timeit
 @aws_handle_regions
 def get_secret_list(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     client = boto3_session.client('secretsmanager', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('list_secrets')
     secrets: List[Dict] = []
-    for page in paginator.paginate():
+    for page in paginator.paginate(IncludePlannedDeletion=False):
         secrets.extend(page['SecretList'])
-    return secrets
+    return filter_active_secrets(secrets)
 
 
 @timeit

--- a/cartography/intel/gcp/dataflow.py
+++ b/cartography/intel/gcp/dataflow.py
@@ -16,35 +16,24 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 gcp_console_link = GCPLinker()
 
-# Terminal / non-live Dataflow job states that should not be ingested.
-INACTIVE_DATAFLOW_JOB_STATES = {
-    'JOB_STATE_DONE',
-    'JOB_STATE_FAILED',
-    'JOB_STATE_CANCELLED',
-    'JOB_STATE_UPDATED',
-    'JOB_STATE_DRAINED',
-}
-
-
-def filter_active_dataflow_jobs(jobs: List[Dict]) -> List[Dict]:
-    """Keep only non-terminal Dataflow jobs."""
-    return [
-        job for job in jobs
-        if job.get('currentState') not in INACTIVE_DATAFLOW_JOB_STATES
-    ]
+# Dataflow jobs.aggregated filter enum — ACTIVE = non-terminal/running jobs.
+DATAFLOW_ACTIVE_FILTER = 'ACTIVE'
 
 
 @timeit
 def get_dataflow_jobs(dataflow: Resource, project_id: str, regions: list, common_job_parameters) -> List[Dict]:
     jobs = []
     try:
-        req = dataflow.projects().jobs().aggregated(projectId=project_id)
+        req = dataflow.projects().jobs().aggregated(
+            projectId=project_id,
+            filter=DATAFLOW_ACTIVE_FILTER,
+        )
         while req is not None:
             res = req.execute()
             if res.get('jobs'):
                 jobs.extend(res.get('jobs', []))
             req = dataflow.projects().jobs().aggregated_next(previous_request=req, previous_response=res)
-        return filter_active_dataflow_jobs(jobs)
+        return jobs
     except HttpError as e:
         err = json.loads(e.content.decode('utf-8'))['error']
         if err.get('status', '') == 'PERMISSION_DENIED' or err.get('message', '') == 'Forbidden':

--- a/cartography/intel/gcp/dataflow.py
+++ b/cartography/intel/gcp/dataflow.py
@@ -16,6 +16,23 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 gcp_console_link = GCPLinker()
 
+# Terminal / non-live Dataflow job states that should not be ingested.
+INACTIVE_DATAFLOW_JOB_STATES = {
+    'JOB_STATE_DONE',
+    'JOB_STATE_FAILED',
+    'JOB_STATE_CANCELLED',
+    'JOB_STATE_UPDATED',
+    'JOB_STATE_DRAINED',
+}
+
+
+def filter_active_dataflow_jobs(jobs: List[Dict]) -> List[Dict]:
+    """Keep only non-terminal Dataflow jobs."""
+    return [
+        job for job in jobs
+        if job.get('currentState') not in INACTIVE_DATAFLOW_JOB_STATES
+    ]
+
 
 @timeit
 def get_dataflow_jobs(dataflow: Resource, project_id: str, regions: list, common_job_parameters) -> List[Dict]:
@@ -27,7 +44,7 @@ def get_dataflow_jobs(dataflow: Resource, project_id: str, regions: list, common
             if res.get('jobs'):
                 jobs.extend(res.get('jobs', []))
             req = dataflow.projects().jobs().aggregated_next(previous_request=req, previous_response=res)
-        return jobs
+        return filter_active_dataflow_jobs(jobs)
     except HttpError as e:
         err = json.loads(e.content.decode('utf-8'))['error']
         if err.get('status', '') == 'PERMISSION_DENIED' or err.get('message', '') == 'Forbidden':

--- a/cartography/intel/gcp/dataproc.py
+++ b/cartography/intel/gcp/dataproc.py
@@ -16,23 +16,14 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 gcp_console_link = GCPLinker()
 
-# Terminal Dataproc cluster states that should not be ingested.
-INACTIVE_DATAPROC_CLUSTER_STATES = {
-    'TERMINATED',
-    'ERROR',
-    'DELETING',
-    'UNKNOWN',
-}
-
-
-def filter_active_dataproc_clusters(clusters: List[Dict]) -> List[Dict]:
-    """Drop terminated/error Dataproc cluster tombstones."""
-    active = []
-    for cluster in clusters:
-        state = (cluster.get('status') or {}).get('state')
-        if state not in INACTIVE_DATAPROC_CLUSTER_STATES:
-            active.append(cluster)
-    return active
+# Dataproc list filter: ACTIVE = CREATING|UPDATING|RUNNING (API helper state).
+# STOPPED/STOPPING are still live config — fetch those states in separate calls
+# because Dataproc filters only support AND, not OR.
+DATAPROC_LIST_STATE_FILTERS = (
+    'status.state = ACTIVE',
+    'status.state = STOPPED',
+    'status.state = STOPPING',
+)
 
 
 @timeit
@@ -41,21 +32,26 @@ def get_dataproc_clusters(dataproc: Resource, project_id: str, regions: list) ->
     try:
         if regions:
             for region in regions:
-                req = dataproc.projects().regions().clusters().list(projectId=project_id, region=region)
-                while req is not None:
-                    res = req.execute()
-                    if res.get('clusters'):
-                        for cluster in res['clusters']:
-                            cluster['region'] = region
-                            cluster['id'] = f"projects/{project_id}/clusters/{cluster['clusterName']}"
-                            cluster['consolelink'] = gcp_console_link.get_console_link(
-                                project_id=project_id,
-                                dataproc_cluster_name=cluster['clusterName'], region=cluster['region'], resource_name='dataproc_cluster',
-                            )
-                            clusters.append(cluster)
-                    req = dataproc.projects().regions().clusters().list_next(previous_request=req, previous_response=res)
+                for state_filter in DATAPROC_LIST_STATE_FILTERS:
+                    req = dataproc.projects().regions().clusters().list(
+                        projectId=project_id,
+                        region=region,
+                        filter=state_filter,
+                    )
+                    while req is not None:
+                        res = req.execute()
+                        if res.get('clusters'):
+                            for cluster in res['clusters']:
+                                cluster['region'] = region
+                                cluster['id'] = f"projects/{project_id}/clusters/{cluster['clusterName']}"
+                                cluster['consolelink'] = gcp_console_link.get_console_link(
+                                    project_id=project_id,
+                                    dataproc_cluster_name=cluster['clusterName'], region=cluster['region'], resource_name='dataproc_cluster',
+                                )
+                                clusters.append(cluster)
+                        req = dataproc.projects().regions().clusters().list_next(previous_request=req, previous_response=res)
 
-        return filter_active_dataproc_clusters(clusters)
+        return clusters
     except HttpError as e:
         err = json.loads(e.content.decode('utf-8'))['error']
         if err.get('status', '') == 'PERMISSION_DENIED' or err.get('message', '') == 'Forbidden':

--- a/cartography/intel/gcp/dataproc.py
+++ b/cartography/intel/gcp/dataproc.py
@@ -16,6 +16,24 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 gcp_console_link = GCPLinker()
 
+# Terminal Dataproc cluster states that should not be ingested.
+INACTIVE_DATAPROC_CLUSTER_STATES = {
+    'TERMINATED',
+    'ERROR',
+    'DELETING',
+    'UNKNOWN',
+}
+
+
+def filter_active_dataproc_clusters(clusters: List[Dict]) -> List[Dict]:
+    """Drop terminated/error Dataproc cluster tombstones."""
+    active = []
+    for cluster in clusters:
+        state = (cluster.get('status') or {}).get('state')
+        if state not in INACTIVE_DATAPROC_CLUSTER_STATES:
+            active.append(cluster)
+    return active
+
 
 @timeit
 def get_dataproc_clusters(dataproc: Resource, project_id: str, regions: list) -> List[Dict]:
@@ -37,7 +55,7 @@ def get_dataproc_clusters(dataproc: Resource, project_id: str, regions: list) ->
                             clusters.append(cluster)
                     req = dataproc.projects().regions().clusters().list_next(previous_request=req, previous_response=res)
 
-        return clusters
+        return filter_active_dataproc_clusters(clusters)
     except HttpError as e:
         err = json.loads(e.content.decode('utf-8'))['error']
         if err.get('status', '') == 'PERMISSION_DENIED' or err.get('message', '') == 'Forbidden':

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -141,16 +141,10 @@ def get_instance_list_data(
     Get live compute instances in a compartment.
     See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/ListInstances
     """
-    try:
-        raw = _list_instances_with_lifecycle_filter(
-            compute, compartment_id, ACTIVE_INSTANCE_LIFECYCLE_STATES,
-        )
-        return {'Instances': utils.oci_object_to_json(raw)}
-    except oci.exceptions.ServiceError as e:
-        logger.warning(
-            "Could not retrieve compute instances for compartment '%s': %s", compartment_id, e.message,
-        )
-        return {'Instances': []}
+    raw = _list_instances_with_lifecycle_filter(
+        compute, compartment_id, ACTIVE_INSTANCE_LIFECYCLE_STATES,
+    )
+    return {'Instances': utils.oci_object_to_json(raw)}
 
 
 def load_instances(

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -18,6 +18,26 @@ from cartography.util import run_cleanup_job
 
 logger = logging.getLogger(__name__)
 
+# Lifecycle states we treat as live compute worth ingesting.
+# Keep STOPPED (still configured, billable boot volume / security surface).
+# Drop TERMINATED / TERMINATING / CREATING tombstones and in-flight creates.
+ACTIVE_INSTANCE_LIFECYCLE_STATES: List[str] = [
+    "RUNNING",
+    "STARTING",
+    "STOPPING",
+    "STOPPED",
+    "PROVISIONING",
+    "MOVING",
+]
+
+
+def filter_active_oci_instances(instances: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep instances in live lifecycle states only."""
+    return [
+        instance for instance in instances
+        if instance.get("lifecycle-state") in ACTIVE_INSTANCE_LIFECYCLE_STATES
+    ]
+
 
 def get_vnic_data(
     network_client: oci.core.virtual_network_client.VirtualNetworkClient,
@@ -100,14 +120,15 @@ def get_instance_list_data(
     compartment_id: str,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
-    Get all compute instances in a compartment.
+    Get live compute instances in a compartment.
     See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/ListInstances
     """
     try:
         response = oci.pagination.list_call_get_all_results(
             compute.list_instances, compartment_id=compartment_id,
         )
-        return {'Instances': utils.oci_object_to_json(response.data)}
+        instances = filter_active_oci_instances(utils.oci_object_to_json(response.data))
+        return {'Instances': instances}
     except oci.exceptions.ServiceError as e:
         logger.warning(
             "Could not retrieve compute instances for compartment '%s': %s", compartment_id, e.message,

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 # Lifecycle states we treat as live compute worth ingesting.
 # Keep STOPPED (still configured, billable boot volume / security surface).
-# Drop TERMINATED / TERMINATING / CREATING tombstones and in-flight creates.
+# Include transitional states (STARTING, STOPPING, PROVISIONING, MOVING).
+# Drop TERMINATED / TERMINATING / CREATING.
 # list_instances accepts a single lifecycle_state — one call per state.
 ACTIVE_INSTANCE_LIFECYCLE_STATES: List[str] = [
     "RUNNING",

--- a/cartography/intel/oci/compute.py
+++ b/cartography/intel/oci/compute.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # Lifecycle states we treat as live compute worth ingesting.
 # Keep STOPPED (still configured, billable boot volume / security surface).
 # Drop TERMINATED / TERMINATING / CREATING tombstones and in-flight creates.
+# list_instances accepts a single lifecycle_state — one call per state.
 ACTIVE_INSTANCE_LIFECYCLE_STATES: List[str] = [
     "RUNNING",
     "STARTING",
@@ -31,12 +32,28 @@ ACTIVE_INSTANCE_LIFECYCLE_STATES: List[str] = [
 ]
 
 
-def filter_active_oci_instances(instances: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Keep instances in live lifecycle states only."""
-    return [
-        instance for instance in instances
-        if instance.get("lifecycle-state") in ACTIVE_INSTANCE_LIFECYCLE_STATES
-    ]
+def _list_instances_with_lifecycle_filter(
+    compute: oci.core.compute_client.ComputeClient,
+    compartment_id: str,
+    lifecycle_states: List[str],
+) -> List[Any]:
+    """Issue one paginated list_instances call per lifecycle_state and merge."""
+    aggregated: List[Any] = []
+    for state in lifecycle_states:
+        try:
+            response = oci.pagination.list_call_get_all_results(
+                compute.list_instances,
+                compartment_id=compartment_id,
+                lifecycle_state=state,
+            )
+            if response.data:
+                aggregated.extend(response.data)
+        except oci.exceptions.ServiceError as e:
+            logger.warning(
+                "list_instances failed for lifecycle_state '%s' in compartment '%s': %s",
+                state, compartment_id, e.message,
+            )
+    return aggregated
 
 
 def get_vnic_data(
@@ -124,11 +141,10 @@ def get_instance_list_data(
     See https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/ListInstances
     """
     try:
-        response = oci.pagination.list_call_get_all_results(
-            compute.list_instances, compartment_id=compartment_id,
+        raw = _list_instances_with_lifecycle_filter(
+            compute, compartment_id, ACTIVE_INSTANCE_LIFECYCLE_STATES,
         )
-        instances = filter_active_oci_instances(utils.oci_object_to_json(response.data))
-        return {'Instances': instances}
+        return {'Instances': utils.oci_object_to_json(raw)}
     except oci.exceptions.ServiceError as e:
         logger.warning(
             "Could not retrieve compute instances for compartment '%s': %s", compartment_id, e.message,

--- a/tests/unit/cartography/intel/aws/ec2/test_images.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_images.py
@@ -1,16 +1,8 @@
-from cartography.intel.aws.ec2.images import filter_available_ec2_images
+from cartography.intel.aws.ec2.images import EC2_IMAGE_FILTERS
 
 
-def test_filter_available_ec2_images_keeps_available_only():
-    images = [
-        {'ImageId': 'ami-ok', 'State': 'available'},
-        {'ImageId': 'ami-pending', 'State': 'pending'},
-        {'ImageId': 'ami-failed', 'State': 'failed'},
-        {'ImageId': 'ami-missing'},
-    ]
-    filtered = filter_available_ec2_images(images)
-    assert [i['ImageId'] for i in filtered] == ['ami-ok']
-
-
-def test_filter_available_ec2_images_empty():
-    assert filter_available_ec2_images([]) == []
+def test_ec2_image_filters_request_available_only():
+    assert EC2_IMAGE_FILTERS == [{
+        'Name': 'state',
+        'Values': ['available'],
+    }]

--- a/tests/unit/cartography/intel/aws/ec2/test_images.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_images.py
@@ -1,0 +1,16 @@
+from cartography.intel.aws.ec2.images import filter_available_ec2_images
+
+
+def test_filter_available_ec2_images_keeps_available_only():
+    images = [
+        {'ImageId': 'ami-ok', 'State': 'available'},
+        {'ImageId': 'ami-pending', 'State': 'pending'},
+        {'ImageId': 'ami-failed', 'State': 'failed'},
+        {'ImageId': 'ami-missing'},
+    ]
+    filtered = filter_available_ec2_images(images)
+    assert [i['ImageId'] for i in filtered] == ['ami-ok']
+
+
+def test_filter_available_ec2_images_empty():
+    assert filter_available_ec2_images([]) == []

--- a/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
@@ -1,0 +1,23 @@
+from cartography.intel.aws.ec2.launch_templates import filter_current_launch_template_versions
+
+
+def test_filter_current_launch_template_versions_keeps_default_and_latest():
+    versions = [
+        {'VersionNumber': 1, 'DefaultVersion': False},
+        {'VersionNumber': 2, 'DefaultVersion': True},
+        {'VersionNumber': 3, 'DefaultVersion': False},
+        {'VersionNumber': 4, 'DefaultVersion': False},
+    ]
+    filtered = filter_current_launch_template_versions(versions)
+    assert sorted(v['VersionNumber'] for v in filtered) == [2, 4]
+
+
+def test_filter_current_launch_template_versions_same_default_and_latest():
+    versions = [{'VersionNumber': 1, 'DefaultVersion': True}]
+    filtered = filter_current_launch_template_versions(versions)
+    assert len(filtered) == 1
+    assert filtered[0]['VersionNumber'] == 1
+
+
+def test_filter_current_launch_template_versions_empty():
+    assert filter_current_launch_template_versions([]) == []

--- a/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
@@ -1,23 +1,5 @@
-from cartography.intel.aws.ec2.launch_templates import filter_current_launch_template_versions
+from cartography.intel.aws.ec2.launch_templates import LAUNCH_TEMPLATE_VERSIONS
 
 
-def test_filter_current_launch_template_versions_keeps_default_and_latest():
-    versions = [
-        {'VersionNumber': 1, 'DefaultVersion': False},
-        {'VersionNumber': 2, 'DefaultVersion': True},
-        {'VersionNumber': 3, 'DefaultVersion': False},
-        {'VersionNumber': 4, 'DefaultVersion': False},
-    ]
-    filtered = filter_current_launch_template_versions(versions)
-    assert sorted(v['VersionNumber'] for v in filtered) == [2, 4]
-
-
-def test_filter_current_launch_template_versions_same_default_and_latest():
-    versions = [{'VersionNumber': 1, 'DefaultVersion': True}]
-    filtered = filter_current_launch_template_versions(versions)
-    assert len(filtered) == 1
-    assert filtered[0]['VersionNumber'] == 1
-
-
-def test_filter_current_launch_template_versions_empty():
-    assert filter_current_launch_template_versions([]) == []
+def test_launch_template_versions_request_latest_and_default():
+    assert LAUNCH_TEMPLATE_VERSIONS == ['$Latest', '$Default']

--- a/tests/unit/cartography/intel/aws/ec2/test_snapshots.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_snapshots.py
@@ -1,0 +1,16 @@
+from cartography.intel.aws.ec2.snapshots import filter_completed_ebs_snapshots
+
+
+def test_filter_completed_ebs_snapshots_keeps_completed_only():
+    snapshots = [
+        {'SnapshotId': 'snap-done', 'State': 'completed'},
+        {'SnapshotId': 'snap-pending', 'State': 'pending'},
+        {'SnapshotId': 'snap-error', 'State': 'error'},
+        {'SnapshotId': 'snap-missing'},
+    ]
+    filtered = filter_completed_ebs_snapshots(snapshots)
+    assert [s['SnapshotId'] for s in filtered] == ['snap-done']
+
+
+def test_filter_completed_ebs_snapshots_empty():
+    assert filter_completed_ebs_snapshots([]) == []

--- a/tests/unit/cartography/intel/aws/ec2/test_snapshots.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_snapshots.py
@@ -1,16 +1,12 @@
-from cartography.intel.aws.ec2.snapshots import filter_completed_ebs_snapshots
+from cartography.intel.aws.ec2.snapshots import EBS_SNAPSHOT_FILTERS
 
 
-def test_filter_completed_ebs_snapshots_keeps_completed_only():
-    snapshots = [
-        {'SnapshotId': 'snap-done', 'State': 'completed'},
-        {'SnapshotId': 'snap-pending', 'State': 'pending'},
-        {'SnapshotId': 'snap-error', 'State': 'error'},
-        {'SnapshotId': 'snap-missing'},
-    ]
-    filtered = filter_completed_ebs_snapshots(snapshots)
-    assert [s['SnapshotId'] for s in filtered] == ['snap-done']
-
-
-def test_filter_completed_ebs_snapshots_empty():
-    assert filter_completed_ebs_snapshots([]) == []
+def test_ebs_snapshot_filters_request_completed_self_owned():
+    assert {
+        'Name': 'state',
+        'Values': ['completed'],
+    } in EBS_SNAPSHOT_FILTERS
+    assert {
+        'Name': 'owner-alias',
+        'Values': ['self'],
+    } in EBS_SNAPSHOT_FILTERS

--- a/tests/unit/cartography/intel/aws/test_elasticsearch.py
+++ b/tests/unit/cartography/intel/aws/test_elasticsearch.py
@@ -1,0 +1,18 @@
+from cartography.intel.aws.elasticsearch import filter_active_elasticsearch_reserved_instances
+
+
+def test_filter_active_elasticsearch_reserved_instances_keeps_active_only():
+    reserved = [
+        {'ReservedElasticsearchInstanceId': 'es-active', 'State': 'active'},
+        {'ReservedElasticsearchInstanceId': 'es-retired', 'State': 'retired'},
+        {'ReservedElasticsearchInstanceId': 'es-payment-pending', 'State': 'payment-pending'},
+        {'ReservedElasticsearchInstanceId': 'es-missing-state'},
+    ]
+
+    filtered = filter_active_elasticsearch_reserved_instances(reserved)
+
+    assert [r['ReservedElasticsearchInstanceId'] for r in filtered] == ['es-active']
+
+
+def test_filter_active_elasticsearch_reserved_instances_empty():
+    assert filter_active_elasticsearch_reserved_instances([]) == []

--- a/tests/unit/cartography/intel/aws/test_kms.py
+++ b/tests/unit/cartography/intel/aws/test_kms.py
@@ -1,0 +1,16 @@
+from cartography.intel.aws.kms import filter_live_kms_keys
+
+
+def test_filter_live_kms_keys_skips_pending_deletion():
+    keys = [
+        {'KeyId': 'k-enabled', 'KeyState': 'Enabled'},
+        {'KeyId': 'k-disabled', 'KeyState': 'Disabled'},
+        {'KeyId': 'k-pending', 'KeyState': 'PendingDeletion'},
+        {'KeyId': 'k-missing'},
+    ]
+    filtered = filter_live_kms_keys(keys)
+    assert [k['KeyId'] for k in filtered] == ['k-enabled', 'k-disabled', 'k-missing']
+
+
+def test_filter_live_kms_keys_empty():
+    assert filter_live_kms_keys([]) == []

--- a/tests/unit/cartography/intel/aws/test_rds.py
+++ b/tests/unit/cartography/intel/aws/test_rds.py
@@ -1,0 +1,19 @@
+from cartography.intel.aws.rds import filter_active_rds_reserved_db_instances
+
+
+def test_filter_active_rds_reserved_db_instances_keeps_active_only():
+    instances = [
+        {'ReservedDBInstanceId': 'ri-active', 'State': 'active'},
+        {'ReservedDBInstanceId': 'ri-retired', 'State': 'retired'},
+        {'ReservedDBInstanceId': 'ri-payment-failed', 'State': 'payment-failed'},
+        {'ReservedDBInstanceId': 'ri-payment-pending', 'State': 'payment-pending'},
+        {'ReservedDBInstanceId': 'ri-missing-state'},
+    ]
+
+    filtered = filter_active_rds_reserved_db_instances(instances)
+
+    assert [i['ReservedDBInstanceId'] for i in filtered] == ['ri-active']
+
+
+def test_filter_active_rds_reserved_db_instances_empty():
+    assert filter_active_rds_reserved_db_instances([]) == []

--- a/tests/unit/cartography/intel/aws/test_rds.py
+++ b/tests/unit/cartography/intel/aws/test_rds.py
@@ -1,4 +1,5 @@
 from cartography.intel.aws.rds import filter_active_rds_reserved_db_instances
+from cartography.intel.aws.rds import filter_available_rds_snapshots
 
 
 def test_filter_active_rds_reserved_db_instances_keeps_active_only():
@@ -17,3 +18,18 @@ def test_filter_active_rds_reserved_db_instances_keeps_active_only():
 
 def test_filter_active_rds_reserved_db_instances_empty():
     assert filter_active_rds_reserved_db_instances([]) == []
+
+
+def test_filter_available_rds_snapshots_keeps_available_only():
+    snapshots = [
+        {'DBSnapshotIdentifier': 'snap-ok', 'Status': 'available'},
+        {'DBSnapshotIdentifier': 'snap-creating', 'Status': 'creating'},
+        {'DBSnapshotIdentifier': 'snap-error', 'Status': 'error'},
+        {'DBSnapshotIdentifier': 'snap-missing'},
+    ]
+    filtered = filter_available_rds_snapshots(snapshots)
+    assert [s['DBSnapshotIdentifier'] for s in filtered] == ['snap-ok']
+
+
+def test_filter_available_rds_snapshots_empty():
+    assert filter_available_rds_snapshots([]) == []

--- a/tests/unit/cartography/intel/aws/test_redshift.py
+++ b/tests/unit/cartography/intel/aws/test_redshift.py
@@ -1,0 +1,18 @@
+from cartography.intel.aws.redshift import filter_active_redshift_reserved_nodes
+
+
+def test_filter_active_redshift_reserved_nodes_keeps_active_only():
+    nodes = [
+        {'ReservedNodeId': 'rs-active', 'State': 'active'},
+        {'ReservedNodeId': 'rs-retired', 'State': 'retired'},
+        {'ReservedNodeId': 'rs-payment-failed', 'State': 'payment-failed'},
+        {'ReservedNodeId': 'rs-missing-state'},
+    ]
+
+    filtered = filter_active_redshift_reserved_nodes(nodes)
+
+    assert [n['ReservedNodeId'] for n in filtered] == ['rs-active']
+
+
+def test_filter_active_redshift_reserved_nodes_empty():
+    assert filter_active_redshift_reserved_nodes([]) == []

--- a/tests/unit/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/unit/cartography/intel/aws/test_secretsmanager.py
@@ -1,10 +1,18 @@
 """Secrets Manager filters at the API via IncludePlannedDeletion=False."""
-import inspect
+from unittest.mock import MagicMock
 
 from cartography.intel.aws import secretsmanager
 
 
-def test_get_secret_list_source_passes_include_planned_deletion_false():
-    source = inspect.getsource(secretsmanager.get_secret_list)
-    assert 'IncludePlannedDeletion=False' in source
-    assert 'filter_active_secrets' not in source
+def test_get_secret_list_passes_include_planned_deletion_false():
+    boto3_session = MagicMock()
+    client = boto3_session.client.return_value
+    paginator = client.get_paginator.return_value
+    secret = {'ARN': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:example'}
+    paginator.paginate.return_value = [{'SecretList': [secret]}]
+
+    result = secretsmanager.get_secret_list(boto3_session, 'us-east-1')
+
+    client.get_paginator.assert_called_once_with('list_secrets')
+    paginator.paginate.assert_called_once_with(IncludePlannedDeletion=False)
+    assert result == [secret]

--- a/tests/unit/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/unit/cartography/intel/aws/test_secretsmanager.py
@@ -1,18 +1,10 @@
-import datetime
-from datetime import timezone as tz
+"""Secrets Manager filters at the API via IncludePlannedDeletion=False."""
+import inspect
 
-from cartography.intel.aws.secretsmanager import filter_active_secrets
-
-
-def test_filter_active_secrets_excludes_deleted():
-    secrets = [
-        {'Name': 'live'},
-        {'Name': 'deleting', 'DeletedDate': datetime.datetime(2024, 1, 1, tzinfo=tz.utc)},
-        {'Name': 'also-live', 'DeletedDate': None},
-    ]
-    filtered = filter_active_secrets(secrets)
-    assert [s['Name'] for s in filtered] == ['live', 'also-live']
+from cartography.intel.aws import secretsmanager
 
 
-def test_filter_active_secrets_empty():
-    assert filter_active_secrets([]) == []
+def test_get_secret_list_source_passes_include_planned_deletion_false():
+    source = inspect.getsource(secretsmanager.get_secret_list)
+    assert 'IncludePlannedDeletion=False' in source
+    assert 'filter_active_secrets' not in source

--- a/tests/unit/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/unit/cartography/intel/aws/test_secretsmanager.py
@@ -1,0 +1,18 @@
+import datetime
+from datetime import timezone as tz
+
+from cartography.intel.aws.secretsmanager import filter_active_secrets
+
+
+def test_filter_active_secrets_excludes_deleted():
+    secrets = [
+        {'Name': 'live'},
+        {'Name': 'deleting', 'DeletedDate': datetime.datetime(2024, 1, 1, tzinfo=tz.utc)},
+        {'Name': 'also-live', 'DeletedDate': None},
+    ]
+    filtered = filter_active_secrets(secrets)
+    assert [s['Name'] for s in filtered] == ['live', 'also-live']
+
+
+def test_filter_active_secrets_empty():
+    assert filter_active_secrets([]) == []

--- a/tests/unit/cartography/intel/gcp/test_dataflow.py
+++ b/tests/unit/cartography/intel/gcp/test_dataflow.py
@@ -1,0 +1,19 @@
+from cartography.intel.gcp.dataflow import filter_active_dataflow_jobs
+
+
+def test_filter_active_dataflow_jobs_drops_terminal_states():
+    jobs = [
+        {'id': 'running', 'currentState': 'JOB_STATE_RUNNING'},
+        {'id': 'pending', 'currentState': 'JOB_STATE_PENDING'},
+        {'id': 'done', 'currentState': 'JOB_STATE_DONE'},
+        {'id': 'failed', 'currentState': 'JOB_STATE_FAILED'},
+        {'id': 'cancelled', 'currentState': 'JOB_STATE_CANCELLED'},
+        {'id': 'drained', 'currentState': 'JOB_STATE_DRAINED'},
+        {'id': 'missing'},
+    ]
+    filtered = filter_active_dataflow_jobs(jobs)
+    assert [j['id'] for j in filtered] == ['running', 'pending', 'missing']
+
+
+def test_filter_active_dataflow_jobs_empty():
+    assert filter_active_dataflow_jobs([]) == []

--- a/tests/unit/cartography/intel/gcp/test_dataflow.py
+++ b/tests/unit/cartography/intel/gcp/test_dataflow.py
@@ -1,19 +1,5 @@
-from cartography.intel.gcp.dataflow import filter_active_dataflow_jobs
+from cartography.intel.gcp.dataflow import DATAFLOW_ACTIVE_FILTER
 
 
-def test_filter_active_dataflow_jobs_drops_terminal_states():
-    jobs = [
-        {'id': 'running', 'currentState': 'JOB_STATE_RUNNING'},
-        {'id': 'pending', 'currentState': 'JOB_STATE_PENDING'},
-        {'id': 'done', 'currentState': 'JOB_STATE_DONE'},
-        {'id': 'failed', 'currentState': 'JOB_STATE_FAILED'},
-        {'id': 'cancelled', 'currentState': 'JOB_STATE_CANCELLED'},
-        {'id': 'drained', 'currentState': 'JOB_STATE_DRAINED'},
-        {'id': 'missing'},
-    ]
-    filtered = filter_active_dataflow_jobs(jobs)
-    assert [j['id'] for j in filtered] == ['running', 'pending', 'missing']
-
-
-def test_filter_active_dataflow_jobs_empty():
-    assert filter_active_dataflow_jobs([]) == []
+def test_dataflow_active_filter_is_api_enum():
+    assert DATAFLOW_ACTIVE_FILTER == 'ACTIVE'

--- a/tests/unit/cartography/intel/gcp/test_dataproc.py
+++ b/tests/unit/cartography/intel/gcp/test_dataproc.py
@@ -1,0 +1,19 @@
+from cartography.intel.gcp.dataproc import filter_active_dataproc_clusters
+
+
+def test_filter_active_dataproc_clusters_drops_terminated():
+    clusters = [
+        {'clusterName': 'live', 'status': {'state': 'RUNNING'}},
+        {'clusterName': 'creating', 'status': {'state': 'CREATING'}},
+        {'clusterName': 'start', 'status': {'state': 'START'}},
+        {'clusterName': 'terminated', 'status': {'state': 'TERMINATED'}},
+        {'clusterName': 'error', 'status': {'state': 'ERROR'}},
+        {'clusterName': 'deleting', 'status': {'state': 'DELETING'}},
+        {'clusterName': 'missing-status'},
+    ]
+    filtered = filter_active_dataproc_clusters(clusters)
+    assert [c['clusterName'] for c in filtered] == ['live', 'creating', 'start', 'missing-status']
+
+
+def test_filter_active_dataproc_clusters_empty():
+    assert filter_active_dataproc_clusters([]) == []

--- a/tests/unit/cartography/intel/gcp/test_dataproc.py
+++ b/tests/unit/cartography/intel/gcp/test_dataproc.py
@@ -1,19 +1,8 @@
-from cartography.intel.gcp.dataproc import filter_active_dataproc_clusters
+from cartography.intel.gcp.dataproc import DATAPROC_LIST_STATE_FILTERS
 
 
-def test_filter_active_dataproc_clusters_drops_terminated():
-    clusters = [
-        {'clusterName': 'live', 'status': {'state': 'RUNNING'}},
-        {'clusterName': 'creating', 'status': {'state': 'CREATING'}},
-        {'clusterName': 'start', 'status': {'state': 'START'}},
-        {'clusterName': 'terminated', 'status': {'state': 'TERMINATED'}},
-        {'clusterName': 'error', 'status': {'state': 'ERROR'}},
-        {'clusterName': 'deleting', 'status': {'state': 'DELETING'}},
-        {'clusterName': 'missing-status'},
-    ]
-    filtered = filter_active_dataproc_clusters(clusters)
-    assert [c['clusterName'] for c in filtered] == ['live', 'creating', 'start', 'missing-status']
-
-
-def test_filter_active_dataproc_clusters_empty():
-    assert filter_active_dataproc_clusters([]) == []
+def test_dataproc_list_state_filters_are_api_status_filters():
+    assert 'status.state = ACTIVE' in DATAPROC_LIST_STATE_FILTERS
+    assert 'status.state = STOPPED' in DATAPROC_LIST_STATE_FILTERS
+    assert 'status.state = STOPPING' in DATAPROC_LIST_STATE_FILTERS
+    assert not any('TERMINATED' in f for f in DATAPROC_LIST_STATE_FILTERS)

--- a/tests/unit/cartography/intel/oci/test_compute.py
+++ b/tests/unit/cartography/intel/oci/test_compute.py
@@ -1,0 +1,19 @@
+from cartography.intel.oci.compute import filter_active_oci_instances
+
+
+def test_filter_active_oci_instances_keeps_live_states():
+    instances = [
+        {'id': 'i-running', 'lifecycle-state': 'RUNNING'},
+        {'id': 'i-stopped', 'lifecycle-state': 'STOPPED'},
+        {'id': 'i-starting', 'lifecycle-state': 'STARTING'},
+        {'id': 'i-terminated', 'lifecycle-state': 'TERMINATED'},
+        {'id': 'i-terminating', 'lifecycle-state': 'TERMINATING'},
+        {'id': 'i-creating', 'lifecycle-state': 'CREATING'},
+        {'id': 'i-missing'},
+    ]
+    filtered = filter_active_oci_instances(instances)
+    assert [i['id'] for i in filtered] == ['i-running', 'i-stopped', 'i-starting']
+
+
+def test_filter_active_oci_instances_empty():
+    assert filter_active_oci_instances([]) == []

--- a/tests/unit/cartography/intel/oci/test_compute.py
+++ b/tests/unit/cartography/intel/oci/test_compute.py
@@ -1,19 +1,9 @@
-from cartography.intel.oci.compute import filter_active_oci_instances
+from cartography.intel.oci.compute import ACTIVE_INSTANCE_LIFECYCLE_STATES
 
 
-def test_filter_active_oci_instances_keeps_live_states():
-    instances = [
-        {'id': 'i-running', 'lifecycle-state': 'RUNNING'},
-        {'id': 'i-stopped', 'lifecycle-state': 'STOPPED'},
-        {'id': 'i-starting', 'lifecycle-state': 'STARTING'},
-        {'id': 'i-terminated', 'lifecycle-state': 'TERMINATED'},
-        {'id': 'i-terminating', 'lifecycle-state': 'TERMINATING'},
-        {'id': 'i-creating', 'lifecycle-state': 'CREATING'},
-        {'id': 'i-missing'},
-    ]
-    filtered = filter_active_oci_instances(instances)
-    assert [i['id'] for i in filtered] == ['i-running', 'i-stopped', 'i-starting']
-
-
-def test_filter_active_oci_instances_empty():
-    assert filter_active_oci_instances([]) == []
+def test_active_instance_lifecycle_states_for_api_filter():
+    assert 'RUNNING' in ACTIVE_INSTANCE_LIFECYCLE_STATES
+    assert 'STOPPED' in ACTIVE_INSTANCE_LIFECYCLE_STATES
+    assert 'TERMINATED' not in ACTIVE_INSTANCE_LIFECYCLE_STATES
+    assert 'TERMINATING' not in ACTIVE_INSTANCE_LIFECYCLE_STATES
+    assert 'CREATING' not in ACTIVE_INSTANCE_LIFECYCLE_STATES


### PR DESCRIPTION
## Summary
- Prefer provider API filters so inactive, terminal, or short-lived resources are never fetched (EC2 AMI/snapshot Filters, Secrets `IncludePlannedDeletion`, launch-template `$Latest`/`$Default`, Dataflow `filter=ACTIVE`, Dataproc `status.state`, OCI `lifecycle_state`).
- Fall back to post-fetch filtering only where the API has no state knob (RDS/ES/Redshift reserved instances, RDS snapshots, KMS `PendingDeletion`).
- Cuts Neo4j load and stops ingesting retired/tombstone inventory that is not useful for posture.

## Test plan
- [ ] `pytest tests/unit/cartography/intel/aws/test_rds.py tests/unit/cartography/intel/aws/test_elasticsearch.py tests/unit/cartography/intel/aws/test_redshift.py tests/unit/cartography/intel/aws/test_kms.py tests/unit/cartography/intel/aws/test_secretsmanager.py tests/unit/cartography/intel/aws/ec2/ -q`
- [ ] `pytest tests/unit/cartography/intel/gcp/test_dataflow.py tests/unit/cartography/intel/gcp/test_dataproc.py tests/unit/cartography/intel/oci/test_compute.py -q`
- [ ] Spot-check one account sync: reserved counts drop retired/payment-* rows; EBS snapshots/AMIs only completed/available; Dataflow/Dataproc/OCI omit terminated tombstones