### PR TITLE
Fail fast on expired Azure Graph tokens; stream AWS tag pages

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -170,10 +170,6 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     'config:config-rule': {'label': 'AWSConfigRule', 'property': 'id'},
     'ec2:image': {'label': 'EC2Image', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:launch-template': {'label': 'LaunchTemplate', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
-    'ec2:reserved-instances': {
-        'label': 'EC2ReservedInstance', 'property': 'id',
-        'id_func': get_short_id_from_ec2_arn,
-    },
     'ec2:route-table': {'label': 'EC2RouteTable', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:snapshot': {'label': 'EBSSnapshot', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'events:event-bus': {'label': 'AWSEventBridgeEventBus', 'property': 'id'},
@@ -187,7 +183,6 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
         'path': '-[:RESOURCE]->(:EKSCluster)<-[:ASSOCIATED_WITH]-',
     },
     'kinesis:stream': {'label': 'KinesisStream', 'property': 'id'},
-    'rds:ri': {'label': 'RDSReservedDBInstance', 'property': 'id'},
     'logs:log-group': {'label': 'AWSCloudWatchLogGroup', 'property': 'id', 'id_func': get_log_group_arn_with_wildcard},
     'route53:hostedzone': {'label': 'AWSDNSZone', 'property': 'zoneid', 'id_func': get_hosted_zone_id_from_arn},
     'sagemaker:cluster': {'label': 'AWSSagemakerCluster', 'property': 'arn'},
@@ -220,8 +215,7 @@ def iter_tag_pages(
     Yield pages of ResourceTagMappingList from the tagging API.
 
     Streaming keeps peak memory to roughly one API page instead of the full
-    region×resource-type result set (important for large types like
-    ec2:reserved-instances).
+    region×resource-type result set for large resource types.
     """
     # this is a temporary workaround to populate AWS tags for IAM roles.
     # resourcegroupstaggingapi does not support IAM roles and no ETA is provided

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -5,6 +5,7 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from string import Template
 from typing import Dict
+from typing import Iterator
 from typing import List
 
 import boto3
@@ -212,21 +213,27 @@ GLOBAL_RESOURCE_TYPES = frozenset({
 })
 
 
-@timeit
-@aws_handle_regions
-def get_tags(boto3_session: boto3.session.Session, resource_type: str, region: str) -> List[Dict]:
+def iter_tag_pages(
+    boto3_session: boto3.session.Session, resource_type: str, region: str,
+) -> Iterator[List[Dict]]:
     """
-    Create boto3 client and retrieve tag data.
+    Yield pages of ResourceTagMappingList from the tagging API.
+
+    Streaming keeps peak memory to roughly one API page instead of the full
+    region×resource-type result set (important for large types like
+    ec2:reserved-instances).
     """
     # this is a temporary workaround to populate AWS tags for IAM roles.
     # resourcegroupstaggingapi does not support IAM roles and no ETA is provided
     # TODO: when resourcegroupstaggingapi supports iam:role, remove this condition block
-    resources: List[Dict] = []
     try:
         if resource_type == 'iam:role':
-            return get_role_tags(boto3_session)
+            yield get_role_tags(boto3_session)
+            return
 
-        client = boto3_session.client('resourcegroupstaggingapi', region_name=region, config=get_botocore_config())
+        client = boto3_session.client(
+            'resourcegroupstaggingapi', region_name=region, config=get_botocore_config(),
+        )
         paginator = client.get_paginator('get_resources')
 
         for page in paginator.paginate(
@@ -234,9 +241,25 @@ def get_tags(boto3_session: boto3.session.Session, resource_type: str, region: s
             # This is just a starting list; there may be others supported by this API.
             ResourceTypeFilters=[resource_type],
         ):
-            resources.extend(page['ResourceTagMappingList'])
+            mappings = page.get('ResourceTagMappingList') or []
+            if mappings:
+                yield mappings
     except (ClientError, Exception) as e:
         logger.warning(f"Failed to get tags for resource type {resource_type}. {e}")
+
+
+@timeit
+@aws_handle_regions
+def get_tags(boto3_session: boto3.session.Session, resource_type: str, region: str) -> List[Dict]:
+    """
+    Create boto3 client and retrieve tag data.
+
+    Collects all pages into one list. Prefer iter_tag_pages() / sync_tags() for
+    large resource types so peak memory stays bounded.
+    """
+    resources: List[Dict] = []
+    for page_resources in iter_tag_pages(boto3_session, resource_type, region):
+        resources.extend(page_resources)
     return resources
 
 
@@ -330,9 +353,18 @@ def sync_tags(
 ) -> None:
     logger.debug(f"BEGIN processing tags for {region} & {resource_type}")
 
-    tag_data = get_tags(boto3_session, resource_type, region)
-    transform_tags(tag_data, resource_type)
-    load_tags(neo4j_session=neo4j_session, tag_data=tag_data, resource_type=resource_type, region=region, current_aws_account_id=current_aws_account_id, aws_update_tag=update_tag)
+    # Load each tagging-API page as it arrives instead of buffering the full
+    # result set in memory first.
+    for tag_data in iter_tag_pages(boto3_session, resource_type, region):
+        transform_tags(tag_data, resource_type)
+        load_tags(
+            neo4j_session=neo4j_session,
+            tag_data=tag_data,
+            resource_type=resource_type,
+            region=region,
+            current_aws_account_id=current_aws_account_id,
+            aws_update_tag=update_tag,
+        )
 
     logger.debug(f"END processing tags for {region} & {resource_type}")
 

--- a/cartography/intel/azure/iam.py
+++ b/cartography/intel/azure/iam.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
+from typing import Tuple
 from typing import TypedDict
 from typing import Union
 
@@ -656,6 +657,48 @@ async def get_group_members(
     return members_data
 
 
+async def _gather_group_members_fail_fast(
+    credentials: Credentials,
+    group_ids: List[str],
+    client: GraphServiceClient,
+    tenant_id: str,
+) -> Tuple[List[Any], bool]:
+    """
+    Fetch members for many groups with a shared auth circuit breaker.
+
+    Once GraphAuthenticationExpiredError is seen, remaining tasks skip Graph
+    calls so a dead token cannot burn an hour of 401s.
+    Returns (gather_results, auth_expired).
+    """
+    auth_expired = asyncio.Event()
+    member_semaphore = asyncio.Semaphore(3)
+
+    async def _bounded_get_members(group_id: str) -> List[Dict]:
+        if auth_expired.is_set():
+            return []
+        async with member_semaphore:
+            if auth_expired.is_set():
+                return []
+            try:
+                return await get_group_members(credentials, group_id, client=client)
+            except GraphAuthenticationExpiredError:
+                auth_expired.set()
+                raise
+
+    results = await asyncio.gather(
+        *[_bounded_get_members(group_id) for group_id in group_ids],
+        return_exceptions=True,
+    )
+    expired = any(isinstance(result, GraphAuthenticationExpiredError) for result in results)
+    if expired:
+        skipped = sum(1 for result in results if result == [])
+        logger.error(
+            f"IAM tenant={tenant_id}: Graph access token expired during group member fetch; "
+            f"aborting remaining member fetches (skipped≈{skipped}) to avoid a prolonged 401 storm",
+        )
+    return list(results), expired
+
+
 @timeit
 def load_group_memberships(neo4j_session: neo4j.Session, memberships: List[Dict], update_tag: int) -> None:
     neo4j_session.execute_write(_load_group_memberships_tx, memberships, update_tag)
@@ -703,17 +746,14 @@ async def sync_tenant_groups(
         f"IAM tenant={tenant_id}: group list fetch done — {len(tenant_groups_list)} groups in {time.perf_counter() - t0:.2f}s",
     )
 
-    # Fetch all group members concurrently (bounded) then write sequentially
-    _member_semaphore = asyncio.Semaphore(3)
-
-    async def _bounded_get_members(group_id: str) -> List[Dict]:
-        async with _member_semaphore:
-            return await get_group_members(credentials, group_id, client=client)
-
+    # Fetch all group members concurrently (bounded) then write sequentially.
+    # Abort remaining Graph calls if the access token expires mid-fanout.
     t0 = time.perf_counter()
-    membership_results = await asyncio.gather(
-        *[_bounded_get_members(group["id"]) for group in tenant_groups_list],
-        return_exceptions=True,
+    membership_results, auth_expired = await _gather_group_members_fail_fast(
+        credentials,
+        [group["id"] for group in tenant_groups_list],
+        client,
+        tenant_id,
     )
     logger.info(f"IAM tenant={tenant_id}: group member fetch done in {time.perf_counter() - t0:.2f}s")
 
@@ -721,7 +761,8 @@ async def sync_tenant_groups(
     load_tenant_groups(neo4j_session, tenant_id, tenant_groups_list, update_tag)
     for result in membership_results:
         if isinstance(result, Exception):
-            logger.warning(f"IAM tenant={tenant_id}: group member fetch error — {result}")
+            if not isinstance(result, GraphAuthenticationExpiredError):
+                logger.warning(f"IAM tenant={tenant_id}: group member fetch error — {result}")
             continue
         if result:
             load_group_memberships(neo4j_session, result, update_tag)
@@ -1450,28 +1491,28 @@ async def sync_scoped_users_and_groups(
     if not scoped_groups:
         return set()
 
-    # 2. Fetch members for all scoped groups concurrently (bounded by semaphore to avoid 429 floods)
+    # 2. Fetch members for all scoped groups concurrently (bounded by semaphore to avoid 429 floods).
+    # Abort remaining Graph calls if the access token expires mid-fanout.
     t0 = time.perf_counter()
     logger.info(
         f"IAM tenant={tenant_id}: fetching members for {len(scoped_groups)} groups concurrently",
     )
-    _member_semaphore = asyncio.Semaphore(3)
-
-    async def _bounded_get_members(group_id: str) -> List[Dict]:
-        async with _member_semaphore:
-            return await get_group_members(credentials, group_id, client=client)
+    membership_results, auth_expired = await _gather_group_members_fail_fast(
+        credentials,
+        [group["id"] for group in scoped_groups],
+        client,
+        tenant_id,
+    )
 
     all_memberships = []
     all_member_ids = set()
     member_fetch_errors = 0
     rate_limit_errors = 0
-    membership_results = await asyncio.gather(
-        *[_bounded_get_members(group["id"]) for group in scoped_groups],
-        return_exceptions=True,
-    )
     for memberships in membership_results:
         if isinstance(memberships, Exception):
             err_str = str(memberships)
+            if isinstance(memberships, GraphAuthenticationExpiredError):
+                continue
             if "429" in err_str or "throttl" in err_str.lower() or "too many requests" in err_str.lower():
                 rate_limit_errors += 1
             member_fetch_errors += 1
@@ -1481,10 +1522,15 @@ async def sync_scoped_users_and_groups(
             all_memberships.extend(memberships)
             for member in memberships:
                 all_member_ids.add(member["id"])
+    if auth_expired:
+        logger.error(
+            f"IAM tenant={tenant_id}: Graph token expired mid member-fetch; "
+            f"continuing with {len(all_memberships)} memberships gathered before abort",
+        )
     logger.info(
         f"IAM tenant={tenant_id}: member fetch done in {time.perf_counter() - t0:.2f}s — "
         f"memberships={len(all_memberships)} unique_members={len(all_member_ids)} "
-        f"errors={member_fetch_errors} rate_limit_errors={rate_limit_errors}",
+        f"errors={member_fetch_errors} rate_limit_errors={rate_limit_errors} auth_expired={auth_expired}",
     )
     ctx = get_current_context()
     if ctx is not None:

--- a/cartography/intel/azure/iam.py
+++ b/cartography/intel/azure/iam.py
@@ -500,9 +500,22 @@ _GRAPH_DEFAULT_RETRY_AFTER = 10  # seconds to wait on 429 if Retry-After header 
 _IAM_TENANT_SYNC_KEY = "_iam_tenant_level_synced"  # key in common_job_parameters tracking per-cycle dedup
 
 
+class GraphAuthenticationExpiredError(Exception):
+    """Microsoft Graph rejected the request because the access token is expired."""
+
+
 def _is_throttle_error(e: Exception) -> bool:
     err_str = str(e)
     return "429" in err_str or "throttl" in err_str.lower() or "too many requests" in err_str.lower()
+
+
+def _is_graph_auth_expired_error(e: Exception) -> bool:
+    """True when Graph returns InvalidAuthenticationToken / expired access token."""
+    err_str = str(e)
+    if "InvalidAuthenticationToken" in err_str:
+        return True
+    lower = err_str.lower()
+    return "token is expired" in lower or "access token validation failed" in lower
 
 
 def _get_retry_after(e: Exception) -> float:
@@ -603,6 +616,16 @@ async def get_group_members(
 
         except Exception as e:
             ctx = get_current_context()
+            if _is_graph_auth_expired_error(e):
+                logger.error(
+                    f"get_group_members group_id={group_id}: Graph auth expired after "
+                    f"{time.perf_counter() - t0:.2f}s — aborting member fetch",
+                )
+                if ctx is not None:
+                    ctx.request_count += 1
+                raise GraphAuthenticationExpiredError(
+                    f"Microsoft Graph token expired while fetching members for {group_id}",
+                ) from e
             if _is_throttle_error(e):
                 retry_after = _get_retry_after(e)
                 if ctx is not None:

--- a/cartography/intel/azure/iam.py
+++ b/cartography/intel/azure/iam.py
@@ -755,7 +755,10 @@ async def sync_tenant_groups(
         client,
         tenant_id,
     )
-    logger.info(f"IAM tenant={tenant_id}: group member fetch done in {time.perf_counter() - t0:.2f}s")
+    logger.info(
+        f"IAM tenant={tenant_id}: group member fetch done in {time.perf_counter() - t0:.2f}s "
+        f"(auth_expired={auth_expired})",
+    )
 
     t0 = time.perf_counter()
     load_tenant_groups(neo4j_session, tenant_id, tenant_groups_list, update_tag)

--- a/cartography/intel/azure/iam.py
+++ b/cartography/intel/azure/iam.py
@@ -502,7 +502,7 @@ _IAM_TENANT_SYNC_KEY = "_iam_tenant_level_synced"  # key in common_job_parameter
 
 
 class GraphAuthenticationExpiredError(Exception):
-    """Microsoft Graph rejected the request because the access token is expired."""
+    """Microsoft Graph rejected the request due to an invalid or expired access token."""
 
 
 def _is_throttle_error(e: Exception) -> bool:
@@ -619,13 +619,13 @@ async def get_group_members(
             ctx = get_current_context()
             if _is_graph_auth_expired_error(e):
                 logger.error(
-                    f"get_group_members group_id={group_id}: Graph auth expired after "
+                    f"get_group_members group_id={group_id}: Graph auth invalid/expired after "
                     f"{time.perf_counter() - t0:.2f}s — aborting member fetch",
                 )
                 if ctx is not None:
                     ctx.request_count += 1
                 raise GraphAuthenticationExpiredError(
-                    f"Microsoft Graph token expired while fetching members for {group_id}",
+                    f"Microsoft Graph token invalid/expired while fetching members for {group_id}",
                 ) from e
             if _is_throttle_error(e):
                 retry_after = _get_retry_after(e)
@@ -672,12 +672,16 @@ async def _gather_group_members_fail_fast(
     """
     auth_expired = asyncio.Event()
     member_semaphore = asyncio.Semaphore(3)
+    skipped_due_to_auth = 0
 
     async def _bounded_get_members(group_id: str) -> List[Dict]:
+        nonlocal skipped_due_to_auth
         if auth_expired.is_set():
+            skipped_due_to_auth += 1
             return []
         async with member_semaphore:
             if auth_expired.is_set():
+                skipped_due_to_auth += 1
                 return []
             try:
                 return await get_group_members(credentials, group_id, client=client)
@@ -691,10 +695,9 @@ async def _gather_group_members_fail_fast(
     )
     expired = any(isinstance(result, GraphAuthenticationExpiredError) for result in results)
     if expired:
-        skipped = sum(1 for result in results if result == [])
         logger.error(
-            f"IAM tenant={tenant_id}: Graph access token expired during group member fetch; "
-            f"aborting remaining member fetches (skipped≈{skipped}) to avoid a prolonged 401 storm",
+            f"IAM tenant={tenant_id}: Graph access token invalid/expired during group member fetch; "
+            f"aborting remaining member fetches (skipped={skipped_due_to_auth}) to avoid a prolonged 401 storm",
         )
     return list(results), expired
 
@@ -1527,7 +1530,7 @@ async def sync_scoped_users_and_groups(
                 all_member_ids.add(member["id"])
     if auth_expired:
         logger.error(
-            f"IAM tenant={tenant_id}: Graph token expired mid member-fetch; "
+            f"IAM tenant={tenant_id}: Graph token invalid/expired mid member-fetch; "
             f"continuing with {len(all_memberships)} memberships gathered before abort",
         )
     logger.info(

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -218,3 +218,31 @@ def test_iam_role_tags_fetched_once_per_account(mocker, monkeypatch):
 
     calls = [(c.args[2], c.args[3]) for c in sync_tags.call_args_list]
     assert [c for c in calls if c[1] == 'iam:role'] == [('us-east-1', 'iam:role')]
+
+def test_sync_tags_streams_pages_without_buffering(mocker):
+    """Each tagging-API page is transform+load'd immediately; pages are not accumulated."""
+    pages = [
+        [{'ResourceARN': 'arn:aws:ec2:us-east-1:1234:instance/i-1', 'Tags': [{'Key': 'a', 'Value': '1'}]}],
+        [{'ResourceARN': 'arn:aws:ec2:us-east-1:1234:instance/i-2', 'Tags': [{'Key': 'b', 'Value': '2'}]}],
+    ]
+    mocker.patch.object(rgta, 'iter_tag_pages', return_value=iter(pages))
+    transform = mocker.patch.object(rgta, 'transform_tags')
+    load = mocker.patch.object(rgta, 'load_tags')
+
+    rgta.sync_tags(mocker.MagicMock(), mocker.MagicMock(), 'us-east-1', 'ec2:instance', '1234', 111)
+
+    assert transform.call_count == 2
+    assert load.call_count == 2
+    assert transform.call_args_list[0].args[0] is pages[0]
+    assert transform.call_args_list[1].args[0] is pages[1]
+    assert load.call_args_list[0].kwargs['tag_data'] is pages[0]
+    assert load.call_args_list[1].kwargs['tag_data'] is pages[1]
+
+
+def test_get_tags_collects_all_pages(mocker):
+    pages = [[{'ResourceARN': 'a'}], [{'ResourceARN': 'b'}]]
+    mocker.patch.object(rgta, 'iter_tag_pages', return_value=iter(pages))
+    assert rgta.get_tags(mocker.MagicMock(), 'ec2:instance', 'us-east-1') == [
+        {'ResourceARN': 'a'}, {'ResourceARN': 'b'},
+    ]
+

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -129,6 +129,9 @@ def test_untaggable_types_removed():
     # resource types; keeping them only wasted API calls every sync
     assert 'ecs:container' not in rgta.TAG_RESOURCE_TYPE_MAPPINGS
     assert 'elasticloadbalancing:listener' not in rgta.TAG_RESOURCE_TYPE_MAPPINGS
+    # Reserved instances are low-value for tagging and can be large in RGT results
+    assert 'ec2:reserved-instances' not in rgta.TAG_RESOURCE_TYPE_MAPPINGS
+    assert 'rds:ri' not in rgta.TAG_RESOURCE_TYPE_MAPPINGS
 
 
 def test_global_resource_types_synced_once_in_us_east_1(mocker, monkeypatch):
@@ -180,19 +183,11 @@ def test_phase2_remainder_mappings_present():
         'cloudwatch:alarm': 'AWSCloudWatchAlarm',
         'events:rule': 'AWSEventBridgeRule',
         'events:event-bus': 'AWSEventBridgeEventBus',
-        'rds:ri': 'RDSReservedDBInstance',
-        'ec2:reserved-instances': 'EC2ReservedInstance',
         'securityhub:hub': 'SecurityHub',
     }
     for resource_type, label in expected.items():
         assert resource_type in rgta.TAG_RESOURCE_TYPE_MAPPINGS, resource_type
         assert rgta.TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['label'] == label
-
-
-def test_reserved_instance_mapping_uses_short_id():
-    # EC2ReservedInstance nodes are created with id = ReservedInstancesId, not the ARN
-    arn = 'arn:aws:ec2:us-east-1:1234:reserved-instances/ri-abcd'
-    assert rgta.compute_resource_id({'ResourceARN': arn}, 'ec2:reserved-instances') == 'ri-abcd'
 
 
 def test_iam_role_is_a_global_resource_type():

--- a/tests/unit/cartography/intel/azure/test_iam.py
+++ b/tests/unit/cartography/intel/azure/test_iam.py
@@ -1,3 +1,10 @@
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
 from cartography.intel.azure import iam
 
 
@@ -19,3 +26,60 @@ def test_azure_service_principal_managed_type():
     # Customer-owned service principals belong to the customer's own tenant.
     assert iam._azure_service_principal_managed_type("00000000-1111-2222-3333-444444444444") == "custom"
     assert iam._azure_service_principal_managed_type(None) == "custom"
+
+
+def test_is_graph_auth_expired_error_detects_invalid_authentication_token():
+    err = Exception(
+        "APIError Code: 401 error: MainError(code='InvalidAuthenticationToken', "
+        "message='Access token validation failed, the token is expired.')",
+    )
+    assert iam._is_graph_auth_expired_error(err) is True
+
+
+def test_is_graph_auth_expired_error_ignores_throttle_and_other_failures():
+    assert iam._is_graph_auth_expired_error(Exception("429 Too Many Requests")) is False
+    assert iam._is_graph_auth_expired_error(Exception("Connection reset")) is False
+
+
+def test_get_group_members_raises_on_expired_graph_token():
+    client = MagicMock()
+    members = MagicMock()
+    members.get = AsyncMock(
+        side_effect=Exception(
+            "APIError Code: 401 code='InvalidAuthenticationToken' "
+            "message='Access token validation failed, the token is expired.'",
+        ),
+    )
+    client.groups.by_group_id.return_value.members = members
+
+    with pytest.raises(iam.GraphAuthenticationExpiredError):
+        asyncio.run(iam.get_group_members(MagicMock(), "tenants/t/Groups/g1", client=client))
+
+
+def test_gather_group_members_fail_fast_skips_remaining_groups_after_auth_expiry():
+    call_count = {"n": 0}
+
+    async def fake_get_group_members(credentials, group_id, client=None):
+        call_count["n"] += 1
+        # First in-flight call expires; later callers should observe the circuit and skip.
+        if group_id == "g-expire":
+            await asyncio.sleep(0.01)
+            raise iam.GraphAuthenticationExpiredError("expired")
+        await asyncio.sleep(0.05)
+        return [{"id": "u1", "group_id": group_id}]
+
+    async def _run():
+        with patch.object(iam, "get_group_members", side_effect=fake_get_group_members):
+            results, expired = await iam._gather_group_members_fail_fast(
+                MagicMock(),
+                ["g-expire"] + [f"g-{i}" for i in range(20)],
+                MagicMock(),
+                "tenant-1",
+            )
+        return results, expired
+
+    results, expired = asyncio.run(_run())
+    assert expired is True
+    assert any(isinstance(r, iam.GraphAuthenticationExpiredError) for r in results)
+    # Circuit breaker must prevent calling Graph for every remaining group.
+    assert call_count["n"] < 21


### PR DESCRIPTION
## Summary
- Abort Azure IAM group-member fan-out on Microsoft Graph `InvalidAuthenticationToken` / expired access token so jobs do not burn ~1h on thousands of 401s.
- Stream AWS Resource Groups Tagging API pages into Neo4j to cut peak memory for large tag syncs.
- Skip EC2/RDS reserved-instance types from tag sync (low value, can dominate RGT volume).

## Test plan
- [ ] `uv run pytest tests/unit/cartography/intel/azure/test_iam.py -q`
- [ ] `uv run pytest tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py -q`
- [ ] Re-run an Azure SQS sync that previously logged expired-token 401 storms; confirm member fetch aborts quickly and logs `auth_expired=True`
- [ ] Confirm reserved-instance resource types are absent from `TAG_RESOURCE_TYPE_MAPPINGS` and no longer queried by RGT