### PR TITLE
perf(ingest): managed, batched, retried Neo4j writes across all providers

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -12,6 +12,10 @@ from cartography.graph.querybuilder import build_ingestion_query
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.util import batch
 
+# Rows per write transaction. Matches upstream cartography's default; tune per call
+# via the batch_size param if a module's rows are unusually wide.
+DEFAULT_LOAD_BATCH_SIZE = 10000
+
 
 def read_list_of_values_tx(tx: neo4j.Transaction, query: str, **kwargs) -> List[Union[str, int]]:
     """
@@ -209,6 +213,7 @@ def load_graph_data(
         neo4j_session: neo4j.Session,
         query: str,
         dict_list: List[Dict[str, Any]],
+        batch_size: int = DEFAULT_LOAD_BATCH_SIZE,
         **kwargs,
 ) -> None:
     """
@@ -217,10 +222,13 @@ def load_graph_data(
     :param query: The Neo4j write query to run. This query is not meant to be handwritten, rather it should be generated
     with cartography.graph.querybuilder.build_ingestion_query().
     :param dict_list: The data to load to the graph represented as a list of dicts.
+    :param batch_size: Number of items to write per transaction. Defaults to DEFAULT_LOAD_BATCH_SIZE.
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
-    for data_batch in batch(dict_list, size=500):
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
+    for data_batch in batch(dict_list, size=batch_size):
         neo4j_session.execute_write(
             write_list_of_dicts_tx,
             query,
@@ -253,6 +261,7 @@ def load(
         neo4j_session: neo4j.Session,
         node_schema: CartographyNodeSchema,
         dict_list: List[Dict[str, Any]],
+        batch_size: int = DEFAULT_LOAD_BATCH_SIZE,
         **kwargs,
 ) -> None:
     """
@@ -261,12 +270,15 @@ def load(
     :param neo4j_session: The Neo4j session
     :param node_schema: The CartographyNodeSchema object to create indexes for and generate a query.
     :param dict_list: The data to load to the graph represented as a list of dicts.
+    :param batch_size: Number of items to write per transaction. Defaults to DEFAULT_LOAD_BATCH_SIZE.
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
     if len(dict_list) == 0:
         # Nothing to load; skip index creation and query generation round-trips.
         return
     ensure_indexes(neo4j_session, node_schema)
     ingestion_query = build_ingestion_query(node_schema)
-    load_graph_data(neo4j_session, ingestion_query, dict_list, **kwargs)
+    load_graph_data(neo4j_session, ingestion_query, dict_list, batch_size=batch_size, **kwargs)

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -16,8 +16,11 @@ import neo4j
 import neo4j.exceptions
 
 from cartography.graph.querybuilder import build_create_index_queries
+from cartography.graph.querybuilder import build_create_index_queries_for_matchlink
 from cartography.graph.querybuilder import build_ingestion_query
+from cartography.graph.querybuilder import build_matchlink_query
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
 from cartography.util import backoff_handler
 from cartography.util import batch
 
@@ -437,3 +440,67 @@ def load(
     ensure_indexes(neo4j_session, node_schema)
     ingestion_query = build_ingestion_query(node_schema)
     load_graph_data(neo4j_session, ingestion_query, dict_list, batch_size=batch_size, **kwargs)
+
+
+def ensure_indexes_for_matchlinks(neo4j_session: neo4j.Session, rel_schema: CartographyRelSchema) -> None:
+    """
+    Creates indexes for the node fields referenced by a matchlink rel schema (source and
+    target match keys, plus the relationship's sub-resource composite index). Only used
+    for load_matchlinks(); use ensure_indexes() for CartographyNodeSchema objects.
+    :param neo4j_session: The neo4j session
+    :param rel_schema: The CartographyRelSchema object to create indexes for.
+    """
+    queries = build_create_index_queries_for_matchlink(rel_schema)
+
+    for query in queries:
+        if not query.startswith('CREATE INDEX IF NOT EXISTS'):
+            raise ValueError(
+                'Query provided to `ensure_indexes_for_matchlinks()` does not start with '
+                '"CREATE INDEX IF NOT EXISTS".',
+            )
+        try:
+            neo4j_session.execute_write(write_query_tx, query)
+        except neo4j.exceptions.ClientError as e:
+            # Same concurrent-creation race as ensure_indexes().
+            if e.code == "Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists":
+                logger.debug(f"Index already exists (created by a parallel sync): {query}")
+                continue
+            raise
+
+
+def load_matchlinks(
+        neo4j_session: neo4j.Session,
+        rel_schema: CartographyRelSchema,
+        dict_list: List[Dict[str, Any]],
+        batch_size: int = DEFAULT_LOAD_BATCH_SIZE,
+        **kwargs,
+) -> None:
+    """
+    Main entrypoint for intel modules to draw relationships between two nodes that
+    already exist in the graph (the supported replacement for hand-written
+    "link A to B" queries). Ensures indexes for the match keys, then MERGEs the
+    relationships in batches with retry.
+    :param neo4j_session: The Neo4j session
+    :param rel_schema: The CartographyRelSchema with source_node_matcher/label defined.
+    :param dict_list: The link data as a list of dicts (source + target match values).
+    :param batch_size: Number of items to write per transaction. Defaults to DEFAULT_LOAD_BATCH_SIZE.
+    :param kwargs: Additional keyword args supplied to the query. Must include
+        `_sub_resource_label` and `_sub_resource_id` (used by matchlink cleanup).
+    :return: None
+    """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
+    if len(dict_list) == 0:
+        # Nothing to link; skip index creation and query generation round-trips.
+        return
+
+    for required_kwarg in ('_sub_resource_label', '_sub_resource_id'):
+        if required_kwarg not in kwargs:
+            raise ValueError(
+                f"Required kwarg '{required_kwarg}' not provided for {rel_schema.rel_label}. "
+                "This is needed for matchlink cleanup queries.",
+            )
+
+    ensure_indexes_for_matchlinks(neo4j_session, rel_schema)
+    matchlink_query = build_matchlink_query(rel_schema)
+    load_graph_data(neo4j_session, matchlink_query, dict_list, batch_size=batch_size, **kwargs)

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -1,20 +1,139 @@
+import logging
+import time
+from functools import partial
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import TypeVar
 from typing import Union
 
+import backoff
 import neo4j
+import neo4j.exceptions
 
 from cartography.graph.querybuilder import build_create_index_queries
 from cartography.graph.querybuilder import build_ingestion_query
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.util import backoff_handler
 from cartography.util import batch
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 # Rows per write transaction. Matches upstream cartography's default; tune per call
 # via the batch_size param if a module's rows are unusually wide.
 DEFAULT_LOAD_BATCH_SIZE = 10000
+
+_MAX_NETWORK_RETRIES = 5
+_MAX_ENTITY_NOT_FOUND_RETRIES = 5
+_MAX_BUFFER_ERROR_RETRIES = 5
+_NETWORK_EXCEPTIONS: tuple = (
+    ConnectionResetError,
+    neo4j.exceptions.ServiceUnavailable,
+    neo4j.exceptions.SessionExpired,
+    neo4j.exceptions.TransientError,
+)
+
+
+def _is_retryable_client_error(exc: Exception) -> bool:
+    """
+    EntityNotFound during concurrent write operations is a known transient Neo4j error:
+    with concurrent MERGE/DELETE one thread can delete an entity another thread has
+    referenced but not yet locked. Neo4j maintainers recommend retrying it even though
+    the driver classifies it as a non-retryable ClientError
+    (https://github.com/neo4j/neo4j/issues/6823). This is exactly the condition created
+    by our 8-worker-per-provider write concurrency.
+    """
+    if not isinstance(exc, neo4j.exceptions.ClientError):
+        return False
+    # exc.code can be None for locally-created errors
+    return exc.code == "Neo.ClientError.Statement.EntityNotFound"
+
+
+def _is_retryable_buffer_error(exc: Exception) -> bool:
+    """
+    BufferError("... cannot be re-sized") is a known transient error from the neo4j
+    driver's internal buffer management under multi-threaded use.
+    """
+    return isinstance(exc, BufferError) and "cannot be re-sized" in str(exc)
+
+
+def _run_with_retry(operation: Callable[[], T], target: str) -> T:
+    """
+    Execute the supplied callable with retry + exponential backoff for transient network
+    errors, EntityNotFound ClientErrors, and re-size BufferErrors. Anything else raises
+    immediately; exhausted retries re-raise the last error.
+    """
+    network_attempts = 0
+    entity_attempts = 0
+    buffer_attempts = 0
+    network_wait = backoff.expo()
+    entity_wait = backoff.expo()
+    buffer_wait = backoff.expo()
+
+    def _backoff(kind: str, attempts: int, max_attempts: int, wait_gen: Any, exc: Exception) -> None:
+        wait = next(wait_gen) or 1.0
+        backoff_handler({"wait": wait, "tries": attempts, "target": target, "exception": exc})
+        logger.warning(f"{kind} retry {attempts}/{max_attempts} for {target}: {exc}")
+        time.sleep(wait)
+
+    while True:
+        try:
+            result = operation()
+            recovered = network_attempts + entity_attempts + buffer_attempts
+            if recovered:
+                logger.info(f"Recovered after {recovered} retries. Function: {target}")
+            return result
+        except _NETWORK_EXCEPTIONS as exc:
+            if network_attempts >= _MAX_NETWORK_RETRIES - 1:
+                raise
+            network_attempts += 1
+            _backoff("Network error", network_attempts, _MAX_NETWORK_RETRIES, network_wait, exc)
+        except neo4j.exceptions.ClientError as exc:
+            if not _is_retryable_client_error(exc) or entity_attempts >= _MAX_ENTITY_NOT_FOUND_RETRIES - 1:
+                raise
+            entity_attempts += 1
+            _backoff("EntityNotFound", entity_attempts, _MAX_ENTITY_NOT_FOUND_RETRIES, entity_wait, exc)
+        except BufferError as exc:
+            if not _is_retryable_buffer_error(exc) or buffer_attempts >= _MAX_BUFFER_ERROR_RETRIES - 1:
+                raise
+            buffer_attempts += 1
+            _backoff("BufferError", buffer_attempts, _MAX_BUFFER_ERROR_RETRIES, buffer_wait, exc)
+
+
+def execute_write_with_retry(
+        neo4j_session: neo4j.Session,
+        tx_func: Any,
+        *args: Any,
+        **kwargs: Any,
+) -> Any:
+    """
+    Run a transaction function through session.execute_write with _run_with_retry's
+    transient-error classification on top of the driver's own TransientError handling.
+    Use for any custom write that does not fit the load_graph_data() path.
+    """
+    target = getattr(tx_func, "__qualname__", repr(tx_func))
+    operation = partial(neo4j_session.execute_write, tx_func, *args, **kwargs)
+    return _run_with_retry(operation, target)
+
+
+def run_write_query(neo4j_session: neo4j.Session, query: str, **parameters: Any) -> None:
+    """
+    Execute a single write query inside a managed transaction with retry. Drop-in
+    replacement for raw auto-commit neo4j_session.run(query, ...) in intel modules
+    (perf plan Phase 3.7).
+    """
+    def _run_query_tx(tx: neo4j.Transaction) -> None:
+        tx.run(query, **parameters).consume()
+
+    def _operation() -> None:
+        neo4j_session.execute_write(_run_query_tx)
+
+    _run_with_retry(_operation, "run_write_query")
 
 
 def read_list_of_values_tx(tx: neo4j.Transaction, query: str, **kwargs) -> List[Union[str, int]]:
@@ -192,7 +311,7 @@ def write_list_of_dicts_tx(
     :param kwargs: Keyword args to be supplied to the Neo4j query.
     :return: None
     """
-    tx.run(query, kwargs)
+    tx.run(query, kwargs).consume()
 
 
 def write_query_tx(
@@ -229,7 +348,8 @@ def load_graph_data(
     if batch_size <= 0:
         raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
     for data_batch in batch(dict_list, size=batch_size):
-        neo4j_session.execute_write(
+        execute_write_with_retry(
+            neo4j_session,
             write_list_of_dicts_tx,
             query,
             DictList=data_batch,

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 from functools import partial
 from typing import Any
@@ -357,17 +358,35 @@ def load_graph_data(
         )
 
 
+# Schema classes whose indexes were already ensured in this process. load() runs per
+# region x account x schema, so without this every load re-issues 6-8 CREATE INDEX
+# round-trips that are no-ops after the first.
+_ensured_index_schemas: set = set()
+_ensured_index_schemas_lock = threading.Lock()
+
+
+def reset_ensured_indexes_cache() -> None:
+    """Forget which schemas had their indexes ensured (tests / long-lived processes)."""
+    with _ensured_index_schemas_lock:
+        _ensured_index_schemas.clear()
+
+
 def ensure_indexes(neo4j_session: neo4j.Session, node_schema: CartographyNodeSchema) -> None:
     """
     Creates indexes if they don't exist for the given CartographyNodeSchema object, as well as for all of the
     relationships defined on its `other_relationships` and `sub_resource_relationship` fields. This operation is
-    idempotent.
+    idempotent and memoized per schema class for the lifetime of the process.
 
     This ensures that every time we need to MATCH on a node to draw a relationship to it, the field used for the MATCH
     will be indexed, making the operation fast.
     :param neo4j_session: The neo4j session
     :param node_schema: The node_schema object to create indexes for.
     """
+    schema_key = f"{type(node_schema).__module__}.{type(node_schema).__qualname__}"
+    with _ensured_index_schemas_lock:
+        if schema_key in _ensured_index_schemas:
+            return
+
     queries = build_create_index_queries(node_schema)
 
     for query in queries:
@@ -385,6 +404,12 @@ def ensure_indexes(neo4j_session: neo4j.Session, node_schema: CartographyNodeSch
                 logger.debug(f"Index already exists (created by a parallel sync): {query}")
                 continue
             raise
+
+    # Memoize only after every query succeeded so a failed run is retried next load().
+    # Two workers may both run the queries for one schema before either memoizes; that
+    # is harmless (CREATE INDEX IF NOT EXISTS) and cheaper than holding the lock on I/O.
+    with _ensured_index_schemas_lock:
+        _ensured_index_schemas.add(schema_key)
 
 
 def load(

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -373,8 +373,18 @@ def ensure_indexes(neo4j_session: neo4j.Session, node_schema: CartographyNodeSch
     for query in queries:
         if not query.startswith('CREATE INDEX IF NOT EXISTS'):
             raise ValueError('Query provided to `ensure_indexes()` does not start with "CREATE INDEX IF NOT EXISTS".')
-        # Managed transaction so index creation retries on TransientError instead of failing the sync.
-        neo4j_session.execute_write(write_query_tx, query)
+        try:
+            # Managed transaction so index creation retries on TransientError instead of failing the sync.
+            neo4j_session.execute_write(write_query_tx, query)
+        except neo4j.exceptions.ClientError as e:
+            # Despite IF NOT EXISTS, Neo4j has a race where concurrent sessions creating
+            # the same index can fail between the existence check and the creation. Our
+            # provider syncs run 8 workers against a shared driver, so this is expected;
+            # the index existing is the desired end state.
+            if e.code == "Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists":
+                logger.debug(f"Index already exists (created by a parallel sync): {query}")
+                continue
+            raise
 
 
 def load(

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -264,6 +264,9 @@ def load(
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
+    if len(dict_list) == 0:
+        # Nothing to load; skip index creation and query generation round-trips.
+        return
     ensure_indexes(neo4j_session, node_schema)
     ingestion_query = build_ingestion_query(node_schema)
     load_graph_data(neo4j_session, ingestion_query, dict_list, **kwargs)

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
@@ -14,6 +15,7 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 logger = logging.getLogger(__name__)
@@ -98,10 +100,10 @@ def _build_rel_properties_statement(rel_var: str, rel_property_map: Optional[Dic
     return set_clause
 
 
-def _build_match_clause(matcher: TargetNodeMatcher) -> str:
+def _build_match_clause(matcher: Union[TargetNodeMatcher, SourceNodeMatcher]) -> str:
     """
     Generate a Neo4j match statement on one or more keys and values for a given node.
-    :param matcher: A TargetNodeMatcher object
+    :param matcher: A TargetNodeMatcher or SourceNodeMatcher object
     :return: a Neo4j match clause
     """
     match = Template("$Key: $PropRef")
@@ -449,3 +451,99 @@ def build_create_index_queries(node_schema: CartographyNodeSchema) -> List[str]:
         ) for prop_name, prop_ref in node_props_as_dict.items() if prop_ref.extra_index
     ])
     return result
+
+
+def build_create_index_queries_for_matchlink(rel_schema: CartographyRelSchema) -> List[str]:
+    """
+    Generate CREATE INDEX queries for a matchlink rel schema: one per source-node match
+    key, one per target-node match key, and a composite relationship index on the
+    (_sub_resource_label, _sub_resource_id) props used by matchlink cleanup.
+    Only used for load_matchlinks(), where we match on and connect existing nodes.
+    Returns an empty list (with a warning) if the schema has no source matcher/label.
+    """
+    if not rel_schema.source_node_matcher or not rel_schema.source_node_label:
+        logger.warning(
+            "No source node matcher or source node label found for %s; returning no index queries. "
+            "build_create_index_queries_for_matchlink() is only used for load_matchlinks().",
+            rel_schema.rel_label,
+        )
+        return []
+
+    index_template = Template('CREATE INDEX IF NOT EXISTS FOR (n:$NodeLabel) ON (n.$NodeAttribute);')
+
+    result: List[str] = []
+
+    def append_index_query(node_label: str, node_attribute: str) -> None:
+        query = index_template.safe_substitute(NodeLabel=node_label, NodeAttribute=node_attribute)
+        if query not in result:
+            result.append(query)
+
+    for source_key in asdict(rel_schema.source_node_matcher).keys():
+        append_index_query(rel_schema.source_node_label, source_key)
+    for target_key in asdict(rel_schema.target_node_matcher).keys():
+        append_index_query(rel_schema.target_node_label, target_key)
+
+    result.append(
+        f'CREATE INDEX IF NOT EXISTS FOR ()-[r:{rel_schema.rel_label}]-() '
+        'ON (r._sub_resource_label, r._sub_resource_id);',
+    )
+    return result
+
+
+def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
+    """
+    Generate a Neo4j query that links two nodes that already exist in the graph:
+
+        UNWIND $DictList as item
+            MATCH (from:$SourceLabel{...})
+            MATCH (to:$TargetLabel{...})
+            MERGE (from)-[r:$RelLabel]->(to)   # arrow follows rel_schema.direction
+            ON CREATE SET r.firstseen = timestamp()
+            SET r....
+
+    Only used for load_matchlinks(). The rel properties must include
+    _sub_resource_label and _sub_resource_id (set_in_kwargs=True) so that matchlink
+    cleanup can scope deletions to one sub-resource.
+    :param rel_schema: The CartographyRelSchema with source_node_matcher/label defined.
+    :return: The Neo4j ingestion query.
+    """
+    if not rel_schema.source_node_matcher or not rel_schema.source_node_label:
+        raise ValueError(
+            f"No source node matcher or source node label found for {rel_schema.rel_label}. "
+            "MatchLink relationships require source_node_matcher and source_node_label to be defined.",
+        )
+
+    rel_props_as_dict: Dict[str, PropertyRef] = _asdict_with_validate_relprops(rel_schema)
+    for required_prop in ('_sub_resource_label', '_sub_resource_id'):
+        if required_prop not in rel_props_as_dict:
+            raise ValueError(
+                f"Expected {required_prop} to be defined on {rel_schema.properties.__class__.__name__}. "
+                f"Please include `{required_prop}: PropertyRef = PropertyRef('{required_prop}', "
+                "set_in_kwargs=True)` - it is required by the matchlink cleanup query.",
+            )
+
+    if rel_schema.direction == LinkDirection.INWARD:
+        rel_merge_template = Template("MERGE (from)<-[r:$RelLabel]-(to)")
+    else:
+        rel_merge_template = Template("MERGE (from)-[r:$RelLabel]->(to)")
+    rel_merge_clause = rel_merge_template.safe_substitute(RelLabel=rel_schema.rel_label)
+
+    matchlink_query_template = Template(
+        """
+        UNWIND $DictList as item
+            MATCH (from:$SourceLabel{$SourceMatchClause})
+            MATCH (to:$TargetLabel{$TargetMatchClause})
+            $RelMergeClause
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                $set_rel_properties_statement
+        """,
+    )
+    return matchlink_query_template.safe_substitute(
+        SourceLabel=rel_schema.source_node_label,
+        SourceMatchClause=_build_match_clause(rel_schema.source_node_matcher),
+        TargetLabel=rel_schema.target_node_label,
+        TargetMatchClause=_build_match_clause(rel_schema.target_node_matcher),
+        RelMergeClause=rel_merge_clause,
+        set_rel_properties_statement=_build_rel_properties_statement('r', rel_props_as_dict),
+    )

--- a/cartography/graph/session.py
+++ b/cartography/graph/session.py
@@ -7,6 +7,8 @@ from typing import Callable
 import neo4j
 from neo4j.exceptions import TransientError
 
+from cartography.graph import write_timer
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +34,8 @@ class Session:
     def run(self, query: str, parameters: Any = None, max_retries: int = 3, **kwparameters: Any) -> Any:
         for attempt in range(max_retries + 1):
             try:
-                return self.neo4j_session.run(query, parameters, **kwparameters)
+                with write_timer.timed():
+                    return self.neo4j_session.run(query, parameters, **kwparameters)
             except TransientError as e:
                 if attempt >= max_retries:
                     logger.error("Transient Neo4j error unresolved after %d retries: %s", max_retries, e)
@@ -55,7 +58,8 @@ class Session:
 
     def execute_write(self, transaction_function: Callable, *args: Any, **kwargs: Any) -> Any:
         try:
-            return self.neo4j_session.execute_write(transaction_function, *args, **kwargs)
+            with write_timer.timed():
+                return self.neo4j_session.execute_write(transaction_function, *args, **kwargs)
         except Exception as e:
             # Never swallow: callers (e.g. GraphStatement._run_iterative) rely on the
             # real result, and a dropped write must fail the sync stage loudly.
@@ -64,7 +68,8 @@ class Session:
 
     def execute_read(self, transaction_function: Callable, *args: Any, **kwargs: Any) -> Any:
         try:
-            return self.neo4j_session.execute_read(transaction_function, *args, **kwargs)
+            with write_timer.timed():
+                return self.neo4j_session.execute_read(transaction_function, *args, **kwargs)
         except Exception as e:
             logger.warning(f"Failed execute_read for neo4j. Error - {e}", exc_info=True, stack_info=True)
             raise

--- a/cartography/graph/session.py
+++ b/cartography/graph/session.py
@@ -5,27 +5,10 @@ from typing import Any
 from typing import Callable
 
 import neo4j
-from neo4j.exceptions import AuthError
-from neo4j.exceptions import RoutingServiceUnavailable
-from neo4j.exceptions import ServiceUnavailable
-from neo4j.exceptions import SessionExpired
-from neo4j.exceptions import TransactionError
-from neo4j.exceptions import TransactionNestingError
 from neo4j.exceptions import TransientError
-from neo4j.exceptions import WriteServiceUnavailable
 
 
 logger = logging.getLogger(__name__)
-
-_NEO4J_WRITE_EXCEPTIONS = (
-    ServiceUnavailable,
-    AuthError,
-    SessionExpired,
-    TransactionError,
-    TransactionNestingError,
-    RoutingServiceUnavailable,
-    WriteServiceUnavailable,
-)
 
 
 class Session:
@@ -73,20 +56,18 @@ class Session:
     def execute_write(self, transaction_function: Callable, *args: Any, **kwargs: Any) -> Any:
         try:
             return self.neo4j_session.execute_write(transaction_function, *args, **kwargs)
-        except _NEO4J_WRITE_EXCEPTIONS as e:
-            logger.warning(f"Failed execute_write for neo4j. Error - {e}", exc_info=True, stack_info=True)
         except Exception as e:
+            # Never swallow: callers (e.g. GraphStatement._run_iterative) rely on the
+            # real result, and a dropped write must fail the sync stage loudly.
             logger.warning(f"Failed execute_write for neo4j. Error - {e}", exc_info=True, stack_info=True)
-        return None
+            raise
 
     def execute_read(self, transaction_function: Callable, *args: Any, **kwargs: Any) -> Any:
         try:
             return self.neo4j_session.execute_read(transaction_function, *args, **kwargs)
-        except _NEO4J_WRITE_EXCEPTIONS as e:
-            logger.warning(f"Failed execute_read for neo4j. Error - {e}", exc_info=True, stack_info=True)
         except Exception as e:
             logger.warning(f"Failed execute_read for neo4j. Error - {e}", exc_info=True, stack_info=True)
-        return None
+            raise
 
     # ------------------------------------------------------------------
     # Lifecycle helpers

--- a/cartography/graph/session.py
+++ b/cartography/graph/session.py
@@ -51,23 +51,20 @@ class Session:
             try:
                 return self.neo4j_session.run(query, parameters, **kwparameters)
             except TransientError as e:
-                if attempt < max_retries:
-                    wait = random.uniform(0, min(2 ** attempt, 30))
-                    logger.warning(
-                        "Transient Neo4j error (attempt %d/%d), retrying in %.2fs: %s",
-                        attempt + 1, max_retries, wait, e,
-                    )
-                    time.sleep(wait)
-                else:
+                if attempt >= max_retries:
                     logger.error("Transient Neo4j error unresolved after %d retries: %s", max_retries, e)
-                    return self
-            except _NEO4J_WRITE_EXCEPTIONS as e:
-                logger.warning(f"Failed run neo4j cypher query. Error - {e}", exc_info=True, stack_info=True)
-                return self
+                    raise
+                wait = random.uniform(0, min(2 ** attempt, 30))
+                logger.warning(
+                    "Transient Neo4j error (attempt %d/%d), retrying in %.2fs: %s",
+                    attempt + 1, max_retries, wait, e,
+                )
+                time.sleep(wait)
             except Exception as e:
+                # Never swallow: a silently dropped write reports a successful sync
+                # while rows are missing from the graph.
                 logger.warning(f"Failed run neo4j cypher query. Error - {e}", exc_info=True, stack_info=True)
-                return self
-        return self
+                raise
 
     # ------------------------------------------------------------------
     # Transaction helpers (used by cartography.graph.job / statement)

--- a/cartography/graph/write_timer.py
+++ b/cartography/graph/write_timer.py
@@ -1,0 +1,35 @@
+"""
+Thread-local accumulator that separates time spent talking to Neo4j from time spent
+calling cloud APIs inside a service sync.
+
+cartography.graph.session.Session feeds this on every run/execute_write/execute_read;
+provider timing blocks snapshot total() around a service_func call and emit the delta
+as graph_write_seconds next to duration_seconds (perf plan Phase 3.0.2).
+
+Each sync worker thread owns one Session, so a plain thread-local monotonic counter is
+enough: callers measure deltas, never reset.
+"""
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+_local = threading.local()
+
+
+def add(seconds: float) -> None:
+    _local.total = getattr(_local, "total", 0.0) + seconds
+
+
+def total() -> float:
+    """Monotonic per-thread total of seconds spent in Neo4j calls."""
+    return getattr(_local, "total", 0.0)
+
+
+@contextmanager
+def timed() -> Iterator[None]:
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        add(time.perf_counter() - t0)

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -21,6 +21,7 @@ from .ec2.util import get_botocore_config
 from .resources import parse_and_validate_aws_requested_syncs
 from .resources import RESOURCE_FUNCTIONS
 from cartography.config import Config
+from cartography.graph import write_timer
 from cartography.graph.session import Session
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.stats import get_stats_client
@@ -67,6 +68,7 @@ def concurrent_execution(
     shared_neo4j_driver=None,
 ):
     tic = time.perf_counter()
+    _gw0 = write_timer.total()
     _status = "success"
     _err: Dict = {}
     _result = None
@@ -117,6 +119,7 @@ def concurrent_execution(
             "service": service,
             "run_mode": "parallel",
             "duration_seconds": _elapsed,
+            "graph_write_seconds": round(write_timer.total() - _gw0, 4),
             "status": _status,
         }
         if _err:
@@ -172,6 +175,7 @@ def _sync_one_account(
                 if func_name not in ["permission_relationships", "resourcegroupstaggingapi"]:
                     logger.info(f"Processing {func_name}")
                     _svc_tic = time.perf_counter()
+                    _svc_gw0 = write_timer.total()
                     _svc_status = "success"
                     _svc_err: Dict = {}
                     try:
@@ -191,6 +195,7 @@ def _sync_one_account(
                             "service": func_name,
                             "run_mode": "sequential",
                             "duration_seconds": _svc_elapsed,
+                            "graph_write_seconds": round(write_timer.total() - _svc_gw0, 4),
                             "status": _svc_status,
                         }
                         if _svc_err:

--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -16,6 +16,8 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 from policyuniverse.policy import Policy
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -242,7 +244,7 @@ def load_apigateway_rest_apis(
     Ingest the details of API Gateway REST APIs into neo4j.
     """
     ingest_rest_apis = """
-    UNWIND $rest_apis_list AS r
+    UNWIND $DictList AS r
     MERGE (rest_api:APIGatewayRestAPI{id:r.id})
     ON CREATE SET rest_api.firstseen = timestamp(),
     rest_api.createddate = r.createdDate
@@ -270,9 +272,10 @@ def load_apigateway_rest_apis(
         api['Arn'] = f"arn:aws:apigateway:{region}::restapis/{api['id']}"
         api['consolelink'] = aws_console_link.get_console_link(arn=api['Arn'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_rest_apis,
-        rest_apis_list=rest_apis,
+        rest_apis,
         aws_update_tag=aws_update_tag,
         AWS_ACCOUNT_ID=current_aws_account_id,
     )
@@ -286,16 +289,17 @@ def _load_apigateway_policies(
     Ingest API Gateway REST API policy results into neo4j.
     """
     ingest_policies = """
-    UNWIND $policies as policy
+    UNWIND $DictList as policy
     MATCH (r:APIGatewayRestAPI) where r.name = policy.api_id
     SET r.anonymous_access = (coalesce(r.anonymous_access, false) OR policy.internet_accessible),
     r.anonymous_actions = coalesce(r.anonymous_actions, []) + policy.accessible_actions,
     r.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policies,
-        policies=policies,
+        policies,
         UpdateTag=update_tag,
     )
 
@@ -307,7 +311,8 @@ def _set_default_values(neo4j_session: neo4j.Session, aws_account_id: str) -> No
     SET restApi.anonymous_access = false, restApi.anonymous_actions = []
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         set_defaults,
         AWS_ID=aws_account_id,
     )
@@ -321,7 +326,7 @@ def _load_apigateway_stages(
     Ingest the Stage resource details into neo4j.
     """
     ingest_stages = """
-    UNWIND $stages_list AS stage
+    UNWIND $DictList AS stage
     MERGE (s:APIGatewayStage{id: stage.arn})
     ON CREATE SET s.firstseen = timestamp(), s.stagename = stage.stageName,
     s.createddate = stage.createdDate
@@ -349,9 +354,10 @@ def _load_apigateway_stages(
         stage['arn'] = f"arn:aws:apigateway:{stage['region']}::restapis/{stage['apiId']}/stages/{stage['stageName']}"
         stage['consolelink'] = aws_console_link.get_console_link(arn=stage['arn'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_stages,
-        stages_list=stages,
+        stages,
         UpdateTag=update_tag,
     )
 
@@ -364,7 +370,7 @@ def _load_apigateway_certificates(
     Ingest the API Gateway Client Certificate details into neo4j.
     """
     ingest_certificates = """
-    UNWIND $certificates_list as certificate
+    UNWIND $DictList as certificate
     MERGE (c:APIGatewayClientCertificate{id: certificate.arn})
     ON CREATE SET c.firstseen = timestamp(), c.createddate = certificate.createdDate
     SET c.lastupdated = $UpdateTag, c.expirationdate = certificate.expirationDate,
@@ -379,9 +385,10 @@ def _load_apigateway_certificates(
     SET r.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_certificates,
-        certificates_list=certificates,
+        certificates,
         UpdateTag=update_tag,
     )
 
@@ -394,7 +401,7 @@ def _load_apigateway_resources(
     Ingest the API Gateway Resource details into neo4j.
     """
     ingest_resources = """
-    UNWIND $resources_list AS res
+    UNWIND $DictList AS res
     MERGE (s:APIGatewayResource{id: res.id})
     ON CREATE SET s.firstseen = timestamp()
     SET s.path = res.path,
@@ -414,9 +421,10 @@ def _load_apigateway_resources(
     for resource in resources:
         resource['arn'] = f"arn:aws:apigateway:{resource['region']}::restapis/{resource['apiId']}/resources/{resource['id']}"
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_resources,
-        resources_list=resources,
+        resources,
         UpdateTag=update_tag,
     )
 

--- a/cartography/intel/aws/cloudtrail.py
+++ b/cartography/intel/aws/cloudtrail.py
@@ -7,6 +7,7 @@ import boto3
 import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -35,7 +36,7 @@ def transform_trails(trails: List[Dict]) -> List[Dict]:
 @timeit
 def load_trails(neo4j_session: neo4j.Session, trails: List[Dict], current_aws_account_id: str, aws_update_tag: int) -> None:
     query: str = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (trail:AWSCloudTrailTrail{id: record.TrailARN})
     ON CREATE SET trail.firstseen = timestamp(),
         trail.arn = record.TrailARN
@@ -66,9 +67,10 @@ def load_trails(neo4j_session: neo4j.Session, trails: List[Dict], current_aws_ac
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        Records=trails,
+        trails,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )

--- a/cartography/intel/aws/config.py
+++ b/cartography/intel/aws/config.py
@@ -7,6 +7,7 @@ import boto3
 import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -57,7 +58,7 @@ def load_configuration_recorders(
     aws_update_tag: int,
 ) -> None:
     ingest_configuration_recorders = """
-    UNWIND $Recorders as recorder
+    UNWIND $DictList as recorder
         MERGE (n:AWSConfigurationRecorder{id: recorder._id})
         ON CREATE SET n.firstseen = timestamp()
         SET n.name = recorder.name, n.role_arn = recorder.roleARN,
@@ -80,9 +81,10 @@ def load_configuration_recorders(
         arn = f'arn:aws:config:{region}:{current_aws_account_id}:configuration-recorder/{recorder["name"]}'
         recorder['consolelink'] = aws_console_link.get_console_link(arn=arn)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_configuration_recorders,
-        Recorders=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -98,7 +100,7 @@ def load_delivery_channels(
     aws_update_tag: int,
 ) -> None:
     ingest_delivery_channels = """
-    UNWIND $Channels as channel
+    UNWIND $DictList as channel
         MERGE (n:AWSConfigDeliveryChannel{id: channel._id})
         ON CREATE SET n.firstseen = timestamp()
         SET n.name = channel.name,
@@ -123,9 +125,10 @@ def load_delivery_channels(
         arn = f'arn:aws:config:{region}:{current_aws_account_id}:delivery-channel/{channel["name"]}'
         channel['consolelink'] = aws_console_link.get_console_link(arn=arn)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_delivery_channels,
-        Channels=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -141,7 +144,7 @@ def load_config_rules(
     aws_update_tag: int,
 ) -> None:
     ingest_config_rules = """
-    UNWIND $Rules as rule
+    UNWIND $DictList as rule
         MERGE (n:AWSConfigRule{id: rule.ConfigRuleArn})
         ON CREATE SET n.firstseen = timestamp()
         SET n.name = rule.ConfigRuleName, n.description = rule.Description,
@@ -172,9 +175,10 @@ def load_config_rules(
                 details.append(f'{detail}')
         rule["_source_details"] = details
         rule["consolelink"] = aws_console_link.get_console_link(arn=rule['ConfigRuleArn'])
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_config_rules,
-        Rules=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,

--- a/cartography/intel/aws/ec2/auto_scaling_groups.py
+++ b/cartography/intel/aws/ec2/auto_scaling_groups.py
@@ -205,10 +205,7 @@ def load_ec2_auto_scaling_groups(
         if group.get('VPCZoneIdentifier'):
             vpclist = group["VPCZoneIdentifier"]
 
-            if ',' in vpclist:
-                data = vpclist.split(',')
-            else:
-                data = vpclist
+            data = vpclist.split(',')
 
             load_graph_data(
                 neo4j_session,

--- a/cartography/intel/aws/ec2/auto_scaling_groups.py
+++ b/cartography/intel/aws/ec2/auto_scaling_groups.py
@@ -8,6 +8,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -48,7 +49,7 @@ def load_launch_configurations(
         neo4j_session: neo4j.Session, data: List[Dict], region: str, current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_lc = """
-    UNWIND $launch_configurations as lc
+    UNWIND $DictList as lc
         MERGE (config:LaunchConfiguration{id: lc.LaunchConfigurationARN})
         ON CREATE SET config.firstseen = timestamp(), config.name = lc.LaunchConfigurationName,
         config.arn = lc.LaunchConfigurationARN,
@@ -77,9 +78,10 @@ def load_launch_configurations(
         lc['CreatedTime'] = str(int(lc['CreatedTime'].timestamp()))
         lc['consolelink'] = aws_console_link.get_console_link(arn=lc['LaunchConfigurationARN'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_lc,
-        launch_configurations=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,
@@ -91,7 +93,7 @@ def load_ec2_auto_scaling_groups(
     neo4j_session: neo4j.Session, data: List[Dict], region: str, current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_group = """
-    UNWIND $autoscaling_groups_list as ag
+    UNWIND $DictList as ag
         MERGE (group:AutoScalingGroup{arn: ag.AutoScalingGroupARN})
         ON CREATE SET group.firstseen = timestamp(),
         group.createdtime = ag.CreatedTime
@@ -116,7 +118,7 @@ def load_ec2_auto_scaling_groups(
     """
 
     ingest_vpc = """
-    UNWIND $vpc_id_list as vpc_id
+    UNWIND $DictList as vpc_id
     MERGE (subnet:EC2Subnet{subnetid: vpc_id})
     ON CREATE SET subnet.firstseen = timestamp()
     SET subnet.lastupdated = $update_tag
@@ -128,7 +130,7 @@ def load_ec2_auto_scaling_groups(
     """
 
     ingest_instance = """
-    UNWIND $instances_list as i
+    UNWIND $DictList as i
     MERGE (instance:Instance:EC2Instance{id: i.InstanceId})
     ON CREATE SET instance.firstseen = timestamp()
     SET instance.lastupdated = $update_tag, instance.region=$Region
@@ -145,7 +147,7 @@ def load_ec2_auto_scaling_groups(
     """
 
     ingest_lts = """
-    UNWIND $autoscaling_groups_list as ag
+    UNWIND $DictList as ag
         MATCH (group:AutoScalingGroup{arn: ag.AutoScalingGroupARN})
         MATCH (template:LaunchTemplate{id: ag.LaunchTemplate.LaunchTemplateId})
         MERGE (group)-[r:HAS_LAUNCH_TEMPLATE]->(template)
@@ -154,7 +156,7 @@ def load_ec2_auto_scaling_groups(
     """
 
     ingest_lcs = """
-    UNWIND $autoscaling_groups_list as ag
+    UNWIND $DictList as ag
         MATCH (group:AutoScalingGroup{arn: ag.AutoScalingGroupARN})
         MATCH (config:LaunchConfiguration{name: ag.LaunchConfigurationName})
         MERGE (group)-[r:HAS_LAUNCH_CONFIG]->(config)
@@ -173,23 +175,26 @@ def load_ec2_auto_scaling_groups(
         group['CreatedTime'] = str(group['CreatedTime'])
         group['consolelink'] = aws_console_link.get_console_link(arn=group['AutoScalingGroupARN'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_group,
-        autoscaling_groups_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,
     )
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_lcs,
-        autoscaling_groups_list=launch_configs,
+        launch_configs,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,
     )
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_lts,
-        autoscaling_groups_list=launch_templates,
+        launch_templates,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,
@@ -205,18 +210,20 @@ def load_ec2_auto_scaling_groups(
             else:
                 data = vpclist
 
-            neo4j_session.run(
+            load_graph_data(
+                neo4j_session,
                 ingest_vpc,
-                vpc_id_list=data,
+                data,
                 GROUPARN=group_arn,
                 update_tag=update_tag,
             )
 
         if group.get("Instances"):
             data = group["Instances"]
-            neo4j_session.run(
+            load_graph_data(
+                neo4j_session,
                 ingest_instance,
-                instances_list=data,
+                data,
                 GROUPARN=group_arn,
                 AWS_ACCOUNT_ID=current_aws_account_id,
                 Region=region,

--- a/cartography/intel/aws/ec2/elastic_ip_addresses.py
+++ b/cartography/intel/aws/ec2/elastic_ip_addresses.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -96,7 +97,7 @@ def load_elastic_ip_addresses(
     """
     logger.info(f"Loading {len(elastic_ip_addresses)} Elastic IP Addresses")
     ingest_addresses = """
-    UNWIND $elastic_ip_addresses as eia
+    UNWIND $DictList as eia
         MERGE (address: ElasticIPAddress{id: eia.AllocationId})
         ON CREATE SET address.firstseen = timestamp()
         SET address.instance_id = eia.InstanceId, address.public_ip = eia.PublicIp,
@@ -129,9 +130,10 @@ def load_elastic_ip_addresses(
         SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_addresses,
-        elastic_ip_addresses=elastic_ip_addresses,
+        elastic_ip_addresses,
         aws_account_id=current_aws_account_id,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -9,6 +9,9 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
@@ -37,7 +40,10 @@ def get_images_in_use(neo4j_session: neo4j.Session, region: str, current_aws_acc
     WITH images + new_ltv_images AS images
     RETURN images
     """
-    results = neo4j_session.run(get_images_query, AWS_ACCOUNT_ID=current_aws_account_id, Region=region)
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx, get_images_query,
+        AWS_ACCOUNT_ID=current_aws_account_id, Region=region,
+    )
     images = []
     for r in results:
         images.extend(r['images'])
@@ -159,7 +165,7 @@ def load_images(
         neo4j_session: neo4j.Session, data: List[Dict], current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_images = """
-    UNWIND $images_list as image
+    UNWIND $DictList as image
     MERGE (i:EC2Image{id: image.ID})
     ON CREATE SET i.firstseen = timestamp(), i.imageid = image.ImageId, i.name = image.Name,
     i.creationdate = image.CreationDate
@@ -188,9 +194,10 @@ def load_images(
         image['ID'] = image['ImageId'] + '|' + image.get('region', '')
         image['arn'] = f"arn:aws:ec2:{image.get('region', '')}:{current_aws_account_id}:image/{image['ImageId']}"
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_images,
-        images_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         update_tag=update_tag,
     )
@@ -220,7 +227,8 @@ def link_ec2_instances_to_images(neo4j_session: neo4j.Session, update_tag: int) 
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_instance_image_rel,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -11,6 +11,8 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load
 from cartography.data.operating_systems import OPERATING_SYSTEMS
 from cartography.graph.job import GraphJob
@@ -464,16 +466,17 @@ def load_ec2_roles(
     update_tag: int,
 ) -> None:
     ingest_role_instance_relations = """
-    UNWIND $roles as role
+    UNWIND $DictList as role
     MATCH (instance:EC2Instance {id: role.InstanceId}), (roleNode:AWSRole {arn: role.Arn})
     MERGE (instance)-[r:USES]->(roleNode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_role_instance_relations,
-        roles=role_data,
+        role_data,
         aws_update_tag=update_tag,
     )
 
@@ -482,7 +485,7 @@ def load_ec2_roles(
 def link_ec2_to_eks(neo4j_session: neo4j.Session, instance_list: List[Dict], update_tag: int) -> None:
     """Links EC2 instances to EKS Clusters and Node Groups based on extracted tags."""
     cluster_query = """
-    UNWIND $Instances as instance
+    UNWIND $DictList as instance
     WITH instance WHERE instance.EksClusterName IS NOT NULL
     MATCH (i:EC2Instance{id: instance.InstanceId})
     MATCH (c:EKSCluster{name: instance.EksClusterName})
@@ -492,7 +495,7 @@ def link_ec2_to_eks(neo4j_session: neo4j.Session, instance_list: List[Dict], upd
     """
 
     nodegroup_query = """
-    UNWIND $Instances as instance
+    UNWIND $DictList as instance
     WITH instance WHERE instance.EksNodeGroupName IS NOT NULL AND instance.EksClusterName IS NOT NULL
     MATCH (i:EC2Instance{id: instance.InstanceId})
     MATCH (c:EKSCluster{name: instance.EksClusterName})<-[:ASSOCIATED_WITH]-(ng:EKSClusterNodeGroup{name: instance.EksNodeGroupName})
@@ -500,8 +503,8 @@ def link_ec2_to_eks(neo4j_session: neo4j.Session, instance_list: List[Dict], upd
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(cluster_query, Instances=instance_list, update_tag=update_tag)
-    neo4j_session.run(nodegroup_query, Instances=instance_list, update_tag=update_tag)
+    load_graph_data(neo4j_session, cluster_query, instance_list, update_tag=update_tag)
+    load_graph_data(neo4j_session, nodegroup_query, instance_list, update_tag=update_tag)
 
 
 def load_ec2_instance_data(
@@ -543,7 +546,8 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any])
       AND r.lastupdated <> $UPDATE_TAG
     DELETE r
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         cleanup_query,
         UPDATE_TAG=common_job_parameters['UPDATE_TAG'],
         AWS_ID=common_job_parameters['AWS_ID'],

--- a/cartography/intel/aws/ec2/internet_gateways.py
+++ b/cartography/intel/aws/ec2/internet_gateways.py
@@ -8,6 +8,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -98,7 +99,7 @@ def load_internet_gateways(
         arn = f"arn:aws:ec2:{region}:{igw.get('OwnerId', '')}:internet-gateway/{igw['InternetGatewayId']}"
         igw['consolelink'] = aws_console_link.get_console_link(arn=arn)
     query = """
-    UNWIND $internet_gateways as igw
+    UNWIND $DictList as igw
         MERGE (ig:AWSInternetGateway{id: igw.InternetGatewayId})
         ON CREATE SET
             ig.firstseen = timestamp(),
@@ -124,13 +125,14 @@ def load_internet_gateways(
         SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        internet_gateways=internet_gateways,
+        internet_gateways,
         region=region,
         aws_account_id=current_aws_account_id,
         aws_update_tag=update_tag,
-    ).consume()
+    )
 
 
 @timeit

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.models.aws.ec2.keypairs import EC2KeyPairSchema
 from cartography.util import aws_handle_regions
@@ -66,7 +67,8 @@ def load_ec2_key_pairs(
         # consolelink = aws_console_link.get_console_link(arn=key_pair_arn)
         consolelink = ''
 
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_key_pair,
             ARN=key_pair_arn,
             KeyName=key_name,

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -8,6 +8,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -44,7 +45,7 @@ def load_launch_templates(
         neo4j_session: neo4j.Session, data: List[Dict], region: str, current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_lt = """
-    UNWIND $launch_templates as lt
+    UNWIND $DictList as lt
         MERGE (template:LaunchTemplate{id: lt.LaunchTemplateId})
         ON CREATE SET template.firstseen = timestamp(),
         template.name = lt.LaunchTemplateName,
@@ -97,9 +98,10 @@ def load_launch_templates(
         for tv in lt.get("_template_versions", []):
             tv['CreateTime'] = str(time.mktime(tv['CreateTime'].timetuple()))
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_lt,
-        launch_templates=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,

--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -9,6 +9,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -72,143 +73,131 @@ def load_load_balancer_v2s(
     update_tag: int, region: str,
 ) -> None:
     ingest_load_balancer_v2 = """
-    MERGE (elbv2:LoadBalancerV2{id: $ID})
-    ON CREATE SET elbv2.firstseen = timestamp(), elbv2.createdtime = $CREATED_TIME
-    SET elbv2.lastupdated = $update_tag, elbv2.name = $NAME, elbv2.dnsname = $DNS_NAME,
-    elbv2.canonicalhostedzonenameid = $HOSTED_ZONE_NAME_ID,
-    elbv2.type = $ELBv2_TYPE,
-    elbv2.scheme = $SCHEME, elbv2.region = $Region,
-    elbv2.arn = $Arn,
-    elbv2.consolelink = $consolelink
+    UNWIND $DictList AS item
+    MERGE (elbv2:LoadBalancerV2{id: item.id})
+    ON CREATE SET elbv2.firstseen = timestamp(), elbv2.createdtime = item.createdtime
+    SET elbv2.lastupdated = $update_tag, elbv2.name = item.name, elbv2.dnsname = item.id,
+    elbv2.canonicalhostedzonenameid = item.hosted_zone_name_id,
+    elbv2.type = item.type,
+    elbv2.scheme = item.scheme, elbv2.region = item.region,
+    elbv2.arn = item.arn,
+    elbv2.consolelink = item.consolelink
     WITH elbv2
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(elbv2)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
+
+    lb_rows, subnet_rows, sg_rows, listener_rows, instance_rows = [], [], [], [], []
     for lb in data:
         region = lb.get('region', '')
         load_balancer_arn = lb["LoadBalancerArn"]
         load_balancer_id = lb.get("DNSName") or load_balancer_arn
 
-        neo4j_session.run(
-            ingest_load_balancer_v2,
-            ID=load_balancer_id,
-            CREATED_TIME=str(lb["CreatedTime"]),
-            NAME=lb["LoadBalancerName"],
-            DNS_NAME=load_balancer_id,
-            HOSTED_ZONE_NAME_ID=lb.get("CanonicalHostedZoneNameID"),
-            ELBv2_TYPE=lb.get("Type"),
-            SCHEME=lb.get("Scheme"),
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            Region=region,
-            Arn=load_balancer_arn,
-            update_tag=update_tag,
-            consolelink=aws_console_link.get_console_link(arn=load_balancer_arn),
+        lb_rows.append({
+            "id": load_balancer_id,
+            "createdtime": str(lb["CreatedTime"]),
+            "name": lb["LoadBalancerName"],
+            "hosted_zone_name_id": lb.get("CanonicalHostedZoneNameID"),
+            "type": lb.get("Type"),
+            "scheme": lb.get("Scheme"),
+            "region": region,
+            "arn": load_balancer_arn,
+            "consolelink": aws_console_link.get_console_link(arn=load_balancer_arn),
+        })
+        subnet_rows.extend(
+            {"load_balancer_id": load_balancer_id, "subnet_id": az['SubnetId'], "region": region}
+            for az in lb["AvailabilityZones"] or []
         )
-
-        if lb["AvailabilityZones"]:
-            az = lb["AvailabilityZones"]
-            load_load_balancer_v2_subnets(neo4j_session, load_balancer_id, az, region, update_tag)
-
         # NLB's don't have SecurityGroups, so check for one first.
         if 'SecurityGroups' in lb and lb["SecurityGroups"]:
-            ingest_load_balancer_v2_security_group = """
-            MATCH (elbv2:LoadBalancerV2{id: $ID}),
-            (group:EC2SecurityGroup{groupid: $GROUP_ID})
-            MERGE (elbv2)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
-            ON CREATE SET r.firstseen = timestamp()
-            SET r.lastupdated = $update_tag
-            """
-            for group in lb["SecurityGroups"]:
-                neo4j_session.run(
-                    ingest_load_balancer_v2_security_group,
-                    ID=load_balancer_id,
-                    GROUP_ID=str(group),
-                    update_tag=update_tag,
-                )
-
-        if lb.get('Listeners'):
-            load_load_balancer_v2_listeners(neo4j_session, load_balancer_id, lb['Listeners'], update_tag)
-
-        if lb.get('TargetGroups'):
-            load_load_balancer_v2_target_groups(
-                neo4j_session, load_balancer_id, lb['TargetGroups'],
-                current_aws_account_id, update_tag,
+            sg_rows.extend(
+                {"load_balancer_id": load_balancer_id, "group_id": str(group)}
+                for group in lb["SecurityGroups"]
             )
+        if lb.get('Listeners'):
+            listener_rows.append({"load_balancer_id": load_balancer_id, "listeners": lb['Listeners']})
+        instance_rows.extend(_build_target_group_instance_rows(load_balancer_id, lb.get('TargetGroups') or []))
+
+    load_graph_data(
+        neo4j_session, ingest_load_balancer_v2, lb_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id, update_tag=update_tag,
+    )
+    _load_lb_v2_subnet_rows(neo4j_session, subnet_rows, update_tag)
+    ingest_load_balancer_v2_security_group = """
+    UNWIND $DictList AS item
+    MATCH (elbv2:LoadBalancerV2{id: item.load_balancer_id}),
+    (group:EC2SecurityGroup{groupid: item.group_id})
+    MERGE (elbv2)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $update_tag
+    """
+    load_graph_data(neo4j_session, ingest_load_balancer_v2_security_group, sg_rows, update_tag=update_tag)
+    _load_lb_v2_listener_rows(neo4j_session, listener_rows, update_tag)
+    _load_lb_v2_instance_rows(neo4j_session, instance_rows, current_aws_account_id, update_tag)
 
 
-@timeit
-def load_load_balancer_v2_subnets(
-    neo4j_session: neo4j.Session, load_balancer_id: str, az_data: List[Dict],
-    region: str, update_tag: int,
-) -> None:
+def _build_target_group_instance_rows(load_balancer_id: str, target_groups: List[Dict]) -> List[Dict]:
+    return [
+        {
+            "load_balancer_id": load_balancer_id,
+            "instance_id": instance,
+            "target_group_arn": target_group.get('TargetGroupArn'),
+            "port": target_group.get('Port'),
+            "protocol": target_group.get('Protocol'),
+        }
+        for target_group in target_groups
+        # Only working on EC2 Instances now. TODO: Add IP & Lambda EXPOSE.
+        if target_group['TargetType'] == 'instance'
+        for instance in target_group["Targets"]
+    ]
+
+
+def _load_lb_v2_subnet_rows(neo4j_session: neo4j.Session, subnet_rows: List[Dict], update_tag: int) -> None:
     ingest_load_balancer_subnet = """
-    MATCH (elbv2:LoadBalancerV2{id: $ID})
-    MERGE (subnet:EC2Subnet{subnetid: $SubnetId})
+    UNWIND $DictList AS item
+    MATCH (elbv2:LoadBalancerV2{id: item.load_balancer_id})
+    MERGE (subnet:EC2Subnet{subnetid: item.subnet_id})
     ON CREATE SET subnet.firstseen = timestamp()
-    SET subnet.region = $region, subnet.lastupdated = $update_tag
+    SET subnet.region = item.region, subnet.lastupdated = $update_tag
     WITH elbv2, subnet
     MERGE (elbv2)-[r:SUBNET]->(subnet)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    for az in az_data:
-        neo4j_session.run(
-            ingest_load_balancer_subnet,
-            ID=load_balancer_id,
-            SubnetId=az['SubnetId'],
-            region=region,
-            update_tag=update_tag,
-        )
+    load_graph_data(neo4j_session, ingest_load_balancer_subnet, subnet_rows, update_tag=update_tag)
 
 
-@timeit
-def load_load_balancer_v2_target_groups(
-    neo4j_session: neo4j.Session, load_balancer_id: str, target_groups: List[Dict], current_aws_account_id: str,
-    update_tag: int,
+def _load_lb_v2_instance_rows(
+    neo4j_session: neo4j.Session, instance_rows: List[Dict], current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_instances = """
-    MATCH (elbv2:LoadBalancerV2{id: $ID}), (instance:EC2Instance{instanceid: $INSTANCE_ID})
+    UNWIND $DictList AS item
+    MATCH (elbv2:LoadBalancerV2{id: item.load_balancer_id}), (instance:EC2Instance{instanceid: item.instance_id})
     MERGE (elbv2)-[r:EXPOSE]->(instance)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag,
-        r.port = $PORT, r.protocol = $PROTOCOL,
-        r.target_group_arn = $TARGET_GROUP_ARN
+        r.port = item.port, r.protocol = item.protocol,
+        r.target_group_arn = item.target_group_arn
     WITH instance
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(instance)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    for target_group in target_groups:
-
-        if not target_group['TargetType'] == 'instance':
-            # Only working on EC2 Instances now. TODO: Add IP & Lambda EXPOSE.
-            continue
-
-        for instance in target_group["Targets"]:
-            neo4j_session.run(
-                ingest_instances,
-                ID=load_balancer_id,
-                INSTANCE_ID=instance,
-                AWS_ACCOUNT_ID=current_aws_account_id,
-                TARGET_GROUP_ARN=target_group.get('TargetGroupArn'),
-                PORT=target_group.get('Port'),
-                PROTOCOL=target_group.get('Protocol'),
-                update_tag=update_tag,
-            )
+    load_graph_data(
+        neo4j_session, ingest_instances, instance_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id, update_tag=update_tag,
+    )
 
 
-@timeit
-def load_load_balancer_v2_listeners(
-    neo4j_session: neo4j.Session, load_balancer_id: str, listener_data: List[Dict],
-    update_tag: int,
-) -> None:
+def _load_lb_v2_listener_rows(neo4j_session: neo4j.Session, listener_rows: List[Dict], update_tag: int) -> None:
     ingest_listener = """
-    MATCH (elbv2:LoadBalancerV2{id: $LoadBalancerId})
-    WITH elbv2
-    UNWIND $Listeners as data
+    UNWIND $DictList AS item
+    MATCH (elbv2:LoadBalancerV2{id: item.load_balancer_id})
+    WITH elbv2, item
+    UNWIND item.listeners as data
         MERGE (l:Endpoint:ELBV2Listener{id: data.ListenerArn})
         ON CREATE SET l.port = data.Port, l.protocol = data.Protocol,
         l.firstseen = timestamp(),
@@ -221,11 +210,43 @@ def load_load_balancer_v2_listeners(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
-        ingest_listener,
-        LoadBalancerId=load_balancer_id,
-        Listeners=listener_data,
-        update_tag=update_tag,
+    load_graph_data(neo4j_session, ingest_listener, listener_rows, update_tag=update_tag)
+
+
+@timeit
+def load_load_balancer_v2_subnets(
+    neo4j_session: neo4j.Session, load_balancer_id: str, az_data: List[Dict],
+    region: str, update_tag: int,
+) -> None:
+    _load_lb_v2_subnet_rows(
+        neo4j_session,
+        [{"load_balancer_id": load_balancer_id, "subnet_id": az['SubnetId'], "region": region} for az in az_data],
+        update_tag,
+    )
+
+
+@timeit
+def load_load_balancer_v2_target_groups(
+    neo4j_session: neo4j.Session, load_balancer_id: str, target_groups: List[Dict], current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    _load_lb_v2_instance_rows(
+        neo4j_session,
+        _build_target_group_instance_rows(load_balancer_id, target_groups),
+        current_aws_account_id,
+        update_tag,
+    )
+
+
+@timeit
+def load_load_balancer_v2_listeners(
+    neo4j_session: neo4j.Session, load_balancer_id: str, listener_data: List[Dict],
+    update_tag: int,
+) -> None:
+    _load_lb_v2_listener_rows(
+        neo4j_session,
+        [{"load_balancer_id": load_balancer_id, "listeners": listener_data}],
+        update_tag,
     )
 
 

--- a/cartography/intel/aws/ec2/load_balancers.py
+++ b/cartography/intel/aws/ec2/load_balancers.py
@@ -8,6 +8,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -36,16 +37,18 @@ def get_loadbalancer_data(boto3_session: boto3.session.Session, region: str) -> 
 
 @timeit
 def load_load_balancer_listeners(
-    neo4j_session: neo4j.Session, load_balancer_id: str, listener_data: List[Dict],
-    update_tag: int, consolelink: str,
+    neo4j_session: neo4j.Session, listener_rows: List[Dict], update_tag: int,
 ) -> None:
+    """Each row: load_balancer_id, consolelink, listeners (the ListenerDescriptions list)."""
     ingest_listener = """
-    MATCH (elb:LoadBalancer{id: $LoadBalancerId})
-    WITH elb
-    UNWIND $Listeners as data
+    UNWIND $DictList AS item
+    MATCH (elb:LoadBalancer{id: item.load_balancer_id})
+    WITH elb, item
+    UNWIND item.listeners as data
         MERGE (l:Endpoint:ELBListener{id: elb.id + toString(data.Listener.LoadBalancerPort) +
                 toString(data.Listener.Protocol)})
-        ON CREATE SET l.port = data.Listener.LoadBalancerPort, l.protocol = data.Listener.Protocol, l.consolelink = $consolelink,
+        ON CREATE SET l.port = data.Listener.LoadBalancerPort, l.protocol = data.Listener.Protocol,
+        l.consolelink = item.consolelink,
         l.firstseen = timestamp()
         SET l.instance_port = data.Listener.InstancePort, l.instance_protocol = data.Listener.InstanceProtocol,
         l.policy_names = data.PolicyNames,
@@ -55,35 +58,22 @@ def load_load_balancer_listeners(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $update_tag
     """
-
-    neo4j_session.run(
-        ingest_listener,
-        LoadBalancerId=load_balancer_id,
-        consolelink=consolelink,
-        Listeners=listener_data,
-        update_tag=update_tag,
-    )
+    load_graph_data(neo4j_session, ingest_listener, listener_rows, update_tag=update_tag)
 
 
 @timeit
 def load_load_balancer_subnets(
-    neo4j_session: neo4j.Session, load_balancer_id: str, subnets_data: List[Dict],
-    update_tag: int,
+    neo4j_session: neo4j.Session, subnet_rows: List[Dict], update_tag: int,
 ) -> None:
+    """Each row: load_balancer_id, subnet_id."""
     ingest_load_balancer_subnet = """
-    MATCH (elb:LoadBalancer{id: $ID}), (subnet:EC2Subnet{subnetid: $SUBNET_ID})
+    UNWIND $DictList AS item
+    MATCH (elb:LoadBalancer{id: item.load_balancer_id}), (subnet:EC2Subnet{subnetid: item.subnet_id})
     MERGE (elb)-[r:SUBNET]->(subnet)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-
-    for subnet_id in subnets_data:
-        neo4j_session.run(
-            ingest_load_balancer_subnet,
-            ID=load_balancer_id,
-            SUBNET_ID=subnet_id,
-            update_tag=update_tag,
-        )
+    load_graph_data(neo4j_session, ingest_load_balancer_subnet, subnet_rows, update_tag=update_tag)
 
 
 @timeit
@@ -92,11 +82,12 @@ def load_load_balancers(
     update_tag: int,
 ) -> None:
     ingest_load_balancer = """
-    MERGE (elb:LoadBalancer{id: $ID})
-    ON CREATE SET elb.firstseen = timestamp(), elb.createdtime = $CREATED_TIME
-    SET elb.lastupdated = $update_tag, elb.name = $NAME, elb.dnsname = $DNS_NAME,
-    elb.canonicalhostedzonename = $HOSTED_ZONE_NAME, elb.canonicalhostedzonenameid = $HOSTED_ZONE_NAME_ID,
-    elb.scheme = $SCHEME, elb.region = $Region, elb.arn = $Arn
+    UNWIND $DictList AS item
+    MERGE (elb:LoadBalancer{id: item.id})
+    ON CREATE SET elb.firstseen = timestamp(), elb.createdtime = item.createdtime
+    SET elb.lastupdated = $update_tag, elb.name = item.name, elb.dnsname = item.id,
+    elb.canonicalhostedzonename = item.hosted_zone_name, elb.canonicalhostedzonenameid = item.hosted_zone_name_id,
+    elb.scheme = item.scheme, elb.region = item.region, elb.arn = item.arn
     WITH elb
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(elb)
@@ -105,23 +96,26 @@ def load_load_balancers(
     """
 
     ingest_load_balancersource_security_group = """
-    MATCH (elb:LoadBalancer{id: $ID}),
-    (group:EC2SecurityGroup{name: $GROUP_NAME})
+    UNWIND $DictList AS item
+    MATCH (elb:LoadBalancer{id: item.load_balancer_id}),
+    (group:EC2SecurityGroup{name: item.group_name})
     MERGE (elb)-[r:SOURCE_SECURITY_GROUP]->(group)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
 
     ingest_load_balancer_security_group = """
-    MATCH (elb:LoadBalancer{id: $ID}),
-    (group:EC2SecurityGroup{groupid: $GROUP_ID})
+    UNWIND $DictList AS item
+    MATCH (elb:LoadBalancer{id: item.load_balancer_id}),
+    (group:EC2SecurityGroup{groupid: item.group_id})
     MERGE (elb)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
 
     ingest_instances = """
-    MATCH (elb:LoadBalancer{id: $ID}), (instance:EC2Instance{instanceid: $INSTANCE_ID})
+    UNWIND $DictList AS item
+    MATCH (elb:LoadBalancer{id: item.load_balancer_id}), (instance:EC2Instance{instanceid: item.instance_id})
     MERGE (elb)-[r:EXPOSE]->(instance)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
@@ -132,62 +126,62 @@ def load_load_balancers(
     SET r.lastupdated = $update_tag
     """
 
+    lb_rows, subnet_rows, sg_rows, source_sg_rows, instance_rows, listener_rows = [], [], [], [], [], []
     for lb in data:
         region = lb.get('region', '')
         load_balancer_id = lb["DNSName"]
-        load_balancer_arn = f"arn:aws:elasticloadbalancing:{region}:{current_aws_account_id}:loadbalancer/{load_balancer_id}"
-        console_arn = f"arn:aws:elasticloadbalancing:{region}:{current_aws_account_id}:loadbalancer/{lb['LoadBalancerName']}"
+        load_balancer_arn = \
+            f"arn:aws:elasticloadbalancing:{region}:{current_aws_account_id}:loadbalancer/{load_balancer_id}"
+        console_arn = \
+            f"arn:aws:elasticloadbalancing:{region}:{current_aws_account_id}:loadbalancer/{lb['LoadBalancerName']}"
         consolelink = aws_console_link.get_console_link(arn=console_arn)
 
-        neo4j_session.run(
-            ingest_load_balancer,
-            ID=load_balancer_id,
-            CREATED_TIME=str(lb["CreatedTime"]),
-            NAME=lb["LoadBalancerName"],
-            DNS_NAME=load_balancer_id,
-            HOSTED_ZONE_NAME=lb.get("CanonicalHostedZoneName"),
-            HOSTED_ZONE_NAME_ID=lb.get("CanonicalHostedZoneNameID"),
-            SCHEME=lb.get("Scheme", ""),
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            Region=region,
-            consolelink=consolelink,
-            Arn=load_balancer_arn,
-            update_tag=update_tag,
+        lb_rows.append({
+            "id": load_balancer_id,
+            "createdtime": str(lb["CreatedTime"]),
+            "name": lb["LoadBalancerName"],
+            "hosted_zone_name": lb.get("CanonicalHostedZoneName"),
+            "hosted_zone_name_id": lb.get("CanonicalHostedZoneNameID"),
+            "scheme": lb.get("Scheme", ""),
+            "region": region,
+            "arn": load_balancer_arn,
+        })
+        subnet_rows.extend(
+            {"load_balancer_id": load_balancer_id, "subnet_id": subnet_id}
+            for subnet_id in lb["Subnets"] or []
         )
-
-        if lb["Subnets"]:
-            load_load_balancer_subnets(neo4j_session, load_balancer_id, lb["Subnets"], update_tag)
-
-        if lb["SecurityGroups"]:
-            for group in lb["SecurityGroups"]:
-                neo4j_session.run(
-                    ingest_load_balancer_security_group,
-                    ID=load_balancer_id,
-                    GROUP_ID=str(group),
-                    update_tag=update_tag,
-                )
-
+        sg_rows.extend(
+            {"load_balancer_id": load_balancer_id, "group_id": str(group)}
+            for group in lb["SecurityGroups"] or []
+        )
         if lb["SourceSecurityGroup"]:
-            source_group = lb["SourceSecurityGroup"]
-            neo4j_session.run(
-                ingest_load_balancersource_security_group,
-                ID=load_balancer_id,
-                GROUP_NAME=source_group["GroupName"],
-                update_tag=update_tag,
-            )
-
-        if lb["Instances"]:
-            for instance in lb["Instances"]:
-                neo4j_session.run(
-                    ingest_instances,
-                    ID=load_balancer_id,
-                    INSTANCE_ID=instance["InstanceId"],
-                    AWS_ACCOUNT_ID=current_aws_account_id,
-                    update_tag=update_tag,
-                )
-
+            source_sg_rows.append({
+                "load_balancer_id": load_balancer_id,
+                "group_name": lb["SourceSecurityGroup"]["GroupName"],
+            })
+        instance_rows.extend(
+            {"load_balancer_id": load_balancer_id, "instance_id": instance["InstanceId"]}
+            for instance in lb["Instances"] or []
+        )
         if lb["ListenerDescriptions"]:
-            load_load_balancer_listeners(neo4j_session, load_balancer_id, lb["ListenerDescriptions"], update_tag, consolelink)
+            listener_rows.append({
+                "load_balancer_id": load_balancer_id,
+                "consolelink": consolelink,
+                "listeners": lb["ListenerDescriptions"],
+            })
+
+    load_graph_data(
+        neo4j_session, ingest_load_balancer, lb_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id, update_tag=update_tag,
+    )
+    load_load_balancer_subnets(neo4j_session, subnet_rows, update_tag)
+    load_graph_data(neo4j_session, ingest_load_balancer_security_group, sg_rows, update_tag=update_tag)
+    load_graph_data(neo4j_session, ingest_load_balancersource_security_group, source_sg_rows, update_tag=update_tag)
+    load_graph_data(
+        neo4j_session, ingest_instances, instance_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id, update_tag=update_tag,
+    )
+    load_load_balancer_listeners(neo4j_session, listener_rows, update_tag)
 
 
 @timeit

--- a/cartography/intel/aws/ec2/reserved_instances.py
+++ b/cartography/intel/aws/ec2/reserved_instances.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -37,7 +38,7 @@ def load_reserved_instances(
         current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_reserved_instances = """
-    UNWIND $reserved_instances_list as res
+    UNWIND $DictList as res
     MERGE (ri:EC2ReservedInstance{id: res.ReservedInstancesId})
     ON CREATE SET ri.firstseen = timestamp()
     SET ri.lastupdated = $update_tag, ri.availabilityzone = res.AvailabilityZone, ri.duration = res.Duration,
@@ -61,9 +62,10 @@ def load_reserved_instances(
         r_instance['Arn'] = f"arn:aws:ec2:{region}:{current_aws_account_id}:reserved-instances/{r_instance['ReservedInstancesId']}"
         r_instance['consolelink'] = aws_console_link.get_console_link(arn=r_instance['Arn'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_reserved_instances,
-        reserved_instances_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,
         update_tag=update_tag,

--- a/cartography/intel/aws/ec2/security_groups.py
+++ b/cartography/intel/aws/ec2/security_groups.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.graph.job import GraphJob
 from cartography.models.aws.ec2.securitygroup_instance import EC2SecurityGroupInstanceSchema
 from cartography.util import aws_handle_regions
@@ -50,104 +51,123 @@ def get_ec2_security_group_data(boto3_session: boto3.session.Session, region: st
     return security_groups
 
 
+def _build_rule_and_range_rows(groups: List[Dict]) -> tuple:
+    """
+    Flatten group x rule-type x rule (and their IP ranges) into rows, partitioned by
+    node label since each label needs its own query. This was a per-item nested loop.
+    """
+    rule_rows: Dict[str, List[Dict]] = {"IpPermissionInbound": [], "IpPermissionEgress": []}
+    range_rows: Dict[str, List[Dict]] = {"IpRange": [], "Ipv6Range": []}
+    rule_type_map = {"IpPermissions": "IpPermissionInbound", "IpPermissionsEgress": "IpPermissionEgress"}
+
+    for group in groups:
+        group_id = group["GroupId"]
+        for rule_type, rule_label in rule_type_map.items():
+            for rule in group.get(rule_type) or []:
+                protocol = rule.get("IpProtocol", "all")
+                from_port = rule.get("FromPort")
+                to_port = rule.get("ToPort")
+
+                # NOTE This hardcoding is done because some, rules might be applicable for all protocols in that case
+                # the value of protocol variable would be -1 (or all) this means it will also be available for all
+                # ports, hence from_port & to_port values might not be provided
+                # Docs: boto3 EC2 Client.describe_security_groups reference
+                if protocol == "-1" or protocol == "all":
+                    from_port = 0  # the smallest possible IP
+                    to_port = 65535  # the largest possible IP
+
+                ruleid = f"{group_id}/{rule_type}/{from_port}{to_port}{protocol}"
+                rule_rows[rule_label].append({
+                    "ruleid": ruleid,
+                    "from_port": from_port,
+                    "to_port": to_port,
+                    "protocol": protocol,
+                    "group_id": group_id,
+                })
+
+                for ip_range in rule["IpRanges"]:
+                    cidr_ip = ip_range['CidrIp']
+                    range_rows["IpRange"].append({
+                        "range_id": f"IpRule/{ruleid}/ipRange/{cidr_ip}",
+                        "range": cidr_ip,
+                        "range_name": cidr_ip.split('/')[0],
+                        "ruleid": ruleid,
+                    })
+
+                for ipv6_range in rule["Ipv6Ranges"]:
+                    cidr_ipv6 = ipv6_range['CidrIpv6']
+                    range_rows["Ipv6Range"].append({
+                        "range_id": f"IpRule/{ruleid}/ipv6Range/{cidr_ipv6}",
+                        "range": cidr_ipv6,
+                        "range_name": cidr_ipv6.split('/')[0],
+                        "ruleid": ruleid,
+                    })
+
+    return rule_rows, range_rows
+
+
 @timeit
-def load_ec2_security_group_rule(neo4j_session: neo4j.Session, group: Dict, rule_type: str, update_tag: int) -> None:
+def load_ec2_security_group_rules(neo4j_session: neo4j.Session, groups: List[Dict], update_tag: int) -> None:
     INGEST_RULE_TEMPLATE = Template("""
-    MERGE (rule:$rule_label{ruleid: $RuleId})
-    ON CREATE SET rule :IpRule, rule.firstseen = timestamp(), rule.fromport = $FromPort, rule.toport = $ToPort,
-    rule.protocol = $Protocol
+    UNWIND $DictList AS item
+    MERGE (rule:$rule_label{ruleid: item.ruleid})
+    ON CREATE SET rule :IpRule, rule.firstseen = timestamp(), rule.fromport = item.from_port,
+    rule.toport = item.to_port,
+    rule.protocol = item.protocol
     SET rule.lastupdated = $update_tag
-    WITH rule
-    MATCH (group:EC2SecurityGroup{groupid: $GroupId})
+    WITH rule, item
+    MATCH (group:EC2SecurityGroup{groupid: item.group_id})
     MERGE (group)<-[r:MEMBER_OF_EC2_SECURITY_GROUP]-(rule)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag;
     """)
 
     ingest_rule_group_pair = """
-    MERGE (group:EC2SecurityGroup{id: $GroupId})
-    ON CREATE SET group.firstseen = timestamp(), group.groupid = $GroupId
+    UNWIND $DictList AS item
+    MERGE (group:EC2SecurityGroup{id: item.group_id})
+    ON CREATE SET group.firstseen = timestamp(), group.groupid = item.group_id
     SET group.lastupdated = $update_tag
-    WITH group
-    MATCH (inbound:IpRule{ruleid: $RuleId})
+    WITH group, item
+    MATCH (inbound:IpRule{ruleid: item.ruleid})
     MERGE (inbound)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
 
     ingest_range = Template("""
-    MERGE (range:$range_label{id: $RangeId})
-    ON CREATE SET range.firstseen = timestamp(), range.range = $Range
-    SET range.lastupdated = $update_tag, range.name = $RangeName
-    WITH range
-    MATCH (rule:IpRule{ruleid: $RuleId})
+    UNWIND $DictList AS item
+    MERGE (range:$range_label{id: item.range_id})
+    ON CREATE SET range.firstseen = timestamp(), range.range = item.range
+    SET range.lastupdated = $update_tag, range.name = item.range_name
+    WITH range, item
+    MATCH (rule:IpRule{ruleid: item.ruleid})
     MERGE (rule)<-[r:MEMBER_OF_IP_RULE]-(range)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """)
 
-    group_id = group["GroupId"]
-    rule_type_map = {"IpPermissions": "IpPermissionInbound", "IpPermissionsEgress": "IpPermissionEgress"}
+    rule_rows, range_rows = _build_rule_and_range_rows(groups)
 
-    if group.get(rule_type):
-        for rule in group[rule_type]:
-            protocol = rule.get("IpProtocol", "all")
-            from_port = rule.get("FromPort")
-            to_port = rule.get("ToPort")
-
-            # NOTE This hardcoding is done because some, rules might be applicable for all protocols in that case the value of
-            # protocol variable would be -1 (or all) this means it will also be available for all ports, hence from_port & to_port values
-            # might not be provided
-            # Docs Link:https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_security_groups.html
-            if protocol == "-1" or protocol == "all":
-                from_port = 0  # the smallest possible IP
-                to_port = 65535  # the largest possible IP
-
-            ruleid = f"{group_id}/{rule_type}/{from_port}{to_port}{protocol}"
-            # NOTE Cypher query syntax is incompatible with Python string formatting, so we have to do this awkward
-            # NOTE manual formatting instead.
-            neo4j_session.run(
-                INGEST_RULE_TEMPLATE.safe_substitute(rule_label=rule_type_map[rule_type]),
-                RuleId=ruleid,
-                FromPort=from_port,
-                ToPort=to_port,
-                Protocol=protocol,
-                GroupId=group_id,
-                update_tag=update_tag,
-            )
-
-            neo4j_session.run(
-                ingest_rule_group_pair,
-                GroupId=group_id,
-                RuleId=ruleid,
-                update_tag=update_tag,
-            )
-
-            for ip_range in rule["IpRanges"]:
-                cidr_ip = ip_range['CidrIp']
-                range_id = f"IpRule/{ruleid}/ipRange/{cidr_ip}"
-                range_name = cidr_ip.split('/')[0]
-                neo4j_session.run(
-                    ingest_range.safe_substitute(range_label='IpRange'),
-                    RangeId=range_id,
-                    Range=cidr_ip,
-                    RangeName=range_name,
-                    RuleId=ruleid,
-                    update_tag=update_tag,
-                )
-
-            for ipv6_range in rule["Ipv6Ranges"]:
-                cidr_ipv6 = ipv6_range['CidrIpv6']
-                range_id = f"IpRule/{ruleid}/ipv6Range/{cidr_ipv6}"
-                range_name = cidr_ipv6.split('/')[0]
-                neo4j_session.run(
-                    ingest_range.safe_substitute(range_label='Ipv6Range'),
-                    RangeId=range_id,
-                    Range=cidr_ipv6,
-                    RangeName=range_name,
-                    RuleId=ruleid,
-                    update_tag=update_tag,
-                )
+    for rule_label, rows in rule_rows.items():
+        load_graph_data(
+            neo4j_session,
+            INGEST_RULE_TEMPLATE.safe_substitute(rule_label=rule_label),
+            rows,
+            update_tag=update_tag,
+        )
+    load_graph_data(
+        neo4j_session,
+        ingest_rule_group_pair,
+        rule_rows["IpPermissionInbound"] + rule_rows["IpPermissionEgress"],
+        update_tag=update_tag,
+    )
+    for range_label, rows in range_rows.items():
+        load_graph_data(
+            neo4j_session,
+            ingest_range.safe_substitute(range_label=range_label),
+            rows,
+            update_tag=update_tag,
+        )
 
 
 @timeit
@@ -156,24 +176,26 @@ def load_ec2_security_groupinfo(
     current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_security_group = """
-    MERGE (group:EC2SecurityGroup{id: $GroupId})
-    ON CREATE SET group.firstseen = timestamp(), group.groupid = $GroupId
-    SET group.name = $GroupName, group.description = $Description,
-    group.consolelink = $consolelink,
-    group.region = $Region,
-    group.lastupdated = $update_tag, group.arn = $GroupArn,
-    group.is_default = $isDefault
-    WITH group
+    UNWIND $DictList AS item
+    MERGE (group:EC2SecurityGroup{id: item.group_id})
+    ON CREATE SET group.firstseen = timestamp(), group.groupid = item.group_id
+    SET group.name = item.group_name, group.description = item.description,
+    group.consolelink = item.consolelink,
+    group.region = item.region,
+    group.lastupdated = $update_tag, group.arn = item.group_arn,
+    group.is_default = item.is_default
+    WITH group, item
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(group)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
-    WITH group
-    MATCH (vpc:AWSVpc{id: $VpcId})
+    WITH group, item
+    MATCH (vpc:AWSVpc{id: item.vpc_id})
     MERGE (vpc)-[rg:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
     ON CREATE SET rg.firstseen = timestamp()
     """
 
+    group_rows = []
     for group in data:
         region = group.get('region', '')
         group_id = group["GroupId"]
@@ -185,22 +207,25 @@ def load_ec2_security_groupinfo(
         except Exception as ex:
             logger.error('failed to generate console link for security group', {"key": group_arn}, ex)
 
-        neo4j_session.run(
-            ingest_security_group,
-            GroupId=group_id,
-            GroupArn=group_arn,
-            consolelink=consolelink,
-            GroupName=group.get("GroupName"),
-            Description=group.get("Description"),
-            VpcId=group.get("VpcId", None),
-            Region=region,
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            update_tag=update_tag,
-            isDefault=group.get("isDefault", None),
-        )
+        group_rows.append({
+            "group_id": group_id,
+            "group_arn": group_arn,
+            "consolelink": consolelink,
+            "group_name": group.get("GroupName"),
+            "description": group.get("Description"),
+            "vpc_id": group.get("VpcId", None),
+            "region": region,
+            "is_default": group.get("isDefault", None),
+        })
 
-        load_ec2_security_group_rule(neo4j_session, group, "IpPermissions", update_tag)
-        load_ec2_security_group_rule(neo4j_session, group, "IpPermissionsEgress", update_tag)
+    load_graph_data(
+        neo4j_session,
+        ingest_security_group,
+        group_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        update_tag=update_tag,
+    )
+    load_ec2_security_group_rules(neo4j_session, data, update_tag)
 
 
 @timeit

--- a/cartography/intel/aws/ec2/security_groups.py
+++ b/cartography/intel/aws/ec2/security_groups.py
@@ -205,7 +205,7 @@ def load_ec2_security_groupinfo(
         try:
             consolelink = aws_console_link.get_console_link(arn=group_arn)
         except Exception as ex:
-            logger.error('failed to generate console link for security group', {"key": group_arn}, ex)
+            logger.error("failed to generate console link for security group %s: %s", group_arn, ex)
 
         group_rows.append({
             "group_id": group_id,

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -8,6 +8,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -77,7 +78,7 @@ def load_snapshots(
         neo4j_session: neo4j.Session, data: List[Dict], current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_snapshots = """
-    UNWIND $snapshots_list as snapshot
+    UNWIND $DictList as snapshot
     MERGE (s:EBSSnapshot{id: snapshot.SnapshotId})
     ON CREATE SET s.firstseen = timestamp()
     SET s.lastupdated = $update_tag, s.description = snapshot.Description, s.encrypted = snapshot.Encrypted,
@@ -100,9 +101,10 @@ def load_snapshots(
         snapshot['Arn'] = f"arn:aws:ec2:{region}:{current_aws_account_id}:snapshot/{snapshot['SnapshotId']}"
         snapshot['consolelink'] = aws_console_link.get_console_link(arn=snapshot['Arn'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_snapshots,
-        snapshots_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         update_tag=update_tag,
     )
@@ -123,7 +125,7 @@ def load_snapshot_volume_relations(
         neo4j_session: neo4j.Session, data: List[Dict], current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_volumes = """
-    UNWIND $snapshot_volumes_list as volume
+    UNWIND $DictList as volume
     MERGE (v:EBSVolume{id: volume.VolumeId})
     ON CREATE SET v.firstseen = timestamp()
     SET v.lastupdated = $update_tag
@@ -139,9 +141,10 @@ def load_snapshot_volume_relations(
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_volumes,
-        snapshot_volumes_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/ec2/subnets.py
+++ b/cartography/intel/aws/ec2/subnets.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.graph.job import GraphJob
 from cartography.models.aws.ec2.subnet_instance import EC2SubnetInstanceSchema
 from cartography.util import aws_handle_regions
@@ -80,7 +81,7 @@ def load_subnets(
 ) -> None:
 
     ingest_subnets = """
-    UNWIND $subnets as subnet
+    UNWIND $DictList as subnet
     MERGE (snet:EC2Subnet{subnetid: subnet.SubnetId})
     ON CREATE SET snet.firstseen = timestamp()
     SET snet.lastupdated = $aws_update_tag, snet.name = subnet.CidrBlock, snet.cidr_block = subnet.CidrBlock,
@@ -94,7 +95,7 @@ def load_subnets(
     """
 
     ingest_subnet_vpc_relations = """
-    UNWIND $subnets as subnet
+    UNWIND $DictList as subnet
     MATCH (snet:EC2Subnet{subnetid: subnet.SubnetId}), (vpc:AWSVpc{id: subnet.VpcId})
     MERGE (snet)-[r:MEMBER_OF_AWS_VPC]->(vpc)
     ON CREATE SET r.firstseen = timestamp()
@@ -102,23 +103,32 @@ def load_subnets(
     """
 
     ingest_subnet_aws_account_relations = """
-    UNWIND $subnets as subnet
+    UNWIND $DictList as subnet
     MATCH (snet:EC2Subnet{subnetid: subnet.SubnetId}), (aws:AWSAccount{id: $aws_account_id})
     MERGE (aws)-[r:RESOURCE]->(snet)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
-        ingest_subnets, subnets=data, aws_update_tag=aws_update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_subnets,
+        data,
+        aws_update_tag=aws_update_tag,
         aws_account_id=aws_account_id,
     )
-    neo4j_session.run(
-        ingest_subnet_vpc_relations, subnets=data, aws_update_tag=aws_update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_subnet_vpc_relations,
+        data,
+        aws_update_tag=aws_update_tag,
         aws_account_id=aws_account_id,
     )
-    neo4j_session.run(
-        ingest_subnet_aws_account_relations, subnets=data, aws_update_tag=aws_update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_subnet_aws_account_relations,
+        data,
+        aws_update_tag=aws_update_tag,
         aws_account_id=aws_account_id,
     )
 

--- a/cartography/intel/aws/ec2/tgw.py
+++ b/cartography/intel/aws/ec2/tgw.py
@@ -9,6 +9,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import run_write_query
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -99,7 +100,8 @@ def load_transit_gateways(
     for tgw in data:
         tgw_id = tgw["TransitGatewayId"]
 
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_transit_gateway,
             TgwId=tgw_id,
             ARN=tgw["TransitGatewayArn"],
@@ -133,7 +135,8 @@ def _attach_shared_transit_gateway(
     """
 
     if tgw["OwnerId"] != current_aws_account_id:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             attach_tgw,
             ARN=tgw["TransitGatewayArn"],
             TransitGatewayId=tgw["TransitGatewayId"],
@@ -174,7 +177,8 @@ def load_tgw_attachments(
         tgwa_id = tgwa["TransitGatewayAttachmentId"]
         tgwa_arn = f"arn:aws:ec2:{region}:{current_aws_account_id}:transit-gateway-attachment/{tgwa_id}"
 
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_transit_gateway,
             TgwAttachmentId=tgwa_id,
             TransitGatewayId=tgwa["TransitGatewayId"],
@@ -226,7 +230,8 @@ def _attach_tgw_vpc_attachment_to_vpc_subnets(
     SET p.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         attach_vpc_tgw_attachment_to_vpc,
         VpcId=tgw_vpc_attachment["VpcId"],
         TgwAttachmentId=tgw_vpc_attachment["TransitGatewayAttachmentId"],
@@ -234,7 +239,8 @@ def _attach_tgw_vpc_attachment_to_vpc_subnets(
     )
 
     for subnet_id in tgw_vpc_attachment["SubnetIds"]:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             attach_vpc_tgw_attachment_to_subnet,
             SubnetId=subnet_id,
             TgwAttachmentId=tgw_vpc_attachment["TransitGatewayAttachmentId"],

--- a/cartography/intel/aws/ec2/volumes.py
+++ b/cartography/intel/aws/ec2/volumes.py
@@ -9,6 +9,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
@@ -88,7 +89,7 @@ def load_volumes(
         neo4j_session: neo4j.Session, data: List[Dict], current_aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_volumes = """
-    UNWIND $volumes_list as volume
+    UNWIND $DictList as volume
         MERGE (vol:EBSVolume{id: volume.VolumeId})
         ON CREATE SET vol.firstseen = timestamp()
         SET vol.arn = volume.VolumeArn,
@@ -117,9 +118,10 @@ def load_volumes(
     for volume in data:
         console_arn = f"arn:aws:ec2:{volume['region']}:{current_aws_account_id}:volume/{volume['VolumeId']}"
         volume['consolelink'] = aws_console_link.get_console_link(arn=console_arn)
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_volumes,
-        volumes_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -10,6 +10,8 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -50,7 +52,7 @@ def _get_cidr_association_statement(block_type: str) -> str:
     INGEST_CIDR_TEMPLATE = Template("""
     MATCH (vpc:AWSVpc{id: $VpcId})
     WITH vpc
-    UNWIND $CidrBlock as block_data
+    UNWIND $DictList as block_data
         MERGE (new_block:$block_label{id: $VpcId + '|' + block_data.$block_cidr})
         ON CREATE SET new_block.firstseen = timestamp()
         SET new_block.association_id = block_data.AssociationId,
@@ -93,10 +95,11 @@ def load_cidr_association_set(
     else:
         data = vpc_data.get("CidrBlockAssociationSet", [])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_statement,
+        data,
         VpcId=vpc_id,
-        CidrBlock=data,
         update_tag=update_tag,
     )
 
@@ -166,7 +169,8 @@ def load_ec2_vpcs(
                 vpc_name = tag.get("Value")
                 break
 
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_vpc,
             VpcId=vpc_id,
             InstanceTenancy=vpc.get("InstanceTenancy", None),

--- a/cartography/intel/aws/ec2/vpc_peerings.py
+++ b/cartography/intel/aws/ec2/vpc_peerings.py
@@ -8,6 +8,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load_graph_data
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -36,7 +37,7 @@ def load_vpc_peerings(
     aws_account_id: str, update_tag: int,
 ) -> None:
     ingest_vpc_peerings = """
-    UNWIND $vpc_peerings AS vpc_peering
+    UNWIND $DictList AS vpc_peering
 
     MERGE (pcx:AWSPeeringConnection{id: vpc_peering.VpcPeeringConnectionId})
     ON CREATE SET pcx.firstseen = timestamp()
@@ -93,8 +94,11 @@ def load_vpc_peerings(
         item['arn'] = f"arn:aws:ec2:{region}:{aws_account_id}:vpc-peering-connection/{item['VpcPeeringConnectionId']}"
         item['consolelink'] = aws_console_link.get_console_link(arn=item['arn'])
 
-    neo4j_session.run(
-        ingest_vpc_peerings, vpc_peerings=data, update_tag=update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_vpc_peerings,
+        data,
+        update_tag=update_tag,
         region=region, aws_account_id=aws_account_id,
     )
 
@@ -106,7 +110,7 @@ def load_accepter_cidrs(
 ) -> None:
 
     ingest_accepter_cidr = """
-    UNWIND $vpc_peerings AS vpc_peering
+    UNWIND $DictList AS vpc_peering
     UNWIND vpc_peering.AccepterVpcInfo.CidrBlockSet AS c_b
 
     MERGE (ac_b:AWSCidrBlock:AWSIpv4CidrBlock{id: vpc_peering.AccepterVpcInfo.VpcId + '|' + c_b.CidrBlock})
@@ -126,8 +130,11 @@ def load_accepter_cidrs(
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
-        ingest_accepter_cidr, vpc_peerings=data, update_tag=update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_accepter_cidr,
+        data,
+        update_tag=update_tag,
         region=region, aws_account_id=aws_account_id,
     )
 
@@ -139,7 +146,7 @@ def load_requester_cidrs(
 ) -> None:
 
     ingest_requester_cidr = """
-    UNWIND $vpc_peerings AS vpc_peering
+    UNWIND $DictList AS vpc_peering
     UNWIND vpc_peering.RequesterVpcInfo.CidrBlockSet AS c_b
 
     MERGE (rc_b:AWSCidrBlock:AWSIpv4CidrBlock{id: vpc_peering.RequesterVpcInfo.VpcId + '|' + c_b.CidrBlock})
@@ -159,8 +166,11 @@ def load_requester_cidrs(
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
-        ingest_requester_cidr, vpc_peerings=data, update_tag=update_tag,
+    load_graph_data(
+        neo4j_session,
+        ingest_requester_cidr,
+        data,
+        update_tag=update_tag,
         region=region, aws_account_id=aws_account_id,
     )
 

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -8,6 +8,7 @@ import boto3
 import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import batch
@@ -76,7 +77,7 @@ def load_ecr_repositories(
     aws_update_tag: int,
 ) -> None:
     query = """
-    UNWIND $Repositories as ecr_repo
+    UNWIND $DictList as ecr_repo
         MERGE (repo:ECRRepository{id: ecr_repo.repositoryArn})
         ON CREATE SET repo.firstseen = timestamp(),
             repo.arn = ecr_repo.repositoryArn,
@@ -93,12 +94,13 @@ def load_ecr_repositories(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        Repositories=repos,
+        repos,
         aws_update_tag=aws_update_tag,
         AWS_ACCOUNT_ID=current_aws_account_id,
-    ).consume()  # See issue #440
+    )
 
 
 @timeit

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -9,6 +9,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import camel_to_snake
@@ -140,7 +141,7 @@ def load_ecs_clusters(
     aws_update_tag: int,
 ) -> None:
     ingest_clusters = """
-    UNWIND $Clusters AS cluster
+    UNWIND $DictList AS cluster
         MERGE (c:ECSCluster{id: cluster.clusterArn})
         ON CREATE SET c.firstseen = timestamp()
         SET c.name = cluster.clusterName, c.region = cluster.region,
@@ -171,9 +172,10 @@ def load_ecs_clusters(
 
         clusters.append(cluster)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_clusters,
-        Clusters=clusters,
+        clusters,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -189,7 +191,7 @@ def load_ecs_container_instances(
     aws_update_tag: int,
 ) -> None:
     ingest_instances = """
-    UNWIND $Instances AS instance
+    UNWIND $DictList AS instance
         MERGE (i:ECSContainerInstance{id: instance.containerInstanceArn})
         ON CREATE SET i.firstseen = timestamp()
         SET i.ec2_instance_id = instance.ec2InstanceId, i.region = $Region,
@@ -216,10 +218,11 @@ def load_ecs_container_instances(
         instance["registeredAt"] = dict_date_to_epoch(instance, "registeredAt")
         instances.append(instance)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_instances,
+        instances,
         ClusterARN=cluster_arn,
-        Instances=instances,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -236,7 +239,7 @@ def load_ecs_services(
     aws_update_tag: int,
 ) -> None:
     ingest_services = """
-    UNWIND $Services AS service
+    UNWIND $DictList AS service
         MERGE (s:ECSService{id: service.serviceArn})
         ON CREATE SET s.firstseen = timestamp()
         SET s.name = service.serviceName, s.region = $Region,
@@ -279,10 +282,11 @@ def load_ecs_services(
         service["createdAt"] = dict_date_to_epoch(service, "createdAt")
         services.append(service)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_services,
+        services,
         ClusterARN=cluster_arn,
-        Services=services,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -298,7 +302,7 @@ def load_ecs_task_definitions(
     aws_update_tag: int,
 ) -> None:
     ingest_task_definitions = """
-    UNWIND $Definitions AS def
+    UNWIND $DictList AS def
         MERGE (d:ECSTaskDefinition{id: def.taskDefinitionArn})
         ON CREATE SET d.firstseen = timestamp()
         SET d.arn = def.taskDefinitionArn, d.region = $Region,
@@ -350,9 +354,10 @@ def load_ecs_task_definitions(
 
         task_definitions.append(task_definition)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_task_definitions,
-        Definitions=task_definitions,
+        task_definitions,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -377,7 +382,7 @@ def load_ecs_tasks(
     aws_update_tag: int,
 ) -> None:
     ingest_tasks = """
-    UNWIND $Tasks AS task
+    UNWIND $DictList AS task
         MERGE (t:ECSTask{id: task.taskArn})
         ON CREATE SET t.firstseen = timestamp()
         SET t.arn = task.taskArn, t.region = $Region,
@@ -441,10 +446,11 @@ def load_ecs_tasks(
         containers.extend(task["containers"])
         tasks.append(task)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_tasks,
+        tasks,
         ClusterARN=cluster_arn,
-        Tasks=tasks,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -468,7 +474,7 @@ def load_ecs_container_definitions(
     aws_update_tag: int,
 ) -> None:
     ingest_definitions = """
-    UNWIND $Definitions AS def
+    UNWIND $DictList AS def
         MERGE (d:ECSContainerDefinition{id: def._taskDefinitionArn + "-" + def.name})
         ON CREATE SET d.firstseen = timestamp()
         SET d.task_definition_arn = def._taskDefinitionArn, d.region = $Region,
@@ -501,9 +507,10 @@ def load_ecs_container_definitions(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_definitions,
-        Definitions=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
@@ -519,7 +526,7 @@ def load_ecs_containers(
     aws_update_tag: int,
 ) -> None:
     ingest_containers = """
-    UNWIND $Containers AS container
+    UNWIND $DictList AS container
         MERGE (c:ECSContainer{id: container.containerArn})
         ON CREATE SET c.firstseen = timestamp()
         SET c.arn = container.containerArn, c.region = $Region,
@@ -543,9 +550,10 @@ def load_ecs_containers(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_containers,
-        Containers=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,

--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -9,6 +9,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import load_graph_data
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.eks.clusters import EKSClusterSchema
@@ -158,7 +159,7 @@ def get_auto_scaling_groups(boto3_session: boto3.session.Session, region: str, a
 @timeit
 def attact_autoscaling_groups_to_nodegroups(neo4j_session: neo4j.Session, nodegroup_arn: str, auto_scalin_groups: List[Dict], update_tag: int) -> None:
     attach_autoscaling = """
-    UNWIND $auto_scalin_groups as agroup
+    UNWIND $DictList as agroup
     MERGE (g:AutoScalingGroup{arn: agroup.AutoScalingGroupARN})
     ON CREATE SET g.firstseen = timestamp()
     SET g.lastupdated = $update_tag
@@ -168,9 +169,10 @@ def attact_autoscaling_groups_to_nodegroups(neo4j_session: neo4j.Session, nodegr
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_autoscaling,
-        auto_scalin_groups=auto_scalin_groups,
+        auto_scalin_groups,
         GROUPARN=nodegroup_arn,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/elasticache.py
+++ b/cartography/intel/aws/elasticache.py
@@ -8,6 +8,7 @@ import boto3
 import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
@@ -60,7 +61,7 @@ def load_elasticache_clusters(
     aws_account_id: str, update_tag: int,
 ) -> None:
     query = """
-    UNWIND $clusters as elasticache_cluster
+    UNWIND $DictList as elasticache_cluster
         MERGE (cluster:ElasticacheCluster{id:elasticache_cluster.ARN})
         ON CREATE SET cluster.firstseen = timestamp(),
             cluster.arn = elasticache_cluster.ARN,
@@ -94,9 +95,10 @@ def load_elasticache_clusters(
         SET r2.lastupdated = $aws_update_tag
     """
     logger.info(f"Loading f{len(clusters)} ElastiCache clusters into graph.")
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        clusters=clusters,
+        clusters,
         aws_update_tag=update_tag,
         aws_account_id=aws_account_id,
     )
@@ -105,7 +107,7 @@ def load_elasticache_clusters(
 @timeit
 def attach_elasticache_clusters_to_security_groups(neo4j_session: neo4j.Session, clusters: List[Dict], update_tag: int) -> None:
     query = """
-    UNWIND $clusters as elasticache_cluster
+    UNWIND $DictList as elasticache_cluster
         MATCH (cluster:ElasticacheCluster{id:elasticache_cluster.ARN})
         UNWIND elasticache_cluster.SecurityGroups as sg
             MERGE (security_group:EC2SecurityGroup{id: sg.SecurityGroupId})
@@ -116,9 +118,10 @@ def attach_elasticache_clusters_to_security_groups(neo4j_session: neo4j.Session,
             ON CREATE SET r.firstseen = timestamp()
             SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        clusters=clusters,
+        clusters,
         aws_update_tag=update_tag,
     )
 

--- a/cartography/intel/aws/elasticache.py
+++ b/cartography/intel/aws/elasticache.py
@@ -94,7 +94,7 @@ def load_elasticache_clusters(
         ON CREATE SET r2.firstseen = timestamp()
         SET r2.lastupdated = $aws_update_tag
     """
-    logger.info(f"Loading f{len(clusters)} ElastiCache clusters into graph.")
+    logger.info(f"Loading {len(clusters)} ElastiCache clusters into graph.")
     load_graph_data(
         neo4j_session,
         query,

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -11,6 +11,8 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 from policyuniverse.policy import Policy
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.intel.dns import ingest_dns_record_by_fqdn
 from cartography.util import aws_handle_regions
@@ -68,7 +70,7 @@ def _load_es_domains(
     :param domains: Domain list to ingest
     """
     ingest_records = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (es:ESDomain{id: record.DomainId})
     ON CREATE SET es.firstseen = timestamp(), es.arn = record.ARN, es.domainid = record.DomainId
     SET es.lastupdated = $aws_update_tag, es.deleted = record.Deleted, es.created = record.created,
@@ -102,9 +104,10 @@ def _load_es_domains(
     for d in domain_list:
         del d['ServiceSoftwareOptions']
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        Records=domain_list,
+        domain_list,
         AWS_ACCOUNT_ID=aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -151,7 +154,7 @@ def _link_es_domain_vpc(neo4j_session: neo4j.Session, domain_id: str, domain_dat
     ingest_subnet = """
     MATCH (es:ESDomain{id: $DomainId})
     WITH es
-    UNWIND $SubnetList as subnet_id
+    UNWIND $DictList as subnet_id
         MATCH (subnet_node:EC2Subnet{id: subnet_id})
         MERGE (es)-[r:PART_OF_SUBNET]->(subnet_node)
         ON CREATE SET r.firstseen = timestamp()
@@ -161,7 +164,7 @@ def _link_es_domain_vpc(neo4j_session: neo4j.Session, domain_id: str, domain_dat
     ingest_sec_groups = """
     MATCH (es:ESDomain{id: $DomainId})
     WITH es
-    UNWIND $SecGroupList as ecsecgroup_id
+    UNWIND $DictList as ecsecgroup_id
         MATCH (group_node:EC2SecurityGroup{id: ecsecgroup_id})
         MERGE (es)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group_node)
         ON CREATE SET r.firstseen = timestamp()
@@ -173,21 +176,20 @@ def _link_es_domain_vpc(neo4j_session: neo4j.Session, domain_id: str, domain_dat
         subnetList = vpc_data.get("SubnetIds", [])
         groupList = vpc_data.get("SecurityGroupIds", [])
 
-        if len(subnetList) > 0:
-            neo4j_session.run(
-                ingest_subnet,
-                DomainId=domain_id,
-                SubnetList=subnetList,
-                aws_update_tag=aws_update_tag,
-            )
-
-        if len(groupList) > 0:
-            neo4j_session.run(
-                ingest_sec_groups,
-                DomainId=domain_id,
-                SecGroupList=groupList,
-                aws_update_tag=aws_update_tag,
-            )
+        load_graph_data(
+            neo4j_session,
+            ingest_subnet,
+            subnetList,
+            DomainId=domain_id,
+            aws_update_tag=aws_update_tag,
+        )
+        load_graph_data(
+            neo4j_session,
+            ingest_sec_groups,
+            groupList,
+            DomainId=domain_id,
+            aws_update_tag=aws_update_tag,
+        )
 
 
 @timeit
@@ -209,7 +211,7 @@ def _process_access_policy(neo4j_session: neo4j.Session, domain_id: str, domain_
         if policy.is_internet_accessible():
             exposed_internet = True
 
-    neo4j_session.run(tag_es, DomainId=domain_id, InternetExposed=exposed_internet)
+    run_write_query(neo4j_session, tag_es, DomainId=domain_id, InternetExposed=exposed_internet)
 
 
 @timeit

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -155,7 +155,7 @@ def _link_es_domain_vpc(neo4j_session: neo4j.Session, domain_id: str, domain_dat
     MATCH (es:ESDomain{id: $DomainId})
     WITH es
     UNWIND $DictList as subnet_id
-        MATCH (subnet_node:EC2Subnet{id: subnet_id})
+        MATCH (subnet_node:EC2Subnet{subnetid: subnet_id})
         MERGE (es)-[r:PART_OF_SUBNET]->(subnet_node)
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -818,9 +818,10 @@ def load_roles(
 @timeit
 def load_group_memberships(neo4j_session: neo4j.Session, group_memberships: Dict, aws_update_tag: int) -> None:
     ingest_membership = """
-    MATCH (group:AWSGroup{arn: $GroupArn})
-    WITH group
-    MATCH (user:AWSPrincipal{arn: $PrincipalArn})
+    UNWIND $DictList AS item
+    MATCH (group:AWSGroup{arn: item.group_arn})
+    WITH group, item
+    MATCH (user:AWSPrincipal{arn: item.principal_arn})
     WHERE user:AWSUser OR user:AWSServiceAccount
     MERGE (user)-[r:MEMBER_AWS_GROUP]->(group)
     ON CREATE SET r.firstseen = timestamp()
@@ -831,15 +832,12 @@ def load_group_memberships(neo4j_session: neo4j.Session, group_memberships: Dict
     SET r2.lastupdated = $aws_update_tag
     """
 
-    for group_arn, membership_data in group_memberships.items():
-        for info in membership_data.get("Users", []):
-            principal_arn = info["Arn"]
-            neo4j_session.run(
-                ingest_membership,
-                GroupArn=group_arn,
-                PrincipalArn=principal_arn,
-                aws_update_tag=aws_update_tag,
-            )
+    membership_rows = [
+        {"group_arn": group_arn, "principal_arn": info["Arn"]}
+        for group_arn, membership_data in group_memberships.items()
+        for info in membership_data.get("Users", [])
+    ]
+    load_graph_data(neo4j_session, ingest_membership, membership_rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
@@ -881,9 +879,10 @@ def sync_assumerole_relationships(
     """
 
     ingest_policies_assume_role = """
-    MATCH (source:AWSPrincipal{arn: $SourceArn})
-    WITH source
-    MATCH (role:AWSRole{arn: $TargetArn})
+    UNWIND $DictList AS item
+    MATCH (source:AWSPrincipal{arn: item.source_arn})
+    WITH source, item
+    MATCH (role:AWSRole{arn: item.target_arn})
     WITH role, source
     MERGE (source)-[r:STS_ASSUMEROLE_ALLOW]->(role)
     ON CREATE SET r.firstseen = timestamp()
@@ -895,15 +894,14 @@ def sync_assumerole_relationships(
         AccountId=current_aws_account_id,
     )
     potential_matches = [(r["source_arn"], r["target_arn"]) for r in results]
-    for source_arn, target_arn in potential_matches:
-        policies = get_policies_for_principal(neo4j_session, source_arn)
-        if principal_allowed_on_resource(policies, target_arn, ["sts:AssumeRole"]):
-            neo4j_session.run(
-                ingest_policies_assume_role,
-                SourceArn=source_arn,
-                TargetArn=target_arn,
-                aws_update_tag=aws_update_tag,
-            )
+    allowed_rows = [
+        {"source_arn": source_arn, "target_arn": target_arn}
+        for source_arn, target_arn in potential_matches
+        if principal_allowed_on_resource(
+            get_policies_for_principal(neo4j_session, source_arn), target_arn, ["sts:AssumeRole"],
+        )
+    ]
+    load_graph_data(neo4j_session, ingest_policies_assume_role, allowed_rows, aws_update_tag=aws_update_tag)
     run_cleanup_job(
         "aws_import_roles_policy_cleanup.json",
         neo4j_session,
@@ -922,18 +920,19 @@ def load_user_access_keys(
     # To rotate key there is no option in aws. we need to create new and delete existing key that's why rotatedate same as createdate
     # TODO change the node label to reflect that this is a user access key, not an account access key
     ingest_account_key = """
-    MATCH (user:AWSPrincipal{arn: $ARN})
+    UNWIND $DictList AS item
+    MATCH (user:AWSPrincipal{arn: item.arn})
     WHERE user:AWSUser OR user:AWSServiceAccount
-    WITH user
-    MERGE (key:AccountAccessKey{accesskeyid: $AccessKeyId})
+    WITH user, item
+    MERGE (key:AccountAccessKey{accesskeyid: item.accesskeyid})
     ON CREATE SET key.firstseen = timestamp(),
-    key.region = $region,
-    key.createdate = $CreateDate,
-    key.rotatedate = $CreateDate,
+    key.region = 'global',
+    key.createdate = item.createdate,
+    key.rotatedate = item.createdate,
     key.consolelink = $consolelink
-    SET key.status = $Status,
-    key.keyage = $KeyAge,
-    key.lastuseddate = $LastUsedDate,
+    SET key.status = item.status,
+    key.keyage = item.keyage,
+    key.lastuseddate = item.lastuseddate,
     key.lastupdated = $aws_update_tag
     WITH user,key
     MERGE (user)-[r:AWS_ACCESS_KEY]->(key)
@@ -941,21 +940,23 @@ def load_user_access_keys(
     SET r.lastupdated = $aws_update_tag
     """
 
-    for arn, access_keys in user_access_keys.items():
-        for key in access_keys["AccessKeyMetadata"]:
-            if key.get("AccessKeyId"):
-                neo4j_session.run(
-                    ingest_account_key,
-                    consolelink=consolelink,
-                    ARN=arn,
-                    AccessKeyId=key["AccessKeyId"],
-                    LastUsedDate=str(key.get("LastUsedDate", "")),
-                    CreateDate=str(key.get("CreateDate", "")),
-                    KeyAge=str(key.get("KeyAge", "")),
-                    Status=key["Status"],
-                    region="global",
-                    aws_update_tag=aws_update_tag,
-                )
+    access_key_rows = [
+        {
+            "arn": arn,
+            "accesskeyid": key["AccessKeyId"],
+            "lastuseddate": str(key.get("LastUsedDate", "")),
+            "createdate": str(key.get("CreateDate", "")),
+            "keyage": str(key.get("KeyAge", "")),
+            "status": key["Status"],
+        }
+        for arn, access_keys in user_access_keys.items()
+        for key in access_keys["AccessKeyMetadata"]
+        if key.get("AccessKeyId")
+    ]
+    load_graph_data(
+        neo4j_session, ingest_account_key, access_key_rows,
+        consolelink=consolelink, aws_update_tag=aws_update_tag,
+    )
 
 
 def ensure_list(obj: Any) -> List[Any]:
@@ -1163,6 +1164,98 @@ def load_policy_statements(
     ).consume()
 
 
+def _batch_load_policies(
+    neo4j_session: neo4j.Session,
+    policy_rows: List[Dict],
+    policy_type: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Batched equivalent of _load_policy_tx: one UNWIND write linking policies to
+    principals matched by arn, and one matching principals by id (SSO principals).
+    """
+    if policy_type == PolicyType.managed.value:
+        create_clause = """
+        ON CREATE SET
+        policy.firstseen = timestamp()
+        """
+    else:
+        create_clause = """
+        ON CREATE SET
+        policy.firstseen = timestamp(),
+        policy.type = $PolicyType,
+        policy.region = 'global',
+        policy.name = item.policy_name,
+        policy.arn = item.policy_arn,
+        policy.managed_type = $ManagedType,
+        policy.consolelink = item.consolelink
+        """
+
+    ingest_policy = f"""
+    UNWIND $DictList AS item
+    MERGE (policy:AWSPolicy{{id: item.policy_id}})
+    {create_clause}
+    SET policy.lastupdated = $aws_update_tag
+    WITH policy, item
+    MATCH (principal:AWSPrincipal{{arn: item.principal_arn}})
+    MERGE (policy) <-[r:POLICY]-(principal)
+    SET r.lastupdated = $aws_update_tag
+    """
+    ingest_sso_policy = f"""
+    UNWIND $DictList AS item
+    MERGE (policy:AWSPolicy{{id: item.policy_id}})
+    {create_clause}
+    SET policy.lastupdated = $aws_update_tag
+    WITH policy, item
+    MATCH (principal:AWSPrincipal{{id: item.principal_arn}})
+    MERGE (policy) <-[r:POLICY]-(principal)
+    SET r.lastupdated = $aws_update_tag
+    """
+    for query in (ingest_policy, ingest_sso_policy):
+        load_graph_data(
+            neo4j_session,
+            query,
+            policy_rows,
+            PolicyType=policy_type,
+            ManagedType=MANAGED_TYPE_CUSTOM,
+            aws_update_tag=aws_update_tag,
+        )
+
+
+def _batch_load_policy_statements(
+    neo4j_session: neo4j.Session,
+    statement_rows: List[Dict],
+    aws_update_tag: int,
+    consolelink: str,
+) -> None:
+    """Batched equivalent of load_policy_statements: one write for all policies."""
+    ingest_policy_statement = """
+        UNWIND $DictList AS item
+        MATCH (policy:AWSPolicy{id: item.policy_id})
+        WITH policy, item
+        UNWIND item.statements as statement_data
+        MERGE (statement:AWSPolicyStatement{id: statement_data.id})
+        SET
+        statement.effect = statement_data.Effect,
+        statement.action = statement_data.Action,
+        statement.region = 'global',
+        statement.consolelink = $consolelink,
+        statement.notaction = statement_data.NotAction,
+        statement.resource = statement_data.Resource,
+        statement.notresource = statement_data.NotResource,
+        statement.condition = statement_data.Condition,
+        statement.sid = statement_data.Sid,
+        statement.lastupdated = $aws_update_tag
+        MERGE (policy)-[r:STATEMENT]->(statement)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = $aws_update_tag
+        """
+    load_graph_data(
+        neo4j_session, ingest_policy_statement, statement_rows,
+        consolelink=consolelink, aws_update_tag=aws_update_tag,
+    )
+
+
 @timeit
 def load_policy_data(
     neo4j_session: neo4j.Session,
@@ -1171,21 +1264,25 @@ def load_policy_data(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
+    policy_rows = []
+    statement_rows = []
     for principal_arn, policy_list in policy_map.items():
         logger.debug(f"Syncing IAM policies for principal {principal_arn}")
         for policy_name, statements in policy_list.items():
-            consolelink = ""
             policy_id = transform_policy_id(current_aws_account_id, policy_type, policy_name)
-            load_policy(
-                neo4j_session,
-                policy_id,
-                policy_name,
-                policy_type,
-                principal_arn,
-                current_aws_account_id,
-                aws_update_tag,
-            )
-            load_policy_statements(neo4j_session, policy_id, policy_name, statements, aws_update_tag, consolelink)
+            policy = policy_name.split("/")[-1]
+            policy_arn = f"arn:aws:iam::{current_aws_account_id}:policy/{policy}"
+            policy_rows.append({
+                "policy_id": policy_id,
+                "policy_name": policy_name,
+                "principal_arn": principal_arn,
+                "policy_arn": policy_arn,
+                "consolelink": aws_console_link.get_console_link(arn=policy_arn),
+            })
+            statement_rows.append({"policy_id": policy_id, "statements": statements})
+
+    _batch_load_policies(neo4j_session, policy_rows, policy_type, aws_update_tag)
+    _batch_load_policy_statements(neo4j_session, statement_rows, aws_update_tag, consolelink="")
 
 
 @timeit

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -16,6 +16,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
 from cartography.util import run_cleanup_job
@@ -473,15 +474,16 @@ def load_users(
     aws_update_tag: int,
 ) -> None:
     ingest_user = """
-    MERGE (unode:AWSUser{arn: $ARN})
-    ON CREATE SET unode:AWSPrincipal, unode.userid = $USERID, unode.firstseen = timestamp(),
-    unode.consolelink = $consolelink,
-    unode.createdate = $CREATE_DATE
-    SET unode.name = $USERNAME, unode.user_name = $USERNAME,
-    unode.path = $PATH, unode.passwordlastused = $PASSWORD_LASTUSED,
-    unode.region = $region,
-    unode.consoleloginenabled = $CONSOLELOGINENABLED,
-    unode.mfaenabled = $MFAENABLED,
+    UNWIND $DictList AS item
+    MERGE (unode:AWSUser{arn: item.arn})
+    ON CREATE SET unode:AWSPrincipal, unode.userid = item.userid, unode.firstseen = timestamp(),
+    unode.consolelink = item.consolelink,
+    unode.createdate = item.createdate
+    SET unode.name = item.username, unode.user_name = item.username,
+    unode.path = item.path, unode.passwordlastused = item.passwordlastused,
+    unode.region = 'global',
+    unode.consoleloginenabled = item.consoleloginenabled,
+    unode.mfaenabled = item.mfaenabled,
     unode.managed_type = $ManagedType,
     unode.lastupdated = $aws_update_tag
     WITH unode
@@ -491,23 +493,28 @@ def load_users(
     SET r.lastupdated = $aws_update_tag
     """
     logger.info(f"Loading {len(users)} IAM users.")
-    for user in users:
-        neo4j_session.run(
-            ingest_user,
-            ARN=user["Arn"],
-            consolelink=aws_console_link.get_console_link(arn=user["Arn"]),
-            USERID=user["UserId"],
-            CREATE_DATE=str(user["CreateDate"]),
-            USERNAME=user["UserName"],
-            PATH=user["Path"],
-            CONSOLELOGINENABLED=user.get("consoleLoginEnabled", False),
-            MFAENABLED=user.get("MFAEnabled", False),
-            PASSWORD_LASTUSED=str(user.get("PasswordLastUsed", "")),
-            ManagedType=MANAGED_TYPE_CUSTOM,
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            region="global",
-            aws_update_tag=aws_update_tag,
-        )
+    user_rows = [
+        {
+            "arn": user["Arn"],
+            "consolelink": aws_console_link.get_console_link(arn=user["Arn"]),
+            "userid": user["UserId"],
+            "createdate": str(user["CreateDate"]),
+            "username": user["UserName"],
+            "path": user["Path"],
+            "consoleloginenabled": user.get("consoleLoginEnabled", False),
+            "mfaenabled": user.get("MFAEnabled", False),
+            "passwordlastused": str(user.get("PasswordLastUsed", "")),
+        }
+        for user in users
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_user,
+        user_rows,
+        ManagedType=MANAGED_TYPE_CUSTOM,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+    )
 
 
 @timeit
@@ -518,15 +525,16 @@ def load_service_accounts(
     aws_update_tag: int,
 ) -> None:
     ingest_service_account = """
-    MERGE (sanode:AWSServiceAccount{arn: $ARN})
-    ON CREATE SET sanode:AWSPrincipal, sanode.userid = $USERID, sanode.firstseen = timestamp(),
-    sanode.consolelink = $consolelink,
-    sanode.createdate = $CREATE_DATE
-    SET sanode.name = $USERNAME, sanode.user_name = $USERNAME,
-    sanode.path = $PATH, sanode.passwordlastused = $PASSWORD_LASTUSED,
-    sanode.region = $region,
-    sanode.consoleloginenabled = $CONSOLELOGINENABLED,
-    sanode.mfaenabled = $MFAENABLED,
+    UNWIND $DictList AS item
+    MERGE (sanode:AWSServiceAccount{arn: item.arn})
+    ON CREATE SET sanode:AWSPrincipal, sanode.userid = item.userid, sanode.firstseen = timestamp(),
+    sanode.consolelink = item.consolelink,
+    sanode.createdate = item.createdate
+    SET sanode.name = item.username, sanode.user_name = item.username,
+    sanode.path = item.path, sanode.passwordlastused = item.passwordlastused,
+    sanode.region = 'global',
+    sanode.consoleloginenabled = item.consoleloginenabled,
+    sanode.mfaenabled = item.mfaenabled,
     sanode.managed_type = $ManagedType,
     sanode.lastupdated = $aws_update_tag
     WITH sanode
@@ -536,23 +544,28 @@ def load_service_accounts(
     SET r.lastupdated = $aws_update_tag
     """
     logger.info(f"Loading {len(service_accounts)} IAM service accounts.")
-    for sa in service_accounts:
-        neo4j_session.run(
-            ingest_service_account,
-            ARN=sa["Arn"],
-            consolelink=aws_console_link.get_console_link(arn=sa["Arn"]),
-            USERID=sa["UserId"],
-            CREATE_DATE=str(sa["CreateDate"]),
-            USERNAME=sa["UserName"],
-            PATH=sa["Path"],
-            CONSOLELOGINENABLED=sa.get("consoleLoginEnabled", False),
-            MFAENABLED=sa.get("MFAEnabled", False),
-            PASSWORD_LASTUSED=str(sa.get("PasswordLastUsed", "")),
-            ManagedType=MANAGED_TYPE_CUSTOM,
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            region="global",
-            aws_update_tag=aws_update_tag,
-        )
+    sa_rows = [
+        {
+            "arn": sa["Arn"],
+            "consolelink": aws_console_link.get_console_link(arn=sa["Arn"]),
+            "userid": sa["UserId"],
+            "createdate": str(sa["CreateDate"]),
+            "username": sa["UserName"],
+            "path": sa["Path"],
+            "consoleloginenabled": sa.get("consoleLoginEnabled", False),
+            "mfaenabled": sa.get("MFAEnabled", False),
+            "passwordlastused": str(sa.get("PasswordLastUsed", "")),
+        }
+        for sa in service_accounts
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_service_account,
+        sa_rows,
+        ManagedType=MANAGED_TYPE_CUSTOM,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+    )
 
 
 def _is_service_account(user: Dict) -> bool:
@@ -634,11 +647,12 @@ def load_groups(
     aws_update_tag: int,
 ) -> None:
     ingest_group = """
-    MERGE (gnode:AWSGroup{arn: $ARN})
-    ON CREATE SET gnode.groupid = $GROUP_ID, gnode.firstseen = timestamp(), gnode.createdate = $CREATE_DATE
-    SET gnode:AWSPrincipal, gnode.name = $GROUP_NAME, gnode.path = $PATH,
-    gnode.region = $region,
-    gnode.consolelink = $consolelink,
+    UNWIND $DictList AS item
+    MERGE (gnode:AWSGroup{arn: item.arn})
+    ON CREATE SET gnode.groupid = item.groupid, gnode.firstseen = timestamp(), gnode.createdate = item.createdate
+    SET gnode:AWSPrincipal, gnode.name = item.groupname, gnode.path = item.path,
+    gnode.region = 'global',
+    gnode.consolelink = item.consolelink,
     gnode.managed_type = $ManagedType,
     gnode.lastupdated = $aws_update_tag
     WITH gnode
@@ -648,20 +662,25 @@ def load_groups(
     SET r.lastupdated = $aws_update_tag
     """
     logger.info(f"Loading {len(groups)} IAM groups to the graph.")
-    for group in groups:
-        neo4j_session.run(
-            ingest_group,
-            ARN=group["Arn"],
-            consolelink=aws_console_link.get_console_link(arn=group["Arn"]),
-            GROUP_ID=group["GroupId"],
-            CREATE_DATE=str(group["CreateDate"]),
-            GROUP_NAME=group["GroupName"],
-            PATH=group["Path"],
-            ManagedType=MANAGED_TYPE_CUSTOM,
-            region="global",
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            aws_update_tag=aws_update_tag,
-        )
+    group_rows = [
+        {
+            "arn": group["Arn"],
+            "consolelink": aws_console_link.get_console_link(arn=group["Arn"]),
+            "groupid": group["GroupId"],
+            "createdate": str(group["CreateDate"]),
+            "groupname": group["GroupName"],
+            "path": group["Path"],
+        }
+        for group in groups
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_group,
+        group_rows,
+        ManagedType=MANAGED_TYPE_CUSTOM,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+    )
 
 
 def _parse_principal_entries(principal: Dict) -> List[Tuple[Any, Any]]:

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -706,17 +706,18 @@ def load_roles(
     aws_update_tag: int,
 ) -> None:
     ingest_role = """
-    MERGE (rnode:AWSRole{arn: $Arn})
-    ON CREATE SET rnode:AWSPrincipal, rnode.roleid = $RoleId, rnode.firstseen = timestamp(),
-    rnode.region = $region,
-    rnode.consolelink = $consolelink,
-    rnode.createdate = $CreateDate
-    SET rnode.name = $RoleName, rnode.path = $Path,
-    rnode.lastuseddate = $LastUsedDate, rnode.lastusedregion = $LastUsedRegion,
-    rnode.is_service_role = $IsServiceRole,
-    rnode.is_sso_reserved_role = $IsSSOReservedRole,
-    rnode.type = $Type,
-    rnode.managed_type = $ManagedType
+    UNWIND $DictList AS item
+    MERGE (rnode:AWSRole{arn: item.arn})
+    ON CREATE SET rnode:AWSPrincipal, rnode.roleid = item.roleid, rnode.firstseen = timestamp(),
+    rnode.region = 'global',
+    rnode.consolelink = item.consolelink,
+    rnode.createdate = item.createdate
+    SET rnode.name = item.rolename, rnode.path = item.path,
+    rnode.lastuseddate = item.lastuseddate, rnode.lastusedregion = item.lastusedregion,
+    rnode.is_service_role = item.is_service_role,
+    rnode.is_sso_reserved_role = item.is_sso_reserved_role,
+    rnode.type = item.type,
+    rnode.managed_type = item.managed_type
     SET rnode.lastupdated = $aws_update_tag
     WITH rnode
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
@@ -726,24 +727,26 @@ def load_roles(
     """
 
     ingest_policy_statement = """
-    MERGE (spnnode:AWSPrincipal{arn: $SpnArn})
+    UNWIND $DictList AS item
+    MERGE (spnnode:AWSPrincipal{arn: item.spn_arn})
     ON CREATE SET spnnode.firstseen = timestamp()
-    SET spnnode.lastupdated = $aws_update_tag, spnnode.type = $SpnType
-    WITH spnnode
-    MATCH (role:AWSRole{arn: $RoleArn})
+    SET spnnode.lastupdated = $aws_update_tag, spnnode.type = item.spn_type
+    WITH spnnode, item
+    MATCH (role:AWSRole{arn: item.role_arn})
     MERGE (role)-[r:TRUSTS_AWS_PRINCIPAL]->(spnnode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
 
     ingest_external_account_principals = """
-    MERGE (epnode:AWSExternalPrincipal{principal: $principal})
+    UNWIND $DictList AS item
+    MERGE (epnode:AWSExternalPrincipal{principal: item.principal})
     ON CREATE SET epnode.firstseen = timestamp()
     SET epnode.lastupdated = $aws_update_tag,
-    epnode.access_type = $AccessType,
-    epnode.account_id = $AccountId
-    WITH epnode
-    MATCH (role:AWSRole{arn: $RoleArn})
+    epnode.access_type = item.access_type,
+    epnode.account_id = item.account_id
+    WITH epnode, item
+    MATCH (role:AWSRole{arn: item.role_arn})
     MERGE (role)-[r:TRUSTS_AWS_PRINCIPAL]->(epnode)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
@@ -751,47 +754,65 @@ def load_roles(
 
     # TODO support conditions
     logger.info(f"Loading {len(roles)} IAM roles to the graph.")
-    for role in roles:
-        neo4j_session.run(
-            ingest_role,
-            Arn=role["Arn"],
-            consolelink=aws_console_link.get_console_link(arn=role["Arn"]),
-            RoleId=role.get("RoleId", None),
-            CreateDate=str(role["CreateDate"]),
-            RoleName=role["RoleName"],
-            Path=role["Path"],
-            IsServiceRole=role.get("isServiceRole", False),
-            IsSSOReservedRole=role.get("isSSOReservedRole", False),
-            Type=role.get("type", None),
-            ManagedType=role.get("type") if role.get("type") in (MANAGED_TYPE_PREDEFINED, MANAGED_TYPE_CUSTOM)
+    role_rows = [
+        {
+            "arn": role["Arn"],
+            "consolelink": aws_console_link.get_console_link(arn=role["Arn"]),
+            "roleid": role.get("RoleId", None),
+            "createdate": str(role["CreateDate"]),
+            "rolename": role["RoleName"],
+            "path": role["Path"],
+            "is_service_role": role.get("isServiceRole", False),
+            "is_sso_reserved_role": role.get("isSSOReservedRole", False),
+            "type": role.get("type", None),
+            "managed_type": role.get("type") if role.get("type") in (MANAGED_TYPE_PREDEFINED, MANAGED_TYPE_CUSTOM)
             else _aws_role_managed_type(role.get("Path", "")),
-            region="global",
-            LastUsedDate=role["RoleLastUsed"].get("LastUsedDate") if "RoleLastUsed" in role else None,
-            LastUsedRegion=role["RoleLastUsed"].get("Region") if "RoleLastUsed" in role else None,
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            aws_update_tag=aws_update_tag,
-        )
+            "lastuseddate": role["RoleLastUsed"].get("LastUsedDate") if "RoleLastUsed" in role else None,
+            "lastusedregion": role["RoleLastUsed"].get("Region") if "RoleLastUsed" in role else None,
+        }
+        for role in roles
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_role,
+        role_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+    )
 
-        for external_principal in role["ExternalAccountPrincipals"]:
-            neo4j_session.run(
-                ingest_external_account_principals,
-                principal=external_principal.get("principal"),
-                AccessType=external_principal.get("access_type"),
-                AccountId=external_principal.get("account_id"),
-                RoleArn=role["Arn"],
-                aws_update_tag=aws_update_tag,
-            )
+    external_principal_rows = [
+        {
+            "principal": external_principal.get("principal"),
+            "access_type": external_principal.get("access_type"),
+            "account_id": external_principal.get("account_id"),
+            "role_arn": role["Arn"],
+        }
+        for role in roles
+        for external_principal in role["ExternalAccountPrincipals"]
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_external_account_principals,
+        external_principal_rows,
+        aws_update_tag=aws_update_tag,
+    )
 
-        for statement in role["AssumeRolePolicyDocument"]["Statement"]:
-            principal_entries = _parse_principal_entries(statement["Principal"])
-            for principal_type, principal_value in principal_entries:
-                neo4j_session.run(
-                    ingest_policy_statement,
-                    SpnArn=principal_value,
-                    SpnType=principal_type,
-                    RoleArn=role["Arn"],
-                    aws_update_tag=aws_update_tag,
-                )
+    trust_principal_rows = [
+        {
+            "spn_arn": principal_value,
+            "spn_type": principal_type,
+            "role_arn": role["Arn"],
+        }
+        for role in roles
+        for statement in role["AssumeRolePolicyDocument"]["Statement"]
+        for principal_type, principal_value in _parse_principal_entries(statement["Principal"])
+    ]
+    load_graph_data(
+        neo4j_session,
+        ingest_policy_statement,
+        trust_principal_rows,
+        aws_update_tag=aws_update_tag,
+    )
 
 
 @timeit

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -17,6 +17,8 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
 from cartography.util import run_cleanup_job
@@ -851,7 +853,8 @@ def get_policies_for_principal(neo4j_session: neo4j.Session, principal_arn: str)
     DISTINCT policy.id AS policy_id,
     COLLECT(DISTINCT statements) AS statements
     """
-    results = neo4j_session.run(
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         get_policy_query,
         Arn=principal_arn,
     )
@@ -889,7 +892,8 @@ def sync_assumerole_relationships(
     SET r.lastupdated = $aws_update_tag
     """
 
-    results = neo4j_session.run(
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         query_potential_matches,
         AccountId=current_aws_account_id,
     )
@@ -1153,7 +1157,8 @@ def load_policy_statements(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
         """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_policy_statement,
         PolicyId=policy_id,
         consolelink=consolelink,
@@ -1161,7 +1166,7 @@ def load_policy_statements(
         Statements=statements,
         region="global",
         aws_update_tag=aws_update_tag,
-    ).consume()
+    )
 
 
 def _batch_load_policies(
@@ -1489,7 +1494,7 @@ def sync_group_memberships(
         "MATCH (group:AWSGroup)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ACCOUNT_ID}) "
         "return group.name as name, group.arn as arn;"
     )
-    groups = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
+    groups = neo4j_session.execute_read(read_list_of_dicts_tx, query, AWS_ACCOUNT_ID=current_aws_account_id)
     groups_membership = {group["arn"]: get_group_membership_data(boto3_session, group["name"]) for group in groups}
     load_group_memberships(neo4j_session, groups_membership, aws_update_tag)
     run_cleanup_job(
@@ -1509,7 +1514,7 @@ def sync_user_access_keys(
 ) -> None:
     logger.info("Syncing IAM user access keys for account '%s'.", current_aws_account_id)
     query = "MATCH (user:AWSPrincipal)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ACCOUNT_ID}) WHERE user:AWSUser OR user:AWSServiceAccount return user.name as name"
-    result = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
+    result = neo4j_session.execute_read(read_list_of_dicts_tx, query, AWS_ACCOUNT_ID=current_aws_account_id)
     usernames = [r["name"] for r in result]
     for name in usernames:
         access_keys = get_account_access_key_data(boto3_session, name)

--- a/cartography/intel/aws/kms.py
+++ b/cartography/intel/aws/kms.py
@@ -15,6 +15,8 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 from policyuniverse.policy import Policy
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -123,7 +125,7 @@ def _load_kms_key_aliases(neo4j_session: neo4j.Session, aliases: List[Dict], upd
     Ingest KMS Aliases into neo4j.
     """
     ingest_aliases = """
-    UNWIND $alias_list AS alias
+    UNWIND $DictList AS alias
     MERGE (a:KMSAlias{id: alias.AliasArn})
     ON CREATE SET a.firstseen = timestamp(), a.targetkeyid = alias.TargetKeyId
     SET a.aliasname = alias.AliasName, a.lastupdated = $UpdateTag,
@@ -136,9 +138,10 @@ def _load_kms_key_aliases(neo4j_session: neo4j.Session, aliases: List[Dict], upd
     SET r.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_aliases,
-        alias_list=aliases,
+        aliases,
         UpdateTag=update_tag,
     )
 
@@ -151,7 +154,7 @@ def _load_kms_key_grants(
     Ingest KMS Key Grants into neo4j.
     """
     ingest_grants = """
-    UNWIND $grants AS grant
+    UNWIND $DictList AS grant
     MERGE (g:KMSGrant{id: grant.GrantId})
     ON CREATE SET g.firstseen = timestamp(), g.granteeprincipal = grant.GranteePrincipal,
     g.creationdate = grant.CreationDate
@@ -170,9 +173,10 @@ def _load_kms_key_grants(
     for grant in grants_list:
         grant['CreationDate'] = str(grant['CreationDate'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_grants,
-        grants=grants_list,
+        grants_list,
         UpdateTag=update_tag,
     )
 
@@ -184,7 +188,7 @@ def _load_kms_key_policies(neo4j_session: neo4j.Session, policies: List[Dict], u
     """
     # NOTE we use the coalesce function so appending works when the value is null initially
     ingest_policies = """
-    UNWIND $policies AS policy
+    UNWIND $DictList AS policy
     MATCH (k:KMSKey) where k.name = policy.kms_key
     SET k.anonymous_access = (coalesce(k.anonymous_access, false) OR policy.internet_accessible),
     k.region=policy.region,
@@ -192,9 +196,10 @@ def _load_kms_key_policies(neo4j_session: neo4j.Session, policies: List[Dict], u
     k.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policies,
-        policies=policies,
+        policies,
         UpdateTag=update_tag,
     )
 
@@ -205,7 +210,8 @@ def _set_default_values(neo4j_session: neo4j.Session, aws_account_id: str) -> No
     SET kmskey.anonymous_access = false, kmskey.anonymous_actions = []
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         set_defaults,
         AWS_ID=aws_account_id,
     )
@@ -317,7 +323,7 @@ def load_kms_keys(
     aws_update_tag: int,
 ) -> None:
     ingest_keys = """
-    UNWIND $key_list AS k
+    UNWIND $DictList AS k
     MERGE (kmskey:KMSKey{id:k.KeyId})
     ON CREATE SET kmskey.firstseen = timestamp(),
     kmskey.arn = k.Arn, kmskey.creationdate = k.CreationDate
@@ -345,9 +351,10 @@ def load_kms_keys(
         key['ValidTo'] = str(key.get('ValidTo'))
         key['consolelink'] = aws_console_link.get_console_link(arn=key['Arn'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_keys,
-        key_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )

--- a/cartography/intel/aws/lambda_function.py
+++ b/cartography/intel/aws/lambda_function.py
@@ -14,6 +14,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 from policyuniverse.policy import Policy
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -188,7 +189,7 @@ def load_lambda_functions(
     aws_update_tag: int,
 ) -> None:
     ingest_lambda_functions = """
-    UNWIND $lambda_functions_list AS lf
+    UNWIND $DictList AS lf
     MERGE (lambda:AWSLambda{id: lf.FunctionArn})
     ON CREATE SET lambda.firstseen = timestamp()
     SET lambda.name = lf.FunctionName,
@@ -237,9 +238,10 @@ def load_lambda_functions(
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_lambda_functions,
-        lambda_functions_list=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -329,7 +331,7 @@ def load_lambda_function_details(
 @timeit
 def _load_lambda_function_aliases(neo4j_session: neo4j.Session, lambda_aliases: List[Dict], update_tag: int) -> None:
     ingest_aliases = """
-    UNWIND $aliases_list AS alias
+    UNWIND $DictList AS alias
     MERGE (a:AWSLambdaFunctionAlias{id: alias.AliasArn})
     ON CREATE SET a.firstseen = timestamp()
     SET a.aliasname = alias.Name,
@@ -347,9 +349,10 @@ def _load_lambda_function_aliases(neo4j_session: neo4j.Session, lambda_aliases: 
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_aliases,
-        aliases_list=lambda_aliases,
+        lambda_aliases,
         aws_update_tag=update_tag,
     )
 
@@ -361,7 +364,7 @@ def _load_lambda_event_source_mappings(
     update_tag: int,
 ) -> None:
     ingest_esms = """
-    UNWIND $esm_list AS esm
+    UNWIND $DictList AS esm
     MERGE (e:AWSLambdaEventSourceMapping{id: esm.EventSourceArn})
     ON CREATE SET e.firstseen = timestamp()
     SET e.batchsize = esm.BatchSize,
@@ -389,9 +392,10 @@ def _load_lambda_event_source_mappings(
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_esms,
-        esm_list=lambda_event_source_mappings,
+        lambda_event_source_mappings,
         aws_update_tag=update_tag,
     )
 
@@ -399,7 +403,7 @@ def _load_lambda_event_source_mappings(
 @timeit
 def _load_lambda_layers(neo4j_session: neo4j.Session, lambda_layers: List[Dict], update_tag: int) -> None:
     ingest_layers = """
-    UNWIND $layers_list AS layer
+    UNWIND $DictList AS layer
     MERGE (l:AWSLambdaLayer{id: layer.Arn})
     ON CREATE SET l.firstseen = timestamp()
     SET l.codesize = layer.CodeSize,
@@ -417,9 +421,10 @@ def _load_lambda_layers(neo4j_session: neo4j.Session, lambda_layers: List[Dict],
     SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_layers,
-        layers_list=lambda_layers,
+        lambda_layers,
         aws_update_tag=update_tag,
     )
 

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -6,6 +6,7 @@ import boto3
 import botocore.exceptions
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -140,7 +141,8 @@ def load_aws_accounts(
     """
     for account_name, account_id in aws_accounts.items():
         root_arn = f'arn:aws:iam::{account_id}:root'
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             WORKSPACE_ID=common_job_parameters['WORKSPACE_ID'],
             WORKSPACE_NAME=common_job_parameters['WORKSPACE_NAME'],

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -13,6 +13,8 @@ import boto3
 import neo4j
 import yaml
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.graph.statement import GraphStatement
 from cartography.util import timeit
 
@@ -253,7 +255,8 @@ def get_principals_for_account(neo4j_session: neo4j.Session, account_id: str) ->
     RETURN
     DISTINCT principal.arn as principal_arn, policy.id as policy_id, collect(statements) as statements
     """
-    results = neo4j_session.run(
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         get_policy_query,
         AccountId=account_id,
     )
@@ -274,7 +277,8 @@ def get_resource_arns(neo4j_session: neo4j.Session, account_id: str, node_label:
     return resource.arn as arn
     """)
     get_resource_query_template = get_resource_query.safe_substitute(node_label=node_label)
-    results = neo4j_session.run(
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         get_resource_query_template,
         AccountId=account_id,
     )
@@ -287,7 +291,7 @@ def load_principal_mappings(
     relationship_name: str, update_tag: int,
 ) -> None:
     map_policy_query = Template("""
-    UNWIND $Mapping as mapping
+    UNWIND $DictList as mapping
     MATCH (principal:AWSPrincipal{arn:mapping.principal_arn})
     MATCH (resource:$node_label{arn:mapping.resource_arn})
     MERGE (principal)-[r:$relationship_name]->(resource)
@@ -299,9 +303,10 @@ def load_principal_mappings(
         node_label=node_label,
         relationship_name=relationship_name,
     )
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         map_policy_query_template,
-        Mapping=principal_mappings,
+        principal_mappings,
         aws_update_tag=update_tag,
     )
 

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -11,6 +11,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
@@ -218,24 +219,22 @@ def cleanup_rds_security_groups(neo4j_session: neo4j.Session, common_job_paramet
 
 @timeit
 def attach_db_security_groups_to_ec2_security_groups(
-    session: neo4j.Session, data: List[Dict],
-    db_sg_id: str, aws_update_tag: int,
+    session: neo4j.Session, db_sgs: List[Dict], aws_update_tag: int,
 ):
-    for sg in data:
-        ingest_script = """
-        MATCH (dbsg:RDSSecurityGroup{id:$DBSecurityGroupId})
-        MATCH (sg:EC2SecurityGroup{id:$EC2SecurityGroupId})
-        MERGE (dbsg)-[r:USING]->(sg)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = $aws_update_tag
-        """
-
-        session.run(
-            ingest_script,
-            DBSecurityGroupId=db_sg_id,
-            EC2SecurityGroupId=sg.get('EC2SecurityGroupId'),
-            aws_update_tag=aws_update_tag,
-        )
+    ingest_script = """
+    UNWIND $DictList AS item
+    MATCH (dbsg:RDSSecurityGroup{id:item.db_sg_id})
+    MATCH (sg:EC2SecurityGroup{id:item.ec2_sg_id})
+    MERGE (dbsg)-[r:USING]->(sg)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $aws_update_tag
+    """
+    rows = [
+        {"db_sg_id": db_sg.get('DBSecurityGroupArn'), "ec2_sg_id": sg.get('EC2SecurityGroupId')}
+        for db_sg in db_sgs
+        for sg in db_sg.get('EC2SecurityGroups', [])
+    ]
+    load_graph_data(session, ingest_script, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
@@ -252,12 +251,7 @@ def sync_rds_security_groups(
     logger.info(f"Total RDS Security Groups: {len(data)}")
 
     load_rds_security_groups(neo4j_session, data, current_aws_account_id, update_tag)
-    for db_sg in data:
-        attach_db_security_groups_to_ec2_security_groups(
-            neo4j_session, db_sg.get(
-                'EC2SecurityGroups', [],
-            ), db_sg.get('DBSecurityGroupArn'), update_tag,
-        )
+    attach_db_security_groups_to_ec2_security_groups(neo4j_session, data, update_tag)
     cleanup_rds_security_groups(neo4j_session, common_job_parameters)
 
 
@@ -424,8 +418,8 @@ def load_rds_clusters(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
+    _attach_associate_roles(neo4j_session, data, aws_update_tag)
     for cluster in data:
-        _attach_associate_roles(neo4j_session, cluster, aws_update_tag)
         _attach_db_subnet_group(neo4j_session, cluster, aws_update_tag)
         _attach_ec2_security_groups_cluster(neo4j_session, cluster, aws_update_tag)
         # TODO: track read replicas
@@ -450,21 +444,21 @@ def load_rds_clusters(
 
 
 @timeit
-def _attach_associate_roles(neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int) -> None:
+def _attach_associate_roles(neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int) -> None:
     attach_cluster_to_role = """
-    MATCH (c:RDSCluster{id:$DBClusterArn})
-    MERGE (p:AWSPrincipal{arn:$RoleArn})
+    UNWIND $DictList AS item
+    MATCH (c:RDSCluster{id:item.cluster_arn})
+    MERGE (p:AWSPrincipal{arn:item.role_arn})
     MERGE (c)-[s:RDS_ASSUMEROLE_ALLOW]->(p)
     ON CREATE SET s.firstseen = timestamp()
     SET s.lastupdated = $aws_update_tag
     """
-    for role in cluster.get('AssociatedRoles', []):
-        neo4j_session.run(
-            attach_cluster_to_role,
-            DBClusterArn=cluster['DBClusterArn'],
-            RoleArn=role['RoleArn'],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = [
+        {"cluster_arn": cluster['DBClusterArn'], "role_arn": role['RoleArn']}
+        for cluster in clusters
+        for role in cluster.get('AssociatedRoles', [])
+    ]
+    load_graph_data(neo4j_session, attach_cluster_to_role, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
@@ -367,7 +368,7 @@ def load_rds_clusters(
     Ingest the RDS clusters to neo4j and link them to necessary nodes.
     """
     ingest_rds_cluster = """
-    UNWIND $Clusters as rds_cluster
+    UNWIND $DictList as rds_cluster
         MERGE (cluster:RDSCluster{id: rds_cluster.DBClusterArn})
         ON CREATE SET cluster.firstseen = timestamp(),
             cluster.arn = rds_cluster.DBClusterArn
@@ -435,9 +436,10 @@ def load_rds_clusters(
         cluster['ScalingConfigurationInfoMaxCapacity'] = cluster.get('ScalingConfigurationInfo', {}).get('MaxCapacity')
         cluster['ScalingConfigurationInfoAutoPause'] = cluster.get('ScalingConfigurationInfo', {}).get('AutoPause')
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_rds_cluster,
-        Clusters=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -467,17 +469,18 @@ def _attach_ec2_security_groups_cluster(neo4j_session: neo4j.Session, cluster: D
     Attach an RDS instance to its EC2SecurityGroups
     """
     attach_rds_to_group = """
-    UNWIND $VpcSecurityGroups as rds_sg
+    UNWIND $DictList as rds_sg
         MATCH (rds:RDSCluster{id: $DBClusterArn})
         MERGE (sg:EC2SecurityGroup{id: rds_sg.VpcSecurityGroupId})
         MERGE (rds)-[m:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
         ON CREATE SET m.firstseen = timestamp()
         SET m.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_rds_to_group,
+        cluster['VpcSecurityGroups'],
         DBClusterArn=cluster['DBClusterArn'],
-        VpcSecurityGroups=cluster['VpcSecurityGroups'],
         aws_update_tag=aws_update_tag,
     )
 
@@ -491,7 +494,8 @@ def _attach_db_subnet_group(neo4j_session: neo4j.Session, cluster: Dict, aws_upd
     ON CREATE SET s.firstseen = timestamp()
     SET s.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         attach_cluster_to_role,
         DBClusterArn=cluster['DBClusterArn'],
         DBSubnetGroup=cluster['DBSubnetGroup'],
@@ -524,7 +528,7 @@ def load_rds_instances(
     Ingest the RDS instances to neo4j and link them to necessary nodes.
     """
     ingest_rds_instance = """
-    UNWIND $Instances as rds_instance
+    UNWIND $DictList as rds_instance
         MERGE (rds:RDSInstance{id: rds_instance.DBInstanceArn})
         ON CREATE SET rds.firstseen = timestamp(),
             rds.arn = rds_instance.DBInstanceArn
@@ -612,9 +616,10 @@ def load_rds_instances(
                 publicIp = ip.get("ip")
         rds['privateIp'] = privateIp
         rds['publicIp'] = publicIp
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_rds_instance,
-        Instances=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -633,7 +638,7 @@ def load_rds_snapshots(
     Ingest the RDS snapshots to neo4j and link them to necessary nodes.
     """
     ingest_rds_snapshot = """
-    UNWIND $Snapshots as rds_snapshot
+    UNWIND $DictList as rds_snapshot
         MERGE (snapshot:RDSSnapshot{id: rds_snapshot.DBSnapshotArn})
         ON CREATE SET snapshot.firstseen = timestamp(),
             snapshot.arn = rds_snapshot.DBSnapshotArn
@@ -679,9 +684,10 @@ def load_rds_snapshots(
 
     snapshots = transform_rds_snapshots(data)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_rds_snapshot,
-        Snapshots=data,
+        data,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -694,7 +700,7 @@ def load_rds_snapshot_attributes(neo4j_session: neo4j.Session, data: Dict, aws_u
     Ingest the RDS snapshot attributes to neo4j and link them to RDS snapshot.
     """
     ingest_rds_snapshot_attributes = """
-    UNWIND $snapshotAttributes as result
+    UNWIND $DictList as result
         MATCH (rdsSnapshot:RDSSnapshot{db_snapshot_identifier: result.DBSnapshotIdentifier})
         WITH result, rdsSnapshot
         UNWIND result.DBSnapshotAttributes as attribute
@@ -709,9 +715,10 @@ def load_rds_snapshot_attributes(neo4j_session: neo4j.Session, data: Dict, aws_u
             SET r.lastupdated = $aws_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_rds_snapshot_attributes,
-        snapshotAttributes=data,
+        data,
         aws_update_tag=aws_update_tag,
     )
 
@@ -722,16 +729,17 @@ def _attach_snapshots(neo4j_session: neo4j.Session, snapshots: List[Dict], aws_u
     Attach snapshots to their source instance
     """
     attach_member_to_source = """
-    UNWIND $Snapshots as snapshot
+    UNWIND $DictList as snapshot
         MATCH (rdsInstance:RDSInstance {db_instance_identifier: snapshot.DBInstanceIdentifier}),
         (rdsSnapshot:RDSSnapshot {arn: snapshot.DBSnapshotArn})
         MERGE (rdsInstance)-[r:IS_SNAPSHOT_SOURCE]->(rdsSnapshot)
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_member_to_source,
-        Snapshots=snapshots,
+        snapshots,
         aws_update_tag=aws_update_tag,
     )
 
@@ -745,7 +753,7 @@ def _attach_ec2_subnet_groups(
     Attach RDS instances to their EC2 subnet groups
     """
     attach_rds_to_subnet_group = """
-    UNWIND $SubnetGroups as rds_sng
+    UNWIND $DictList as rds_sng
         MERGE (sng:DBSubnetGroup{id: rds_sng.arn})
         ON CREATE SET sng.firstseen = timestamp()
         SET sng.name = rds_sng.DBSubnetGroupName,
@@ -768,9 +776,10 @@ def _attach_ec2_subnet_groups(
         db_sng['instance_arn'] = instance['DBInstanceArn']
         db_sng['region'] = region
         db_sngs.append(db_sng)
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_rds_to_subnet_group,
-        SubnetGroups=db_sngs,
+        db_sngs,
         aws_update_tag=aws_update_tag,
     )
     _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_sngs, current_aws_account_id, aws_update_tag)
@@ -790,7 +799,7 @@ def _attach_ec2_subnets_to_subnetgroup(
     Availability Zone to select a subnet and an IP address within that subnet to associate with your DB instance.`
     """
     attach_subnets_to_sng = """
-    UNWIND $Subnets as rds_sn
+    UNWIND $DictList as rds_sn
         MATCH (sng:DBSubnetGroup{id: rds_sn.sng_arn})
         MERGE (subnet:EC2Subnet{subnetid: rds_sn.sn_id})
         ON CREATE SET subnet.firstseen = timestamp()
@@ -812,9 +821,10 @@ def _attach_ec2_subnets_to_subnetgroup(
                 'sng_arn': sng_arn,
                 'az': az,
             })
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_subnets_to_sng,
-        Subnets=subnets,
+        subnets,
         aws_update_tag=aws_update_tag,
     )
 
@@ -825,7 +835,7 @@ def _attach_ec2_security_groups(neo4j_session: neo4j.Session, instances: List[Di
     Attach an RDS instance to its EC2SecurityGroups
     """
     attach_rds_to_group = """
-    UNWIND $Groups as rds_sg
+    UNWIND $DictList as rds_sg
         MATCH (rds:RDSInstance{id: rds_sg.arn})
         MERGE (sg:EC2SecurityGroup{id: rds_sg.group_id})
         MERGE (rds)-[m:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
@@ -839,9 +849,10 @@ def _attach_ec2_security_groups(neo4j_session: neo4j.Session, instances: List[Di
                 'arn': instance['DBInstanceArn'],
                 'group_id': group['VpcSecurityGroupId'],
             })
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_rds_to_group,
-        Groups=groups,
+        groups,
         aws_update_tag=aws_update_tag,
     )
 
@@ -852,16 +863,17 @@ def _attach_read_replicas(neo4j_session: neo4j.Session, read_replicas: List[Dict
     Attach read replicas to their source instances
     """
     attach_replica_to_source = """
-    UNWIND $Replicas as rds_replica
+    UNWIND $DictList as rds_replica
         MATCH (replica:RDSInstance{id: rds_replica.DBInstanceArn}),
         (source:RDSInstance{db_instance_identifier: rds_replica.ReadReplicaSourceDBInstanceIdentifier})
         MERGE (replica)-[r:IS_READ_REPLICA_OF]->(source)
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_replica_to_source,
-        Replicas=read_replicas,
+        read_replicas,
         aws_update_tag=aws_update_tag,
     )
 
@@ -872,16 +884,17 @@ def _attach_clusters(neo4j_session: neo4j.Session, cluster_members: List[Dict], 
     Attach cluster members to their source clusters
     """
     attach_member_to_source = """
-    UNWIND $Members as rds_cluster_member
+    UNWIND $DictList as rds_cluster_member
     MATCH (member:RDSInstance{id: rds_cluster_member.DBInstanceArn}),
     (source:RDSCluster{db_cluster_identifier: rds_cluster_member.DBClusterIdentifier})
     MERGE (member)-[r:IS_CLUSTER_MEMBER_OF]->(source)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_member_to_source,
-        Members=cluster_members,
+        cluster_members,
         aws_update_tag=aws_update_tag,
     )
 

--- a/cartography/intel/aws/redshift.py
+++ b/cartography/intel/aws/redshift.py
@@ -8,6 +8,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -155,26 +156,27 @@ def load_redshift_cluster_data(
     aws_update_tag: int,
 ) -> None:
     ingest_cluster = """
-    MERGE (cluster:RedshiftCluster{id: $Arn})
+    UNWIND $DictList AS item
+    MERGE (cluster:RedshiftCluster{id: item.arn})
     ON CREATE SET cluster.firstseen = timestamp(),
-    cluster.arn = $Arn
-    SET cluster.availability_zone = $AZ,
-    cluster.cluster_create_time = $ClusterCreateTime,
-    cluster.cluster_identifier = $ClusterIdentifier,
-    cluster.cluster_revision_number = $ClusterRevisionNumber,
-    cluster.db_name = $DBName,
-    cluster.consolelink = $consolelink,
-    cluster.encrypted = $Encrypted,
-    cluster.cluster_status = $ClusterStatus,
-    cluster.endpoint_address = $EndpointAddress,
-    cluster.endpoint_port = $EndpointPort,
-    cluster.master_username = $MasterUsername,
-    cluster.node_type = $NodeType,
-    cluster.number_of_nodes = $NumberOfNodes,
-    cluster.publicly_accessible = $PubliclyAccessible,
-    cluster.vpc_id = $VpcId,
+    cluster.arn = item.arn
+    SET cluster.availability_zone = item.az,
+    cluster.cluster_create_time = item.cluster_create_time,
+    cluster.cluster_identifier = item.cluster_identifier,
+    cluster.cluster_revision_number = item.cluster_revision_number,
+    cluster.db_name = item.db_name,
+    cluster.consolelink = item.consolelink,
+    cluster.encrypted = item.encrypted,
+    cluster.cluster_status = item.cluster_status,
+    cluster.endpoint_address = item.endpoint_address,
+    cluster.endpoint_port = item.endpoint_port,
+    cluster.master_username = item.master_username,
+    cluster.node_type = item.node_type,
+    cluster.number_of_nodes = item.number_of_nodes,
+    cluster.publicly_accessible = item.publicly_accessible,
+    cluster.vpc_id = item.vpc_id,
     cluster.lastupdated = $aws_update_tag,
-    cluster.region = $Region
+    cluster.region = item.region
     WITH cluster
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(cluster)
@@ -182,140 +184,138 @@ def load_redshift_cluster_data(
     SET r.lastupdated = $aws_update_tag
     """
 
+    cluster_rows = []
     for cluster in clusters:
-        endpoint_address = ""
-        endpoint_port = ""
-        if cluster.get("Endpoint"):
-            endpoint_address = cluster.get("Endpoint").get("Address")
-            endpoint_port = cluster.get("Endpoint").get("Port")
-
-        neo4j_session.run(
-            ingest_cluster,
-            Arn=cluster["arn"],
-            consolelink=aws_console_link.get_console_link(arn=cluster["arn"]),
-            AZ=cluster.get("AvailabilityZone"),
-            ClusterCreateTime=cluster.get("ClusterCreateTime"),
-            ClusterIdentifier=cluster.get("ClusterIdentifier"),
-            ClusterRevisionNumber=cluster.get("ClusterRevisionNumber"),
-            ClusterStatus=cluster.get("ClusterStatus"),
-            DBName=cluster.get("DBName"),
-            Encrypted=cluster.get("Encrypted"),
-            EndpointAddress=endpoint_address,
-            EndpointPort=endpoint_port,  # type: ignore
-            MasterUsername=cluster.get("MasterUsername"),
-            NodeType=cluster.get("NodeType"),
-            NumberOfNodes=cluster.get("NumberOfNodes"),
-            PubliclyAccessible=cluster.get("PubliclyAccessible"),
-            VpcId=cluster.get("VpcId"),
-            Region=cluster.get("region"),
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            aws_update_tag=aws_update_tag,
-        )
-        _attach_ec2_security_groups(neo4j_session, cluster, aws_update_tag, current_aws_account_id)
-        _attach_iam_roles(neo4j_session, cluster, aws_update_tag)
-        _attach_aws_vpc(neo4j_session, cluster, aws_update_tag)
-        _attach_aws_network_interface(neo4j_session, cluster, aws_update_tag)
-        _attach_aws_ec2_subnet(neo4j_session, cluster, aws_update_tag)
+        endpoint = cluster.get("Endpoint") or {}
+        cluster_rows.append({
+            "arn": cluster["arn"],
+            "consolelink": aws_console_link.get_console_link(arn=cluster["arn"]),
+            "az": cluster.get("AvailabilityZone"),
+            "cluster_create_time": cluster.get("ClusterCreateTime"),
+            "cluster_identifier": cluster.get("ClusterIdentifier"),
+            "cluster_revision_number": cluster.get("ClusterRevisionNumber"),
+            "cluster_status": cluster.get("ClusterStatus"),
+            "db_name": cluster.get("DBName"),
+            "encrypted": cluster.get("Encrypted"),
+            "endpoint_address": endpoint.get("Address", ""),
+            "endpoint_port": endpoint.get("Port", ""),
+            "master_username": cluster.get("MasterUsername"),
+            "node_type": cluster.get("NodeType"),
+            "number_of_nodes": cluster.get("NumberOfNodes"),
+            "publicly_accessible": cluster.get("PubliclyAccessible"),
+            "vpc_id": cluster.get("VpcId"),
+            "region": cluster.get("region"),
+        })
+    load_graph_data(
+        neo4j_session, ingest_cluster, cluster_rows,
+        AWS_ACCOUNT_ID=current_aws_account_id, aws_update_tag=aws_update_tag,
+    )
+    _attach_ec2_security_groups(neo4j_session, clusters, aws_update_tag, current_aws_account_id)
+    _attach_iam_roles(neo4j_session, clusters, aws_update_tag)
+    _attach_aws_vpc(neo4j_session, clusters, aws_update_tag)
+    _attach_aws_network_interface(neo4j_session, clusters, aws_update_tag)
+    _attach_aws_ec2_subnet(neo4j_session, clusters, aws_update_tag)
 
 
 @timeit
 def _attach_ec2_security_groups(
-    neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int, account_id: str,
+    neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int, account_id: str,
 ) -> None:
     attach_cluster_to_group = """
-    MATCH (c:RedshiftCluster{id:$ClusterArn})
-    MERGE (sg:EC2SecurityGroup{id:$GroupId})
-    SET sg.consolelink = $consolelink
+    UNWIND $DictList AS item
+    MATCH (c:RedshiftCluster{id:item.cluster_arn})
+    MERGE (sg:EC2SecurityGroup{id:item.group_id})
+    SET sg.consolelink = item.consolelink
     MERGE (c)-[m:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
     ON CREATE SET m.firstseen = timestamp()
     SET m.lastupdated = $aws_update_tag
     """
-    for group in cluster.get("VpcSecurityGroups", []):
-        region = group.get("region", "")
-        group_id = group.get("GroupId")
-        group_arn = f"arn:aws:ec2:{region}:{account_id}:security-group/{group_id}"
-        consolelink = aws_console_link.get_console_link(arn=group_arn)
-        neo4j_session.run(
-            attach_cluster_to_group,
-            ClusterArn=cluster["arn"],
-            consolelink=consolelink,
-            GroupId=group["VpcSecurityGroupId"],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = []
+    for cluster in clusters:
+        for group in cluster.get("VpcSecurityGroups", []):
+            region = group.get("region", "")
+            group_id = group.get("GroupId")
+            group_arn = f"arn:aws:ec2:{region}:{account_id}:security-group/{group_id}"
+            rows.append({
+                "cluster_arn": cluster["arn"],
+                "consolelink": aws_console_link.get_console_link(arn=group_arn),
+                "group_id": group["VpcSecurityGroupId"],
+            })
+    load_graph_data(neo4j_session, attach_cluster_to_group, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
-def _attach_iam_roles(neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int) -> None:
+def _attach_iam_roles(neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int) -> None:
     attach_cluster_to_role = """
-    MATCH (c:RedshiftCluster{id:$ClusterArn})
-    MERGE (p:AWSPrincipal{arn:$RoleArn})
+    UNWIND $DictList AS item
+    MATCH (c:RedshiftCluster{id:item.cluster_arn})
+    MERGE (p:AWSPrincipal{arn:item.role_arn})
     MERGE (c)-[s:STS_ASSUMEROLE_ALLOW]->(p)
     ON CREATE SET s.firstseen = timestamp()
     SET s.lastupdated = $aws_update_tag
     """
-    for role in cluster.get("IamRoles", []):
-        neo4j_session.run(
-            attach_cluster_to_role,
-            ClusterArn=cluster["arn"],
-            RoleArn=role["IamRoleArn"],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = [
+        {"cluster_arn": cluster["arn"], "role_arn": role["IamRoleArn"]}
+        for cluster in clusters
+        for role in cluster.get("IamRoles", [])
+    ]
+    load_graph_data(neo4j_session, attach_cluster_to_role, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
-def _attach_aws_vpc(neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int) -> None:
+def _attach_aws_vpc(neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int) -> None:
     attach_cluster_to_vpc = """
-    MATCH (c:RedshiftCluster{id:$ClusterArn})
-    MERGE (v:AWSVpc{id:$VpcId})
+    UNWIND $DictList AS item
+    MATCH (c:RedshiftCluster{id:item.cluster_arn})
+    MERGE (v:AWSVpc{id:item.vpc_id})
     MERGE (c)-[m:MEMBER_OF_AWS_VPC]->(v)
     ON CREATE SET m.firstseen = timestamp()
     SET m.lastupdated = $aws_update_tag
     """
-    if cluster.get("VpcId"):
-        neo4j_session.run(
-            attach_cluster_to_vpc,
-            ClusterArn=cluster["arn"],
-            VpcId=cluster["VpcId"],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = [
+        {"cluster_arn": cluster["arn"], "vpc_id": cluster["VpcId"]}
+        for cluster in clusters
+        if cluster.get("VpcId")
+    ]
+    load_graph_data(neo4j_session, attach_cluster_to_vpc, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
-def _attach_aws_network_interface(neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int) -> None:
+def _attach_aws_network_interface(neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int) -> None:
     attach_cluster_to_network_interface = """
-    UNWIND $NetworkInterfaces as NetworkInterface
-        MATCH (c:RedshiftCluster{id:$ClusterArn})
-        MERGE (v:NetworkInterface{id: NetworkInterface.NetworkInterfaceId})
+    UNWIND $DictList AS item
+        MATCH (c:RedshiftCluster{id:item.cluster_arn})
+        MERGE (v:NetworkInterface{id: item.network_interface_id})
         MERGE (c)-[m:NETWORK_INTERFACE]->(v)
         ON CREATE SET m.firstseen = timestamp()
         SET m.lastupdated = $aws_update_tag
     """
-    for vpc_endpoint in cluster.get("VpcEndpoints", []):
-        neo4j_session.run(
-            attach_cluster_to_network_interface,
-            ClusterArn=cluster["arn"],
-            NetworkInterfaces=vpc_endpoint["NetworkInterfaces"],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = [
+        {"cluster_arn": cluster["arn"], "network_interface_id": nic["NetworkInterfaceId"]}
+        for cluster in clusters
+        for vpc_endpoint in cluster.get("VpcEndpoints", [])
+        for nic in vpc_endpoint["NetworkInterfaces"]
+    ]
+    load_graph_data(neo4j_session, attach_cluster_to_network_interface, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit
-def _attach_aws_ec2_subnet(neo4j_session: neo4j.Session, cluster: Dict, aws_update_tag: int) -> None:
+def _attach_aws_ec2_subnet(neo4j_session: neo4j.Session, clusters: List[Dict], aws_update_tag: int) -> None:
     attach_cluster_to_ec2_subnet = """
-    UNWIND $NetworkInterfaces as NetworkInterface
-        MATCH (c:RedshiftCluster{id:$ClusterArn})
-        MERGE (s:EC2Subnet{id: NetworkInterface.SubnetId})
+    UNWIND $DictList AS item
+        MATCH (c:RedshiftCluster{id:item.cluster_arn})
+        MERGE (s:EC2Subnet{id: item.subnet_id})
         MERGE (c)-[m:CLUSTER_SUBNET]->(s)
         ON CREATE SET m.firstseen = timestamp()
         SET m.lastupdated = $aws_update_tag
     """
-    for vpc_endpoint in cluster.get("VpcEndpoints", []):
-        neo4j_session.run(
-            attach_cluster_to_ec2_subnet,
-            ClusterArn=cluster["arn"],
-            NetworkInterfaces=vpc_endpoint["NetworkInterfaces"],
-            aws_update_tag=aws_update_tag,
-        )
+    rows = [
+        {"cluster_arn": cluster["arn"], "subnet_id": nic["SubnetId"]}
+        for cluster in clusters
+        for vpc_endpoint in cluster.get("VpcEndpoints", [])
+        for nic in vpc_endpoint["NetworkInterfaces"]
+    ]
+    load_graph_data(neo4j_session, attach_cluster_to_ec2_subnet, rows, aws_update_tag=aws_update_tag)
 
 
 @timeit

--- a/cartography/intel/aws/redshift.py
+++ b/cartography/intel/aws/redshift.py
@@ -309,7 +309,7 @@ def _attach_aws_ec2_subnet(neo4j_session: neo4j.Session, clusters: List[Dict], a
     attach_cluster_to_ec2_subnet = """
     UNWIND $DictList AS item
         MATCH (c:RedshiftCluster{id:item.cluster_arn})
-        MERGE (s:EC2Subnet{id: item.subnet_id})
+        MERGE (s:EC2Subnet{subnetid: item.subnet_id})
         MERGE (c)-[m:CLUSTER_SUBNET]->(s)
         ON CREATE SET m.firstseen = timestamp()
         SET m.lastupdated = $aws_update_tag

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -11,6 +11,8 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -112,7 +114,7 @@ def link_aws_resources(neo4j_session: neo4j.Session, update_tag: int) -> None:
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $update_tag
     """
-    neo4j_session.run(link_records, update_tag=update_tag)
+    run_write_query(neo4j_session, link_records, update_tag=update_tag)
 
     # find records that point to AWS LoadBalancers
     link_elb = """
@@ -121,7 +123,7 @@ def link_aws_resources(neo4j_session: neo4j.Session, update_tag: int) -> None:
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $update_tag
     """
-    neo4j_session.run(link_elb, update_tag=update_tag)
+    run_write_query(neo4j_session, link_elb, update_tag=update_tag)
 
     # find records that point to AWS LoadBalancersV2
     link_elbv2 = """
@@ -130,7 +132,7 @@ def link_aws_resources(neo4j_session: neo4j.Session, update_tag: int) -> None:
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $update_tag
     """
-    neo4j_session.run(link_elbv2, update_tag=update_tag)
+    run_write_query(neo4j_session, link_elbv2, update_tag=update_tag)
 
     # find records that point to AWS EC2 Instances
     link_ec2 = """
@@ -139,13 +141,13 @@ def link_aws_resources(neo4j_session: neo4j.Session, update_tag: int) -> None:
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $update_tag
     """
-    neo4j_session.run(link_ec2, update_tag=update_tag)
+    run_write_query(neo4j_session, link_ec2, update_tag=update_tag)
 
 
 @timeit
 def load_a_records(neo4j_session: neo4j.Session, records: List[Dict], update_tag: int) -> None:
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (a:DNSRecord:AWSDNSRecord{id: record.id})
     ON CREATE SET a.firstseen = timestamp(), a.name = record.name,
     a.region = record.Region,
@@ -158,9 +160,10 @@ def load_a_records(neo4j_session: neo4j.Session, records: List[Dict], update_tag
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=records,
+        records,
         update_tag=update_tag,
     )
 
@@ -169,7 +172,7 @@ def load_a_records(neo4j_session: neo4j.Session, records: List[Dict], update_tag
 def load_alias_records(neo4j_session: neo4j.Session, records: List[Dict], update_tag: int) -> None:
     # create the DNSRecord nodes and link them to matching DNSZone and S3Bucket nodes
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (a:DNSRecord:AWSDNSRecord{id: record.id})
     ON CREATE SET a.firstseen = timestamp(), a.name = record.name,
     a.region = record.Region,
@@ -182,9 +185,10 @@ def load_alias_records(neo4j_session: neo4j.Session, records: List[Dict], update
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=records,
+        records,
         update_tag=update_tag,
     )
 
@@ -192,7 +196,7 @@ def load_alias_records(neo4j_session: neo4j.Session, records: List[Dict], update
 @timeit
 def load_cname_records(neo4j_session: neo4j.Session, records: List[Dict], update_tag: int) -> None:
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (a:DNSRecord:AWSDNSRecord{id: record.id})
     ON CREATE SET a.firstseen = timestamp(), a.name = record.name,
     a.region = record.Region,
@@ -205,9 +209,10 @@ def load_cname_records(neo4j_session: neo4j.Session, records: List[Dict], update
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=records,
+        records,
         update_tag=update_tag,
     )
 
@@ -228,7 +233,8 @@ def load_zone(neo4j_session: neo4j.Session, zone: Dict, current_aws_id: str, upd
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_z,
         ZoneName=zone['name'][:-1],
         ZoneId=zone['zoneid'],
@@ -245,7 +251,7 @@ def load_zone(neo4j_session: neo4j.Session, zone: Dict, current_aws_id: str, upd
 @timeit
 def load_ns_records(neo4j_session: neo4j.Session, records: List[Dict], zone_name: str, update_tag: int, consolelink: str) -> None:
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (a:DNSRecord:AWSDNSRecord{id: record.id})
     ON CREATE SET a.firstseen = timestamp(), a.name = record.name,
     a.region = record.Region,
@@ -266,16 +272,17 @@ def load_ns_records(neo4j_session: neo4j.Session, records: List[Dict], zone_name
     SET pt.lastupdated = $update_tag
 
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=records,
+        records,
         consolelink=consolelink,
         update_tag=update_tag,
     )
 
     # Map the official name servers for a domain.
     map_ns_records = """
-    UNWIND $servers as server
+    UNWIND $DictList as server
     MATCH (ns:NameServer{id:server})
     MATCH (zone:AWSDNSZone{zoneid: $zoneid})
     MERGE (ns)<-[r:NAMESERVER]-(zone)
@@ -283,9 +290,10 @@ def load_ns_records(neo4j_session: neo4j.Session, records: List[Dict], zone_name
     """
     for record in records:
         if zone_name == record["name"]:
-            neo4j_session.run(
+            load_graph_data(
+                neo4j_session,
                 map_ns_records,
-                servers=record["servers"],
+                record["servers"],
                 zoneid=record["zoneid"],
                 update_tag=update_tag,
             )
@@ -306,7 +314,8 @@ def link_sub_zones(neo4j_session: neo4j.Session, update_tag: int) -> None:
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         query,
         update_tag=update_tag,
     )

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -17,6 +17,8 @@ from botocore.exceptions import EndpointConnectionError
 from cloudconsolelink.clouds.aws import AWSLinker
 from policyuniverse.policy import Policy
 
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
@@ -257,7 +259,7 @@ def _load_s3_acls(
     Ingest S3 ACL into neo4j.
     """
     ingest_acls = """
-    UNWIND $acls AS acl
+    UNWIND $DictList AS acl
     MERGE (a:S3Acl{id: acl.id})
     ON CREATE SET a.firstseen = timestamp(), a.owner = acl.owner, a.ownerid = acl.ownerid, a.type = acl.type,
     a.displayname = acl.displayname, a.granteeid = acl.granteeid, a.uri = acl.uri, a.permission = acl.permission
@@ -268,9 +270,10 @@ def _load_s3_acls(
     SET r.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_acls,
-        acls=acls,
+        acls,
         UpdateTag=update_tag,
     )
 
@@ -293,7 +296,7 @@ def _load_s3_policies(
 
     # NOTE we use the coalesce function so appending works when the value is null initially
     ingest_policies = """
-    UNWIND $policies AS policy
+    UNWIND $DictList AS policy
     MATCH (s:S3Bucket) where s.name = policy.bucket
     SET s.anonymous_access = (coalesce(s.anonymous_access, false) OR policy.internet_accessible),
     s.anonymous_actions = coalesce(s.anonymous_actions, []) + policy.accessible_actions,
@@ -301,9 +304,10 @@ def _load_s3_policies(
     s.policy_document = policy.policyDocument
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policies,
-        policies=policies,
+        policies,
         UpdateTag=update_tag,
     )
 
@@ -335,16 +339,17 @@ def _load_s3_policy_statuses(
     Ingest S3 policy statuses into neo4j.
     """
     ingest_policy_statuses = """
-    UNWIND $policy_statuses as policy_status
+    UNWIND $DictList as policy_status
     MATCH (bucket:S3Bucket{name: policy_status.bucket})
     SET
         bucket.is_public = coalesce(policy_status.is_public, false),
         bucket.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policy_statuses,
-        policy_statuses=policy_statuses,
+        policy_statuses,
         UpdateTag=update_tag,
     )
 
@@ -356,7 +361,7 @@ def _load_s3_policy_statements(
     update_tag: int,
 ) -> None:
     ingest_policy_statement = """
-        UNWIND $Statements as statement_data
+        UNWIND $DictList as statement_data
         MERGE (statement:S3PolicyStatement{id: statement_data.statement_id})
         ON CREATE SET statement.firstseen = timestamp()
         SET
@@ -375,11 +380,12 @@ def _load_s3_policy_statements(
         MERGE (bucket)-[r:POLICY_STATEMENT]->(statement)
         SET r.lastupdated = $UpdateTag
         """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policy_statement,
-        Statements=statements,
+        statements,
         UpdateTag=update_tag,
-    ).consume()
+    )
 
 
 @timeit
@@ -389,7 +395,7 @@ def _load_s3_encryption(neo4j_session: neo4j.Session, encryption_configs: List[D
     """
     # NOTE we use the coalesce function so appending works when the value is null initially
     ingest_encryption = """
-    UNWIND $encryption_configs AS encryption
+    UNWIND $DictList AS encryption
     MATCH (s:S3Bucket) where s.name = encryption.bucket
     SET s.default_encryption = (coalesce(s.default_encryption, false) OR encryption.default_encryption),
     s.encryption_algorithm = encryption.encryption_algorithm,
@@ -397,9 +403,10 @@ def _load_s3_encryption(neo4j_session: neo4j.Session, encryption_configs: List[D
     s.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_encryption,
-        encryption_configs=encryption_configs,
+        encryption_configs,
         UpdateTag=update_tag,
     )
 
@@ -410,16 +417,17 @@ def _load_s3_versioning(neo4j_session: neo4j.Session, versioning_configs: List[D
     Ingest S3 versioning results into neo4j.
     """
     ingest_versioning = """
-    UNWIND $versioning_configs AS versioning
+    UNWIND $DictList AS versioning
     MATCH (s:S3Bucket) where s.name = versioning.bucket
     SET s.versioning_status = versioning.status,
         s.mfa_delete = versioning.mfa_delete,
         s.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_versioning,
-        versioning_configs=versioning_configs,
+        versioning_configs,
         UpdateTag=update_tag,
     )
 
@@ -434,7 +442,7 @@ def _load_s3_public_access_block(
     Ingest S3 public access block results into neo4j.
     """
     ingest_public_access_block = """
-    UNWIND $public_access_block_configs AS public_access_block
+    UNWIND $DictList AS public_access_block
     MATCH (s:S3Bucket) where s.name = public_access_block.bucket
     SET s.block_public_acls = public_access_block.block_public_acls,
         s.ignore_public_acls = public_access_block.ignore_public_acls,
@@ -443,9 +451,10 @@ def _load_s3_public_access_block(
         s.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_public_access_block,
-        public_access_block_configs=public_access_block_configs,
+        public_access_block_configs,
         UpdateTag=update_tag,
     )
 
@@ -455,7 +464,8 @@ def _set_default_values(neo4j_session: neo4j.Session, aws_account_id: str) -> No
     MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(s:S3Bucket) where s.anonymous_actions IS NULL
     SET s.anonymous_access = false, s.anonymous_actions = []
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         set_defaults,
         AWS_ID=aws_account_id,
     )
@@ -464,7 +474,8 @@ def _set_default_values(neo4j_session: neo4j.Session, aws_account_id: str) -> No
     MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(s:S3Bucket) where s.default_encryption IS NULL
     SET s.default_encryption = false
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         set_encryption_defaults,
         AWS_ID=aws_account_id,
     )
@@ -814,7 +825,8 @@ def load_s3_buckets(neo4j_session: neo4j.Session, data: Dict, current_aws_accoun
     for bucket in data["Buckets"]:
         arn = "arn:aws:s3:::" + bucket["Name"]
         consolelink = aws_console_link.get_console_link(arn=arn)
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_bucket,
             BucketName=bucket["Name"],
             BucketRegion=bucket["Region"],

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -7,6 +7,7 @@ import boto3
 import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import dict_date_to_epoch
@@ -37,7 +38,7 @@ def load_secrets(
     aws_update_tag: int,
 ) -> None:
     ingest_secrets = """
-    UNWIND $Secrets as secret
+    UNWIND $DictList as secret
         MERGE (s:SecretsManagerSecret{id: secret.ARN})
         ON CREATE SET s.firstseen = timestamp()
         SET s.name = secret.Name, s.description = secret.Description, s.kms_key_id = secret.KmsKeyId,
@@ -63,9 +64,10 @@ def load_secrets(
         secret['CreatedDate'] = dict_date_to_epoch(secret, 'CreatedDate')
         secret['consolelink'] = aws_console_link.get_console_link(arn=secret['ARN'])
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_secrets,
-        Secrets=data,
+        data,
         Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,

--- a/cartography/intel/aws/securityhub.py
+++ b/cartography/intel/aws/securityhub.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ConnectTimeoutError
 from cloudconsolelink.clouds.aws import AWSLinker
 from dateutil import parser
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -61,7 +62,8 @@ def load_hub(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_hub,
         Hub=data,
         region="global",

--- a/cartography/intel/aws/sqs.py
+++ b/cartography/intel/aws/sqs.py
@@ -10,6 +10,7 @@ import neo4j
 from botocore.exceptions import ClientError
 from cloudconsolelink.clouds.aws import AWSLinker
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -74,7 +75,7 @@ def load_sqs_queues(
     aws_update_tag: int,
 ) -> None:
     ingest_queues = """
-    UNWIND $Queues as sqs_queue
+    UNWIND $DictList as sqs_queue
         MERGE (queue:SQSQueue{id: sqs_queue.QueueArn})
         ON CREATE SET queue.firstseen = timestamp(), queue.url = sqs_queue.url
         SET queue.name = sqs_queue.name, queue.region = sqs_queue.region, queue.arn = sqs_queue.QueueArn,
@@ -125,9 +126,10 @@ def load_sqs_queues(
                 })
         queues.append(queue)
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_queues,
-        Queues=queues,
+        queues,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -141,15 +143,16 @@ def _attach_dead_letter_queues(neo4j_session: neo4j.Session, data: List[Dict[str
     Attach deadletter queues to their queues.
     """
     attach_deadletter_to_queue = """
-    UNWIND $Relations as relation
+    UNWIND $DictList as relation
         MATCH (queue:SQSQueue{id: relation.arn}), (deadletter:SQSQueue{id: relation.dead_letter_arn})
         MERGE (queue)-[r:HAS_DEADLETTER_QUEUE]->(deadletter)
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         attach_deadletter_to_queue,
-        Relations=data,
+        data,
         aws_update_tag=aws_update_tag,
     )
 

--- a/cartography/intel/aws/ssm.py
+++ b/cartography/intel/aws/ssm.py
@@ -9,6 +9,7 @@ import neo4j
 from cloudconsolelink.clouds.aws import AWSLinker
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.ssm.instance_information import SSMInstanceInformationSchema
@@ -28,7 +29,10 @@ def get_instance_ids(neo4j_session: neo4j.Session, region: str, current_aws_acco
     WHERE i.region = $Region
     RETURN i.id
     """
-    results = neo4j_session.run(get_instances_query, AWS_ACCOUNT_ID=current_aws_account_id, Region=region)
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx, get_instances_query,
+        AWS_ACCOUNT_ID=current_aws_account_id, Region=region,
+    )
     instance_ids = []
     for r in results:
         instance_ids.append(r['i.id'])

--- a/cartography/intel/azure/compute.py
+++ b/cartography/intel/azure/compute.py
@@ -10,6 +10,8 @@ from cloudconsolelink.clouds.azure import AzureLinker
 
 from . import vmss
 from .util.credentials import Credentials
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.data.operating_systems import OPERATING_SYSTEMS
 from cartography.util import get_azure_resource_group_name
 from cartography.util import run_cleanup_job
@@ -137,7 +139,7 @@ def get_vm_list(credentials: Credentials, subscription_id: str, regions: list, c
 
 def load_vms(neo4j_session: neo4j.Session, subscription_id: str, vm_list: List[Dict], update_tag: int) -> None:
     ingest_vm = """
-    UNWIND $vms AS vm
+    UNWIND $DictList AS vm
     MERGE (v:AzureVirtualMachine{id: vm.id})
     ON CREATE SET v.firstseen = timestamp(),
     v.type = vm.type, v.location = vm.location,
@@ -173,9 +175,10 @@ def load_vms(neo4j_session: neo4j.Session, subscription_id: str, vm_list: List[D
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_vm,
-        vms=vm_list,
+        vm_list,
         SUBSCRIPTION_ID=subscription_id,
         update_tag=update_tag,
     )
@@ -204,7 +207,7 @@ def load_vms(neo4j_session: neo4j.Session, subscription_id: str, vm_list: List[D
 
 def load_vm_image_relations(neo4j_session: neo4j.Session, vm_list: List[Dict], update_tag: int) -> None:
     ingest_vm_image = """
-    UNWIND $vms AS vm
+    UNWIND $DictList AS vm
     WITH vm
     WHERE vm.image_reference_id IS NOT NULL
     MERGE (img:AzureImage {id: vm.image_reference_id})
@@ -221,9 +224,10 @@ def load_vm_image_relations(neo4j_session: neo4j.Session, vm_list: List[Dict], u
     ON CREATE SET rel.firstseen = timestamp()
     SET rel.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_vm_image,
-        vms=vm_list,
+        vm_list,
         update_tag=update_tag,
     )
 
@@ -685,7 +689,7 @@ def sync_virtual_machine_scale_sets_extensions(
 
 def load_vm_data_disks(neo4j_session: neo4j.Session, vm_id: str, data_disks: List[Dict], update_tag: int) -> None:
     ingest_data_disk = """
-    UNWIND $disks AS disk
+    UNWIND $DictList AS disk
     MERGE (d:AzureDisk:AzureDataDisk{id: disk.managed_disk.id})
     ON CREATE SET d.firstseen = timestamp(), d.lun = disk.lun
     SET d.lastupdated = $update_tag, d.name = disk.name,
@@ -703,9 +707,10 @@ def load_vm_data_disks(neo4j_session: neo4j.Session, vm_id: str, data_disks: Lis
     """
 
     # for disk in data_disks:
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_data_disk,
-        disks=data_disks,
+        data_disks,
         VM_ID=vm_id,
         update_tag=update_tag,
     )
@@ -713,7 +718,7 @@ def load_vm_data_disks(neo4j_session: neo4j.Session, vm_id: str, data_disks: Lis
 
 def load_vm_managed_identities(neo4j_session: neo4j.Session, vm_id: str, managed_identities: List[str], update_tag: int) -> None:  # noqa: E501
     ingest_managed_identity = """
-    UNWIND $managed_identities AS ua
+    UNWIND $DictList AS ua
     MERGE (i:AzureManagedIdentity{id: toLower(ua)})
     ON CREATE SET i:AzurePrincipal,
     i.firstseen = timestamp()
@@ -725,9 +730,10 @@ def load_vm_managed_identities(neo4j_session: neo4j.Session, vm_id: str, managed
     SET rel.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_managed_identity,
-        managed_identities=managed_identities,
+        managed_identities,
         VM_ID=vm_id,
         update_tag=update_tag,
     )
@@ -749,7 +755,8 @@ def load_vm_os_disk(neo4j_session: neo4j.Session, vm_id: str, os_disk: Dict, upd
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_os_disk,
         disk=os_disk,
         VM_ID=vm_id,
@@ -767,7 +774,8 @@ def _attach_snapshot_disk(neo4j_session: neo4j.Session, snapshot_id: str, disk_i
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         attach_snapshot_disk,
         snapshot_id=snapshot_id,
         disk_id=disk_id,
@@ -804,7 +812,7 @@ def get_disks(credentials: Credentials, subscription_id: str, regions: list, com
 
 def load_disks(neo4j_session: neo4j.Session, subscription_id: str, disk_list: List[Dict], update_tag: int) -> None:
     ingest_disks = """
-    UNWIND $disks AS disk
+    UNWIND $DictList AS disk
     MERGE (d:AzureDisk{id: disk.id})
     ON CREATE SET d.firstseen = timestamp(),
     d.type = disk.type, d.location = disk.location,
@@ -823,9 +831,10 @@ def load_disks(neo4j_session: neo4j.Session, subscription_id: str, disk_list: Li
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag"""
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_disks,
-        disks=disk_list,
+        disk_list,
         SUBSCRIPTION_ID=subscription_id,
         update_tag=update_tag,
     )
@@ -843,7 +852,8 @@ def _attach_resource_group_disk(neo4j_session: neo4j.Session, disk_id: str, reso
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_disks,
         disk_id=disk_id,
         resource_group=resource_group,
@@ -880,7 +890,7 @@ def get_snapshots_list(credentials: Credentials, subscription_id: str, regions: 
 
 def load_snapshots(neo4j_session: neo4j.Session, subscription_id: str, snapshots: List[Dict], update_tag: int) -> None:
     ingest_snapshots = """
-    UNWIND $snapshots as snapshot
+    UNWIND $DictList as snapshot
     MERGE (s:AzureSnapshot{id: snapshot.id})
     ON CREATE SET s.firstseen = timestamp(),
     s.resourcegroup = snapshot.resource_group,
@@ -898,9 +908,10 @@ def load_snapshots(neo4j_session: neo4j.Session, subscription_id: str, snapshots
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag"""
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_snapshots,
-        snapshots=snapshots,
+        snapshots,
         SUBSCRIPTION_ID=subscription_id,
         update_tag=update_tag,
     )
@@ -918,7 +929,8 @@ def _attach_resource_group_disk_snapshot(neo4j_session: neo4j.Session, snapshot_
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_snapshots,
         snapshot_id=snapshot_id,
         resource_group=resource_group,
@@ -1012,8 +1024,8 @@ def link_compute_to_aks(neo4j_session: neo4j.Session, update_tag: int) -> None:
     """
 
     for label in aks_node_labels:
-        neo4j_session.run(cluster_query.format(label=label), update_tag=update_tag)
-        neo4j_session.run(pool_query.format(label=label), update_tag=update_tag)
+        run_write_query(neo4j_session, cluster_query.format(label=label), update_tag=update_tag)
+        run_write_query(neo4j_session, pool_query.format(label=label), update_tag=update_tag)
 
 
 @timeit

--- a/cartography/intel/azure/cosmosdb.py
+++ b/cartography/intel/azure/cosmosdb.py
@@ -16,6 +16,8 @@ from azure.mgmt.cosmosdb import CosmosDBManagementClient
 from cloudconsolelink.clouds.azure import AzureLinker
 
 from .util.credentials import Credentials
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import get_azure_resource_group_name
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -97,7 +99,7 @@ def load_database_account_data(
     Ingest data of all database accounts into neo4j.
     """
     ingest_database_account = """
-    UNWIND $database_accounts_list AS da
+    UNWIND $DictList AS da
     MERGE (d:AzureCosmosDBAccount{id: da.id})
     ON CREATE SET d.firstseen = timestamp(),
     d.type = da.type, d.resourcegroup = da.resourceGroup,
@@ -133,9 +135,10 @@ def load_database_account_data(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_database_account,
-        database_accounts_list=database_account_list,
+        database_account_list,
         AZURE_SUBSCRIPTION_ID=subscription_id,
         azure_update_tag=azure_update_tag,
     )
@@ -153,7 +156,8 @@ def _attach_resource_group_database_account(neo4j_session: neo4j.Session, databa
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_database_account,
         database_account_id=database_account_id,
         resource_group=resource_group,
@@ -187,7 +191,7 @@ def _load_database_account_associated_iprules(
 ) -> None:
     """Relationship between Azure Cosmos DB And Public Ip Addresses in Cartography """
     ingest_iprules = """
-        UNWIND $ip_rules_list as ip_rule
+        UNWIND $DictList as ip_rule
         MERGE (rule:AzureFirewallRule{id: ip_rule})
         ON CREATE SET
         rule.firstseen = timestamp(),
@@ -219,9 +223,10 @@ def _load_database_account_associated_iprules(
 
         """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_iprules,
-        ip_rules_list=database_account.get('ipruleslist', []),
+        database_account.get('ipruleslist', []),
         DatabaseAccountId=database_account.get('id'),
         resourceType=database_account.get('type'),
         azure_update_tag=azure_update_tag,
@@ -243,7 +248,7 @@ def _load_database_account_write_locations(
             location["location_name"] = location.get("location_name", "").replace(" ", "").lower()
 
         ingest_write_location = """
-        UNWIND $write_locations_list as wl
+        UNWIND $DictList as wl
         MERGE (loc:AzureCosmosDBLocation{id: wl.id})
         ON CREATE SET loc.firstseen = timestamp()
         SET loc.lastupdated = $azure_update_tag,
@@ -260,9 +265,10 @@ def _load_database_account_write_locations(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_write_location,
-            write_locations_list=write_locations,
+            write_locations,
             DatabaseAccountId=database_account_id,
             azure_update_tag=azure_update_tag,
         )
@@ -283,7 +289,7 @@ def _load_database_account_read_locations(
             location["location_name"] = location.get("location_name", "").replace(" ", "").lower()
 
         ingest_read_location = """
-        UNWIND $read_locations_list as rl
+        UNWIND $DictList as rl
         MERGE (loc:AzureCosmosDBLocation{id: rl.id})
         ON CREATE SET loc.firstseen = timestamp()
         SET loc.lastupdated = $azure_update_tag,
@@ -300,9 +306,10 @@ def _load_database_account_read_locations(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_read_location,
-            read_locations_list=read_locations,
+            read_locations,
             DatabaseAccountId=database_account_id,
             azure_update_tag=azure_update_tag,
         )
@@ -323,7 +330,7 @@ def _load_database_account_associated_locations(
             location["location_name"] = location.get("location_name", "").replace(" ", "").lower()
 
         ingest_associated_location = """
-        UNWIND $associated_locations_list as al
+        UNWIND $DictList as al
         MERGE (loc:AzureCosmosDBLocation{id: al.id})
         ON CREATE SET loc.firstseen = timestamp()
         SET loc.lastupdated = $azure_update_tag,
@@ -340,9 +347,10 @@ def _load_database_account_associated_locations(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_associated_location,
-            associated_locations_list=associated_locations,
+            associated_locations,
             DatabaseAccountId=database_account_id,
             azure_update_tag=azure_update_tag,
         )
@@ -373,7 +381,7 @@ def _load_cosmosdb_cors_policy(
         cors_policies = database_account['cors']
 
         ingest_cors_policy = """
-        UNWIND $cors_policies_list AS cp
+        UNWIND $DictList AS cp
         MERGE (corspolicy:AzureCosmosDBCorsPolicy{id: cp.cors_policy_unique_id})
         ON CREATE SET corspolicy.firstseen = timestamp(),
         corspolicy.allowedorigins = cp.allowed_origins
@@ -390,9 +398,10 @@ def _load_cosmosdb_cors_policy(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_cors_policy,
-            cors_policies_list=cors_policies,
+            cors_policies,
             DatabaseAccountId=database_account_id,
             region="global",
             azure_update_tag=azure_update_tag,
@@ -413,7 +422,7 @@ def _load_cosmosdb_failover_policies(
             policy["id"] = f'{database_account_id}/failoverPolicies/{policy["id"]}'
 
         ingest_failover_policies = """
-        UNWIND $failover_policies_list AS fp
+        UNWIND $DictList AS fp
         MERGE (fpolicy:AzureCosmosDBAccountFailoverPolicy{id: fp.id})
         ON CREATE SET fpolicy.firstseen = timestamp()
         SET fpolicy.lastupdated = $azure_update_tag,
@@ -427,9 +436,10 @@ def _load_cosmosdb_failover_policies(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_failover_policies,
-            failover_policies_list=failover_policies,
+            failover_policies,
             DatabaseAccountId=database_account_id,
             azure_update_tag=azure_update_tag,
         )
@@ -449,7 +459,7 @@ def _load_cosmosdb_private_endpoint_connections(
         private_endpoint_connections = database_account['private_endpoint_connections']
 
         ingest_private_endpoint_connections = """
-        UNWIND $private_endpoint_connections_list AS connection
+        UNWIND $DictList AS connection
         MERGE (pec:AzureCDBPrivateEndpointConnection{id: connection.id})
         ON CREATE SET pec.firstseen = timestamp()
         SET pec.lastupdated = $azure_update_tag,
@@ -465,9 +475,10 @@ def _load_cosmosdb_private_endpoint_connections(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_private_endpoint_connections,
-            private_endpoint_connections_list=private_endpoint_connections,
+            private_endpoint_connections,
             DatabaseAccountId=database_account_id,
             region=database_account.get("location", "global"),
             azure_update_tag=azure_update_tag,
@@ -486,7 +497,8 @@ def _attach_resource_group_private_endpoint_connection(neo4j_session: neo4j.Sess
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $azure_update_tag
         """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_endpoint_connections,
         connection_id=private_endpoint_connection_id,
         resource_group=resource_group,
@@ -508,7 +520,7 @@ def _load_cosmosdb_virtual_network_rules(
             network_rule['consolelink'] = azure_console_link.get_console_link(id=network_rule['id'], primary_ad_domain_name=common_job_parameters['Azure_Primary_AD_Domain_Name'])
 
         ingest_virtual_network_rules = """
-        UNWIND $virtual_network_rules_list AS vnr
+        UNWIND $DictList AS vnr
         MERGE (rules:AzureCosmosDBVirtualNetworkRule{id: vnr.id})
         ON CREATE SET rules.firstseen = timestamp(),
         rules.region = $region
@@ -522,9 +534,10 @@ def _load_cosmosdb_virtual_network_rules(
         SET r.lastupdated = $azure_update_tag
         """
 
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_virtual_network_rules,
-            virtual_network_rules_list=virtual_network_rules,
+            virtual_network_rules,
             DatabaseAccountId=database_account_id,
             region=database_account.get("location", "global"),
             azure_update_tag=azure_update_tag,
@@ -756,7 +769,7 @@ def _load_sql_databases(neo4j_session: neo4j.Session, sql_databases: List[Dict],
     Ingest SQL Databases into neo4j.
     """
     ingest_sql_databases = """
-    UNWIND $sql_databases_list AS database
+    UNWIND $DictList AS database
     MERGE (sdb:AzureCosmosDBSqlDatabase{id: database.id})
     ON CREATE SET sdb.firstseen = timestamp(), sdb.type = database.type,
     sdb.location = database.location,
@@ -773,9 +786,10 @@ def _load_sql_databases(neo4j_session: neo4j.Session, sql_databases: List[Dict],
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_sql_databases,
-        sql_databases_list=sql_databases,
+        sql_databases,
         azure_update_tag=update_tag,
     )
 
@@ -786,7 +800,7 @@ def _load_cassandra_keyspaces(neo4j_session: neo4j.Session, cassandra_keyspaces:
     Ingest Cassandra keyspaces into neo4j.
     """
     ingest_cassandra_keyspaces = """
-    UNWIND $cassandra_keyspaces_list AS keyspace
+    UNWIND $DictList AS keyspace
     MERGE (ck:AzureCosmosDBCassandraKeySpace{id: keyspace.id})
     ON CREATE SET ck.firstseen = timestamp(), ck.type = keyspace.type,
     ck.location = keyspace.location,
@@ -803,9 +817,10 @@ def _load_cassandra_keyspaces(neo4j_session: neo4j.Session, cassandra_keyspaces:
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_cassandra_keyspaces,
-        cassandra_keyspaces_list=cassandra_keyspaces,
+        cassandra_keyspaces,
         azure_update_tag=update_tag,
     )
 
@@ -816,7 +831,7 @@ def _load_mongodb_databases(neo4j_session: neo4j.Session, mongodb_databases: Lis
     Ingest MongoDB databases into neo4j.
     """
     ingest_mongodb_databases = """
-    UNWIND $mongodb_databases_list AS database
+    UNWIND $DictList AS database
     MERGE (mdb:AzureCosmosDBMongoDBDatabase{id: database.id})
     ON CREATE SET mdb.firstseen = timestamp(), mdb.type = database.type,
     mdb.location = database.location,
@@ -833,9 +848,10 @@ def _load_mongodb_databases(neo4j_session: neo4j.Session, mongodb_databases: Lis
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_mongodb_databases,
-        mongodb_databases_list=mongodb_databases,
+        mongodb_databases,
         azure_update_tag=update_tag,
     )
 
@@ -846,7 +862,7 @@ def _load_table_resources(neo4j_session: neo4j.Session, table_resources: List[Di
     Ingest Table resources into neo4j.
     """
     ingest_tables = """
-    UNWIND $table_resources_list AS table
+    UNWIND $DictList AS table
     MERGE (tr:AzureCosmosDBTableResource{id: table.id})
     ON CREATE SET tr.firstseen = timestamp(), tr.type = table.type,
     tr.location = table.location,
@@ -863,9 +879,10 @@ def _load_table_resources(neo4j_session: neo4j.Session, table_resources: List[Di
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_tables,
-        table_resources_list=table_resources,
+        table_resources,
         azure_update_tag=update_tag,
     )
     for table_resource in table_resources:
@@ -883,7 +900,8 @@ def _attach_resource_group_table_resource(neo4j_session: neo4j.Session, table_re
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_tables,
         table_resource_id=table_resource_id,
         resource_group=resource_group,
@@ -970,7 +988,7 @@ def _load_sql_containers(neo4j_session: neo4j.Session, containers: List[Dict], u
     Ingest SQL Container details into neo4j.
     """
     ingest_containers = """
-    UNWIND $sql_containers_list AS container
+    UNWIND $DictList AS container
     MERGE (c:AzureCosmosDBSqlContainer{id: container.id})
     ON CREATE SET c.firstseen = timestamp(), c.type = container.type,
     c.location = container.location,
@@ -993,9 +1011,10 @@ def _load_sql_containers(neo4j_session: neo4j.Session, containers: List[Dict], u
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_containers,
-        sql_containers_list=containers,
+        containers,
         azure_update_tag=update_tag,
     )
     for container in containers:
@@ -1012,7 +1031,8 @@ def _attach_resource_container(neo4j_session: neo4j.Session, container_id: str, 
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_containers,
         container_id=container_id,
         resource_group=resource_group,
@@ -1101,7 +1121,7 @@ def _load_cassandra_tables(neo4j_session: neo4j.Session, cassandra_tables: List[
     Ingest Cassandra Tables into neo4j.
     """
     ingest_cassandra_tables = """
-    UNWIND $cassandra_tables_list AS table
+    UNWIND $DictList AS table
     MERGE (ct:AzureCosmosDBCassandraTable{id: table.id})
     ON CREATE SET ct.firstseen = timestamp(), ct.type = table.type,
     ct.location = table.location,
@@ -1121,9 +1141,10 @@ def _load_cassandra_tables(neo4j_session: neo4j.Session, cassandra_tables: List[
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_cassandra_tables,
-        cassandra_tables_list=cassandra_tables,
+        cassandra_tables,
         azure_update_tag=update_tag,
     )
     for cassandra_table in cassandra_tables:
@@ -1140,7 +1161,8 @@ def _attach_resource_cassandra_table(neo4j_session: neo4j.Session, cassandra_tab
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_cassandra_tables,
         cassandra_table_id=cassandra_table_id,
         resource_group=resource_group,
@@ -1227,7 +1249,7 @@ def _load_collections(neo4j_session: neo4j.Session, collections: List[Dict], upd
     Ingest MongoDB Collections into neo4j.
     """
     ingest_collections = """
-    UNWIND $mongodb_collections_list AS collection
+    UNWIND $DictList AS collection
     MERGE (col:AzureCosmosDBMongoDBCollection{id: collection.id})
     ON CREATE SET col.firstseen = timestamp(), col.type = collection.type,
     col.location = collection.location,
@@ -1246,9 +1268,10 @@ def _load_collections(neo4j_session: neo4j.Session, collections: List[Dict], upd
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_collections,
-        mongodb_collections_list=collections,
+        collections,
         azure_update_tag=update_tag,
     )
     for collection in collections:
@@ -1265,7 +1288,8 @@ def _attach_resource_group_collection(neo4j_session: neo4j.Session, collection_i
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_collections,
         collection_id=collection_id,
         resource_group=resource_group,

--- a/cartography/intel/azure/sql.py
+++ b/cartography/intel/azure/sql.py
@@ -28,6 +28,8 @@ from . import network
 from . import tag as azure_tag
 from .util.credentials import Credentials
 from .util.timing import get_timing_policy
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import get_azure_resource_group_name
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -318,7 +320,7 @@ def load_server_data(
     Ingest the server details into neo4j.
     """
     ingest_server = """
-    UNWIND $server_list as server
+    UNWIND $DictList as server
     MERGE (s:AzureSQLServer{id: server.id})
     ON CREATE SET s.firstseen = timestamp(),
     s.resourcegroup = server.resourceGroup,
@@ -344,9 +346,10 @@ def load_server_data(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_server,
-        server_list=server_list,
+        server_list,
         AZURE_SUBSCRIPTION_ID=subscription_id,
         azure_update_tag=azure_update_tag,
     )
@@ -364,7 +367,8 @@ def _attach_resource_group_server(neo4j_session: neo4j.Session, server_id: str, 
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_server,
         server_id=server_id,
         server_resource_group=server_resource_group,
@@ -378,7 +382,7 @@ def load_server_private_endpoint_connection(neo4j_session: neo4j.Session, server
     """
     ingest_attach_private_endpoint_connection = """
     MATCH (s:AzureSQLServer{id: $server_id})
-    UNWIND $private_endpoint_connections as pec
+    UNWIND $DictList as pec
     MERGE (aspec:AzureServerPrivateEndpointConnection{id: pec.id})
     ON CREATE SET aspec.firstseen = timestamp()
     SET aspec.provisioning_state = pec.properties.provisioning_state,
@@ -389,10 +393,11 @@ def load_server_private_endpoint_connection(neo4j_session: neo4j.Session, server
     SET r.lastupdated = $azure_update_tag
     """
     for server in server_list:
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             ingest_attach_private_endpoint_connection,
+            server.get('private_endpoint_connections', []),
             server_id=server.get('id'),
-            private_endpoint_connections=server.get('private_endpoint_connections', []),
             azure_update_tag=azure_update_tag,
         )
         for private_endpoint_connection in server.get('private_endpoint_connections', []):
@@ -409,7 +414,8 @@ def _attach_resource_group_server_private_endpoint_connections(neo4j_session: ne
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_attach_private_endpoint_connection,
         aspec_id=private_endpoint_connection_id,
         resource_group=resource_group,
@@ -778,7 +784,7 @@ def _load_server_dns_aliases(
     Ingest the DNS Alias details into neo4j.
     """
     ingest_dns_aliases = """
-    UNWIND $dns_aliases_list as dns_alias
+    UNWIND $DictList as dns_alias
     MERGE (alias:AzureServerDNSAlias{id: dns_alias.id})
     ON CREATE SET alias.firstseen = timestamp()
     SET alias.name = dns_alias.name,
@@ -794,9 +800,10 @@ def _load_server_dns_aliases(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_dns_aliases,
-        dns_aliases_list=dns_aliases,
+        dns_aliases,
         azure_update_tag=update_tag,
     )
     for dns_aliases in dns_aliases:
@@ -813,7 +820,8 @@ def _attach_resource_group_dns_alias(neo4j_session: neo4j.Session, dns_alias_id:
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_dns_aliases,
         dns_alias_id=dns_alias_id,
         resource_group=resource_group,
@@ -827,7 +835,7 @@ def _load_firewall_rules(neo4j_session: neo4j.Session, fw_rules: List[Dict], upd
     Ingest the firewall rules into neo4j.
     """
     ingest_firewall_rules = """
-    UNWIND $fw_rules as fw_rule
+    UNWIND $DictList as fw_rule
     MERGE (rule:AzureFirewallRule{id: fw_rule.id})
     ON CREATE SET rule.firstseen = timestamp()
     SET rule.name = fw_rule.name,
@@ -842,9 +850,10 @@ def _load_firewall_rules(neo4j_session: neo4j.Session, fw_rules: List[Dict], upd
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_firewall_rules,
-        fw_rules=fw_rules,
+        fw_rules,
         azure_update_tag=update_tag,
     )
     for fw_rule in fw_rules:
@@ -861,7 +870,8 @@ def _attach_resource_group_fw_rule(neo4j_session: neo4j.Session, fw_rule_id: str
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_firewall_rules,
         fw_rule_id=fw_rule_id,
         resource_group=resource_group,
@@ -909,7 +919,7 @@ def _load_server_ad_admins(
     Ingest the Server AD Administrators details into neo4j.
     """
     ingest_ad_admins = """
-    UNWIND $ad_admins_list as ad_admin
+    UNWIND $DictList as ad_admin
     MERGE (a:AzureServerADAdministrator{id: ad_admin.id})
     ON CREATE SET a.firstseen = timestamp()
     SET a.name = ad_admin.name,
@@ -926,9 +936,10 @@ def _load_server_ad_admins(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_ad_admins,
-        ad_admins_list=ad_admins,
+        ad_admins,
         azure_update_tag=update_tag,
     )
     for ad_admin in ad_admins:
@@ -945,7 +956,8 @@ def _attach_resource_group_ad_admin(neo4j_session: neo4j.Session, ad_admin_id: s
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_ad_admins,
         ad_admin_id=ad_admin_id,
         resource_group=resource_group,
@@ -961,7 +973,7 @@ def _load_recoverable_databases(
     Ingest the recoverable database details into neo4j.
     """
     ingest_recoverable_databases = """
-    UNWIND $recoverable_databases_list as rec_db
+    UNWIND $DictList as rec_db
     MERGE (rd:AzureRecoverableDatabase{id: rec_db.id})
     ON CREATE SET rd.firstseen = timestamp()
     SET rd.name = rec_db.name,
@@ -978,9 +990,10 @@ def _load_recoverable_databases(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_recoverable_databases,
-        recoverable_databases_list=recoverable_databases,
+        recoverable_databases,
         region='global',
         azure_update_tag=update_tag,
     )
@@ -998,7 +1011,8 @@ def _attach_resource_group_recoverable_database(neo4j_session: neo4j.Session, re
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_recoverable_databases,
         rec_db_id=recoverable_database_id,
         resource_group=resource_group,
@@ -1014,7 +1028,7 @@ def _load_restorable_dropped_databases(
     Ingest the restorable dropped database details into neo4j.
     """
     ingest_restorable_dropped_databases = """
-    UNWIND $restorable_dropped_databases_list as res_dropped_db
+    UNWIND $DictList as res_dropped_db
     MERGE (rdd:AzureRestorableDroppedDatabase{id: res_dropped_db.id})
     ON CREATE SET rdd.firstseen = timestamp(), rdd.location = res_dropped_db.location,
     rdd.region = res_dropped_db.location
@@ -1035,9 +1049,10 @@ def _load_restorable_dropped_databases(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_restorable_dropped_databases,
-        restorable_dropped_databases_list=restorable_dropped_databases,
+        restorable_dropped_databases,
         azure_update_tag=update_tag,
     )
     for restorable_dropped_database in restorable_dropped_databases:
@@ -1054,7 +1069,8 @@ def _attach_resource_group_restorable_dropped_database(neo4j_session: neo4j.Sess
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_restorable_dropped_databases,
         res_dropped_db_id=restorable_dropped_database_id,
         resource_group=resource_group,
@@ -1070,7 +1086,7 @@ def _load_failover_groups(
     Ingest the failover groups details into neo4j.
     """
     ingest_failover_groups = """
-    UNWIND $failover_groups_list as fg
+    UNWIND $DictList as fg
     MERGE (f:AzureFailoverGroup{id: fg.id})
     ON CREATE SET f.firstseen = timestamp(), f.location = fg.location
     SET f.name = fg.name,
@@ -1085,9 +1101,10 @@ def _load_failover_groups(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_failover_groups,
-        failover_groups_list=failover_groups,
+        failover_groups,
         azure_update_tag=update_tag,
     )
     for failover_group in failover_groups:
@@ -1104,7 +1121,8 @@ def _attach_resource_group_restorable_failover_group(neo4j_session: neo4j.Sessio
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_failover_groups,
         fg_id=failover_group_id,
         resource_group=resource_group,
@@ -1120,7 +1138,7 @@ def _load_elastic_pools(
     Ingest the elastic pool details into neo4j.
     """
     ingest_elastic_pools = """
-    UNWIND $elastic_pools_list as ep
+    UNWIND $DictList as ep
     MERGE (e:AzureElasticPool{id: ep.id})
     ON CREATE SET e.firstseen = timestamp(), e.location = ep.location,
     e.region = ep.location
@@ -1140,9 +1158,10 @@ def _load_elastic_pools(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_elastic_pools,
-        elastic_pools_list=elastic_pools,
+        elastic_pools,
         azure_update_tag=update_tag,
     )
     for elastic_pool in elastic_pools:
@@ -1159,7 +1178,8 @@ def _attach_resource_group_restorable_elastic_pool(neo4j_session: neo4j.Session,
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_elastic_pools,
         ep_id=elastic_pool_id,
         resource_group=resource_group,
@@ -1175,7 +1195,7 @@ def _load_databases(
     Ingest the database details into neo4j.
     """
     ingest_databases = """
-    UNWIND $databases_list as az_database
+    UNWIND $DictList as az_database
     MERGE (d:AzureSQLDatabase{id: az_database.id})
     ON CREATE SET d.firstseen = timestamp(), d.location = az_database.location,
     d.region = az_database.location
@@ -1201,9 +1221,10 @@ def _load_databases(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_databases,
-        databases_list=databases,
+        databases,
         azure_update_tag=update_tag,
     )
     for database in databases:
@@ -1243,7 +1264,8 @@ def _attach_resource_group_restorable_database(neo4j_session: neo4j.Session, dat
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_databases,
         database_id=database_id,
         resource_group=resource_group,
@@ -1474,7 +1496,7 @@ def _load_replication_links(
     Ingest replication links into neo4j.
     """
     ingest_replication_links = """
-    UNWIND $replication_links_list as replication_link
+    UNWIND $DictList as replication_link
     MERGE (rl:AzureReplicationLink{id: replication_link.id})
     ON CREATE SET rl.firstseen = timestamp(),
     rl.location = replication_link.location,
@@ -1499,9 +1521,10 @@ def _load_replication_links(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_replication_links,
-        replication_links_list=replication_links,
+        replication_links,
         azure_update_tag=update_tag,
     )
     for replication_link in replication_links:
@@ -1518,7 +1541,8 @@ def _attach_resource_group_replication_link(neo4j_session: neo4j.Session, replic
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_replication_links,
         replication_link_id=replication_link_id,
         resource_group=resource_group,
@@ -1534,7 +1558,7 @@ def _load_db_threat_detection_policies(
     Ingest threat detection policy into neo4j.
     """
     ingest_threat_detection_policies = """
-    UNWIND $threat_detection_policies_list as tdp
+    UNWIND $DictList as tdp
     MERGE (policy:AzureDatabaseThreatDetectionPolicy{id: tdp.id})
     ON CREATE SET policy.firstseen = timestamp(),
     policy.location = tdp.location
@@ -1558,9 +1582,10 @@ def _load_db_threat_detection_policies(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_threat_detection_policies,
-        threat_detection_policies_list=threat_detection_policies,
+        threat_detection_policies,
         azure_update_tag=update_tag,
     )
     for threat_detection in threat_detection_policies:
@@ -1577,7 +1602,8 @@ def _attach_resource_group_threat_detection(neo4j_session: neo4j.Session, threat
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_threat_detection_policies,
         threat_detection_id=threat_detection_id,
         resource_group=resource_group,
@@ -1593,7 +1619,7 @@ def _load_restore_points(
     Ingest restore points into neo4j.
     """
     ingest_restore_points = """
-    UNWIND $restore_points_list as rp
+    UNWIND $DictList as rp
     MERGE (point:AzureRestorePoint{id: rp.id})
     ON CREATE SET point.firstseen = timestamp(),
     point.location = rp.location,
@@ -1611,9 +1637,10 @@ def _load_restore_points(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_restore_points,
-        restore_points_list=restore_points,
+        restore_points,
         azure_update_tag=update_tag,
     )
     for restore_point in restore_points:
@@ -1630,7 +1657,8 @@ def _attach_resource_group_restore_point(neo4j_session: neo4j.Session, restore_p
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_restore_points,
         restore_point_id=restore_point_id,
         resource_group=resource_group,
@@ -1646,7 +1674,7 @@ def _load_transparent_data_encryptions(
     Ingest transparent data encryptions into neo4j.
     """
     ingest_data_encryptions = """
-    UNWIND $transparent_data_encryptions_list as e
+    UNWIND $DictList as e
     MERGE (tae:AzureTransparentDataEncryption{id: e.id})
     ON CREATE SET tae.firstseen = timestamp(),
     tae.location = e.location,
@@ -1662,9 +1690,10 @@ def _load_transparent_data_encryptions(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_data_encryptions,
-        transparent_data_encryptions_list=encryptions_list,
+        encryptions_list,
         azure_update_tag=update_tag,
     )
     for encryption in encryptions_list:
@@ -1681,7 +1710,8 @@ def _attach_resource_group_encryption(neo4j_session: neo4j.Session, encryption_i
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_data_encryptions,
         encryption_id=encryption_id,
         resource_group=resource_group,

--- a/cartography/intel/azure/storage.py
+++ b/cartography/intel/azure/storage.py
@@ -16,6 +16,8 @@ from cloudconsolelink.clouds.azure import AzureLinker
 
 from .util.credentials import Credentials
 from .util.timing import get_timing_policy
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import get_azure_resource_group_name
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -79,7 +81,7 @@ def load_storage_account_data(
     Ingest Storage Account details into neo4j.
     """
     ingest_storage_account = """
-    UNWIND $storage_accounts_list as account
+    UNWIND $DictList as account
     MERGE (s:AzureStorageAccount{id: account.id})
     ON CREATE SET s.firstseen = timestamp(),
     s.type = account.type, s.resourcegroup = account.resourceGroup,
@@ -107,9 +109,10 @@ def load_storage_account_data(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_storage_account,
-        storage_accounts_list=storage_account_list,
+        storage_account_list,
         AZURE_SUBSCRIPTION_ID=subscription_id,
         azure_update_tag=azure_update_tag,
     )
@@ -127,7 +130,8 @@ def _attach_resource_group_storage_account(neo4j_session: neo4j.Session, storage
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_storage_account,
         account_id=storage_account_id,
         resource_group=resource_group,
@@ -336,7 +340,7 @@ def _load_queue_services(
     Ingest Queue Service details into neo4j.
     """
     ingest_queue_services = """
-    UNWIND $queue_services_list as qservice
+    UNWIND $DictList as qservice
     MERGE (qs:AzureStorageQueueService{id: qservice.id})
     ON CREATE SET qs.firstseen = timestamp(), qs.type = qservice.type, qs.region = $region
     SET qs.name = qservice.name,
@@ -350,10 +354,11 @@ def _load_queue_services(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_queue_services,
+        queue_services,
         region="global",
-        queue_services_list=queue_services,
         azure_update_tag=update_tag,
     )
     for queue_service in queue_services:
@@ -370,7 +375,8 @@ def _attach_resource_queue_service(neo4j_session: neo4j.Session, queue_service_i
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_queue_services,
         queue_service_id=queue_service_id,
         resource_group=resource_group,
@@ -386,7 +392,7 @@ def _load_table_services(
     Ingest Table Service details into neo4j.
     """
     ingest_table_services = """
-    UNWIND $table_services_list as tservice
+    UNWIND $DictList as tservice
     MERGE (ts:AzureStorageTableService{id: tservice.id})
     ON CREATE SET ts.firstseen = timestamp(), ts.type = tservice.type, ts.region = $region
     SET ts.name = tservice.name,
@@ -400,10 +406,11 @@ def _load_table_services(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_table_services,
+        table_services,
         region="global",
-        table_services_list=table_services,
         azure_update_tag=update_tag,
     )
     for table_service in table_services:
@@ -421,7 +428,8 @@ def _attach_resource_storage_table_service(neo4j_session: neo4j.Session, table_s
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_table_services,
         tservice_id=table_service_id,
         resource_group=resource_group,
@@ -437,7 +445,7 @@ def _load_file_services(
     Ingest File Service details into neo4j.
     """
     ingest_file_services = """
-    UNWIND $file_services_list as fservice
+    UNWIND $DictList as fservice
     MERGE (fs:AzureStorageFileService{id: fservice.id})
     ON CREATE SET fs.firstseen = timestamp(), fs.type = fservice.type, fs.region = $region
     SET fs.name = fservice.name,
@@ -451,10 +459,11 @@ def _load_file_services(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_file_services,
+        file_services,
         region="global",
-        file_services_list=file_services,
         azure_update_tag=update_tag,
     )
     for file_service in file_services:
@@ -471,7 +480,8 @@ def _attach_resource_storage_file_service(neo4j_session: neo4j.Session, file_ser
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_file_services,
         fservice_id=file_service_id,
         resource_group=resource_group,
@@ -487,7 +497,7 @@ def _load_blob_services(
     Ingest Blob Service details into neo4j.
     """
     ingest_blob_services = """
-    UNWIND $blob_services_list as bservice
+    UNWIND $DictList as bservice
     MERGE (bs:AzureStorageBlobService{id: bservice.id})
     ON CREATE SET bs.firstseen = timestamp(), bs.type = bservice.type, bs.region = $region
     SET bs.name = bservice.name,
@@ -501,10 +511,11 @@ def _load_blob_services(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_blob_services,
+        blob_services,
         region="global",
-        blob_services_list=blob_services,
         azure_update_tag=update_tag,
     )
     for blob_service in blob_services:
@@ -521,7 +532,8 @@ def _attach_resource_storage_blob_service(neo4j_session: neo4j.Session, blob_ser
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_blob_services,
         bservice_id=blob_service_id,
         resource_group=resource_group,
@@ -607,7 +619,7 @@ def _load_queues(neo4j_session: neo4j.Session, queues: List[Dict], update_tag: i
     Ingest Queue details into neo4j.
     """
     ingest_queues = """
-    UNWIND $queues_list as queue
+    UNWIND $DictList as queue
     MERGE (q:AzureStorageQueue{id: queue.id})
     ON CREATE SET q.firstseen = timestamp(), q.type = queue.type, q.region = $region
     SET q.name = queue.name,
@@ -621,10 +633,11 @@ def _load_queues(neo4j_session: neo4j.Session, queues: List[Dict], update_tag: i
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_queues,
+        queues,
         region="global",
-        queues_list=queues,
         azure_update_tag=update_tag,
     )
     for queue in queues:
@@ -642,7 +655,8 @@ def _attach_resource_storage_queue(neo4j_session: neo4j.Session, queue_id: str, 
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_queues,
         queue_id=queue_id,
         resource_group=resource_group,
@@ -728,7 +742,7 @@ def _load_tables(neo4j_session: neo4j.Session, tables: List[Dict], update_tag: i
     Ingest Table details into neo4j.
     """
     ingest_tables = """
-    UNWIND $tables_list as table
+    UNWIND $DictList as table
     MERGE (t:AzureStorageTable{id: table.id})
     ON CREATE SET t.firstseen = timestamp(), t.type = table.type, t.region = $region
     SET t.name = table.name,
@@ -743,10 +757,11 @@ def _load_tables(neo4j_session: neo4j.Session, tables: List[Dict], update_tag: i
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_tables,
+        tables,
         region="global",
-        tables_list=tables,
         azure_update_tag=update_tag,
     )
     for table in tables:
@@ -767,7 +782,8 @@ def _attach_resource_storage_table(neo4j_session: neo4j.Session, table_id: str, 
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_tables,
         table_id=table_id,
         resource_group=resource_group,
@@ -853,7 +869,7 @@ def _load_shares(neo4j_session: neo4j.Session, shares: List[Dict], update_tag: i
     Ingest Share details into neo4j.
     """
     ingest_shares = """
-    UNWIND $shares_list as s
+    UNWIND $DictList as s
     MERGE (share:AzureStorageFileShare{id: s.id})
     ON CREATE SET share.firstseen = timestamp(), share.type = s.type, share.region = $region
     SET share.name = s.name,
@@ -878,10 +894,11 @@ def _load_shares(neo4j_session: neo4j.Session, shares: List[Dict], update_tag: i
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_shares,
+        shares,
         region="global",
-        shares_list=shares,
         azure_update_tag=update_tag,
     )
     for share in shares:
@@ -898,7 +915,8 @@ def _attach_resource_storage_share(neo4j_session: neo4j.Session, share_id: str, 
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_shares,
         share_id=share_id,
         resource_group=resource_group,
@@ -988,7 +1006,7 @@ def _load_blob_containers(
     Ingest Blob Container details into neo4j.
     """
     ingest_blob_containers = """
-    UNWIND $blob_containers_list as blob
+    UNWIND $DictList as blob
     MERGE (bc:AzureStorageBlobContainer{id: blob.id})
     ON CREATE SET bc.firstseen = timestamp(), bc.type = blob.type, bc.region = $region
     SET bc.name = blob.name,
@@ -1014,10 +1032,11 @@ def _load_blob_containers(
     SET r.lastupdated = $azure_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_blob_containers,
+        blob_containers,
         region="global",
-        blob_containers_list=blob_containers,
         azure_update_tag=update_tag,
     )
     for blob_container in blob_containers:
@@ -1034,7 +1053,8 @@ def _attach_resource_storage_blob_container(neo4j_session: neo4j.Session, blob_c
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $azure_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_blob_containers,
         blob_id=blob_container_id,
         resource_group=resource_group,

--- a/cartography/intel/azure/subscription.py
+++ b/cartography/intel/azure/subscription.py
@@ -9,6 +9,7 @@ from azure.mgmt.resource import SubscriptionClient
 from cloudconsolelink.clouds.azure import AzureLinker
 
 from .util.credentials import Credentials
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -84,32 +85,26 @@ def load_azure_subscriptions(
     neo4j_session: neo4j.Session, tenant_id: str, subscriptions: List[Dict], update_tag: int,
 ) -> None:
     query = """
+    UNWIND $DictList AS item
     MERGE (at:AzureTenant{id: $TENANT_ID})
     ON CREATE SET at.firstseen = timestamp(),
-    at.region = $region
+    at.region = 'global'
     SET at.lastupdated = $update_tag
-    WITH at
-    MERGE (as:AzureSubscription{id: $SUBSCRIPTION_ID})
-    ON CREATE SET as.firstseen = timestamp(), as.path = $SUBSCRIPTION_PATH,
-    as.region = $region
-    SET as.lastupdated = $update_tag, as.name = $SUBSCRIPTION_NAME, as.state = $SUBSCRIPTION_STATE, as.consolelink = $CONSOLE_LINK
+    WITH at, item
+    MERGE (as:AzureSubscription{id: item.subscriptionId})
+    ON CREATE SET as.firstseen = timestamp(), as.path = item.id,
+    as.region = 'global'
+    SET as.lastupdated = $update_tag, as.name = item.displayName, as.state = item.state,
+    as.consolelink = item.consolelink
     WITH as, at
     MERGE (at)-[r:RESOURCE]->(as)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag;
     """
-    for sub in subscriptions:
-        neo4j_session.run(
-            query,
-            TENANT_ID=tenant_id,
-            SUBSCRIPTION_ID=sub['subscriptionId'],
-            SUBSCRIPTION_PATH=sub['id'],
-            SUBSCRIPTION_NAME=sub['displayName'],
-            SUBSCRIPTION_STATE=sub['state'],
-            CONSOLE_LINK=sub['consolelink'],
-            update_tag=update_tag,
-            region='global',
-        )
+    load_graph_data(
+        neo4j_session, query, subscriptions,
+        TENANT_ID=tenant_id, update_tag=update_tag,
+    )
 
 
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:

--- a/cartography/intel/azure/tenant.py
+++ b/cartography/intel/azure/tenant.py
@@ -8,6 +8,7 @@ from azure.core.exceptions import HttpResponseError
 from azure.mgmt.resource import SubscriptionClient
 
 from .util.credentials import Credentials
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -114,7 +115,8 @@ def load_azure_tenant(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag;
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         query,
         workspaceId=common_job_parameters['WORKSPACE_ID'],
         id=tenant_obj['id'],

--- a/cartography/intel/azure/util/timing.py
+++ b/cartography/intel/azure/util/timing.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 
+from cartography.graph import write_timer
+
 _local = threading.local()
 
 
@@ -24,26 +26,43 @@ class ServiceTimingContext:
     retry_count    : number of responses that carried Retry-After / x-ms-retry-after-ms
     """
 
-    __slots__ = ('service_name', 'request_count', 'throttle_count', 'retry_count')
+    __slots__ = (
+        'service_name', 'request_count', 'throttle_count', 'retry_count',
+        '_graph_t0', '_graph_elapsed',
+    )
 
     def __init__(self, service_name: str) -> None:
         self.service_name = service_name
         self.request_count: int = 0
         self.throttle_count: int = 0
         self.retry_count: int = 0
+        self._graph_t0: float = 0.0
+        self._graph_elapsed: Optional[float] = None
 
     def __enter__(self) -> 'ServiceTimingContext':
         _local.ctx = self
+        self._graph_t0 = write_timer.total()
         return self
 
     def __exit__(self, *args: Any) -> None:
+        # Freeze the graph-write delta so to_dict() stays correct after this thread
+        # moves on to another service.
+        self._graph_elapsed = self.graph_write_seconds
         _local.ctx = None
 
-    def to_dict(self) -> Dict[str, int]:
+    @property
+    def graph_write_seconds(self) -> float:
+        """Seconds this thread spent in Neo4j calls since __enter__ (frozen at exit)."""
+        if self._graph_elapsed is not None:
+            return self._graph_elapsed
+        return round(write_timer.total() - self._graph_t0, 4)
+
+    def to_dict(self) -> Dict[str, Any]:
         return {
             'request_count': self.request_count,
             'throttle_count': self.throttle_count,
             'retry_count': self.retry_count,
+            'graph_write_seconds': self.graph_write_seconds,
         }
 
 

--- a/cartography/intel/azuredevops/members.py
+++ b/cartography/intel/azuredevops/members.py
@@ -9,6 +9,7 @@ import neo4j
 from .util import call_azure_devops_api
 from .util import call_azure_devops_api_pagination
 from .util import validate_user_data
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -104,7 +105,7 @@ def load_users(
     - groupEntitlements: Group entitlements (if available)
     """
     query = """
-    UNWIND $UserData as user
+    UNWIND $DictList as user
 
     MERGE (u:AzureDevOpsUser{id: user.id})
     ON CREATE SET u.firstseen = timestamp()
@@ -125,9 +126,10 @@ def load_users(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        UserData=user_data,
+        user_data,
         OrganizationName=org_name,
         UpdateTag=common_job_parameters["UPDATE_TAG"],
     )

--- a/cartography/intel/azuredevops/organization.py
+++ b/cartography/intel/azuredevops/organization.py
@@ -8,6 +8,7 @@ import neo4j
 
 from .util import call_azure_devops_api
 from .util import validate_organization_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -76,7 +77,8 @@ def load_organization(
     ON CREATE SET o.firstseen = timestamp()
     SET o.lastupdated = $UpdateTag;
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         query,
         OrgName=org_data.get("name"),
         OrgUrl=org_data.get("url"),

--- a/cartography/intel/azuredevops/projects.py
+++ b/cartography/intel/azuredevops/projects.py
@@ -8,6 +8,7 @@ import neo4j
 
 from .util import call_azure_devops_api_pagination
 from .util import validate_project_data
+from cartography.client.core.tx import load_graph_data
 from cartography.util import normalize_datetime
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -77,7 +78,7 @@ def load_projects(
     - capabilities: Project capabilities (if available)
     """
     query = """
-    UNWIND $ProjectData as project
+    UNWIND $DictList as project
 
     MERGE (p:AzureDevOpsProject{id: project.id})
     ON CREATE SET p.firstseen = timestamp()
@@ -101,9 +102,10 @@ def load_projects(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $UPDATE_TAG
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        ProjectData=project_data,
+        project_data,
         OrganizationName=organization_name,
         UPDATE_TAG=common_job_parameters["UPDATE_TAG"],
     )

--- a/cartography/intel/azuredevops/repos.py
+++ b/cartography/intel/azuredevops/repos.py
@@ -10,6 +10,8 @@ import neo4j
 
 from .util import call_azure_devops_api_pagination
 from .util import validate_repository_data
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import normalize_datetime
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -102,7 +104,7 @@ def load_repositories(
     - last_activity_at_timestamp: Last activity timestamp in milliseconds
     """
     query = """
-    UNWIND $RepoData as repo
+    UNWIND $DictList as repo
 
     MERGE (r:AzureDevOpsRepo{id: repo.id})
     ON CREATE SET r.firstseen = timestamp()
@@ -128,9 +130,10 @@ def load_repositories(
     ON CREATE SET rel.firstseen = timestamp()
     SET rel.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        RepoData=repo_data,
+        repo_data,
         ProjectId=project_id,
         UpdateTag=common_job_parameters["UPDATE_TAG"],
     )
@@ -193,7 +196,7 @@ def load_branches_data(
     Load Azure DevOps branch data into Neo4j.
     """
     query = """
-    UNWIND $BranchesData as branch
+    UNWIND $DictList as branch
     MERGE (b:AzureDevOpsBranch{id: branch.id})
     ON CREATE SET b.firstseen = timestamp()
     SET b.name = branch.name,
@@ -206,9 +209,10 @@ def load_branches_data(
     ON CREATE SET rel.firstseen = timestamp()
     SET rel.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        BranchesData=branches_data,
+        branches_data,
         UpdateTag=common_job_parameters["UPDATE_TAG"],
     )
 
@@ -247,8 +251,9 @@ def _update_repo_last_activity(
 
     if last_activity_at is not None:
         iso_str, ts_ms = normalize_datetime(last_activity_at)
-        neo4j_session.run(
-            "MATCH (r:AzureDevOpsRepo{id: $RepoId}) SET r.last_activity_at = $LastActivity, r.last_activity_at_timestamp = $LastActivityTs",
+        run_write_query(
+            neo4j_session,
+            "MATCH (r:AzureDevOpsRepo{id: $RepoId}) SET r.last_activity_at = $LastActivity, r.last_activity_at_timestamp = $LastActivityTs",  # noqa: E501
             RepoId=repo_id,
             LastActivity=iso_str,
             LastActivityTs=ts_ms,

--- a/cartography/intel/bitbucket/repositories.py
+++ b/cartography/intel/bitbucket/repositories.py
@@ -11,6 +11,8 @@ import neo4j
 from clouduniqueid.clouds.bitbucket import BitbucketUniqueId
 
 from .common import cleanse_string
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.util import make_requests_url
 from cartography.util import normalize_datetime
 from cartography.util import run_cleanup_job
@@ -176,7 +178,7 @@ def load_languages(neo4j_session: neo4j.Session, update_tag: int, repo_primary_l
     :param repo_primary_language: list of primary language to repo mappings
     """
     ingest_languages = """
-        UNWIND $Languages as lang
+        UNWIND $DictList as lang
 
         MERGE (pl:ProgrammingLanguage{id: lang.primary_language})
         ON CREATE SET pl.firstseen = timestamp(),
@@ -190,9 +192,10 @@ def load_languages(neo4j_session: neo4j.Session, update_tag: int, repo_primary_l
         SET r.lastupdated = $UpdateTag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_languages,
-        Languages=repo_primary_language,
+        repo_primary_language,
         UpdateTag=update_tag,
     )
 
@@ -262,8 +265,9 @@ def _update_repo_last_activity(
 
     if last_activity_at is not None:
         iso_str, ts_ms = normalize_datetime(last_activity_at)
-        neo4j_session.run(
-            "MATCH (r:BitbucketRepository{id: $RepoId}) SET r.last_activity_at = $LastActivity, r.last_activity_at_timestamp = $LastActivityTs",
+        run_write_query(
+            neo4j_session,
+            "MATCH (r:BitbucketRepository{id: $RepoId}) SET r.last_activity_at = $LastActivity, r.last_activity_at_timestamp = $LastActivityTs",  # noqa: E501
             RepoId=repo_id,
             LastActivity=iso_str,
             LastActivityTs=ts_ms,

--- a/cartography/intel/digitalocean/compute.py
+++ b/cartography/intel/digitalocean/compute.py
@@ -4,6 +4,7 @@ from typing import Optional
 import neo4j
 from digitalocean import Manager
 
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -82,29 +83,30 @@ def _get_project_id_for_droplet(droplet_id: int, project_resources: dict) -> Opt
 @timeit
 def load_droplets(neo4j_session: neo4j.Session, data: list, digitalocean_update_tag: int) -> None:
     query = """
-        MERGE (p:DOProject{id:$ProjectId})
+        UNWIND $DictList AS item
+        MERGE (p:DOProject{id:item.project_id})
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $digitalocean_update_tag
 
-        MERGE (d:DODroplet{id:$DropletId})
+        MERGE (d:DODroplet{id:item.id})
         ON CREATE SET d.firstseen = timestamp()
-        SET d.account_id = $AccountId,
-        d.name = $Name,
-        d.locked = $Locked,
-        d.status = $Status,
-        d.features = $Features,
-        d.region = $RegionSlug,
-        d.created_at = $CreatedAt,
-        d.image = $ImageSlug,
-        d.size = $SizeSlug,
-        d.kernel = $Kernel,
-        d.ip_address = $IpAddress,
-        d.private_ip_address = $PrivateIpAddress,
-        d.project_id = $ProjectId,
-        d.ip_v6_address = $IpV6Address,
-        d.tags = $Tags,
-        d.volumes = $Volumes,
-        d.vpc_uuid = $VpcUuid,
+        SET d.account_id = item.account_id,
+        d.name = item.name,
+        d.locked = item.locked,
+        d.status = item.status,
+        d.features = item.features,
+        d.region = item.region,
+        d.created_at = item.created_at,
+        d.image = item.image,
+        d.size = item.size,
+        d.kernel = item.kernel,
+        d.ip_address = item.ip_address,
+        d.private_ip_address = item.private_ip_address,
+        d.project_id = item.project_id,
+        d.ip_v6_address = item.ip_v6_address,
+        d.tags = item.tags,
+        d.volumes = item.volumes,
+        d.vpc_uuid = item.vpc_uuid,
         d.lastupdated = $digitalocean_update_tag
         WITH d, p
 
@@ -112,29 +114,7 @@ def load_droplets(neo4j_session: neo4j.Session, data: list, digitalocean_update_
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $digitalocean_update_tag
         """
-    for droplet in data:
-        neo4j_session.run(
-            query,
-            AccountId=droplet['account_id'],
-            DropletId=droplet['id'],
-            Name=droplet['name'],
-            Locked=droplet['locked'],
-            Status=droplet['status'],
-            Features=droplet['features'],
-            RegionSlug=droplet['region'],
-            CreatedAt=droplet['created_at'],
-            ImageSlug=droplet['image'],
-            SizeSlug=droplet['size'],
-            IpAddress=droplet['ip_address'],
-            PrivateIpAddress=droplet['private_ip_address'],
-            ProjectId=droplet['project_id'],
-            IpV6Address=droplet['ip_v6_address'],
-            Kernel=droplet['kernel'],
-            Tags=droplet['tags'],
-            Volumes=droplet['volumes'],
-            VpcUuid=droplet['vpc_uuid'],
-            digitalocean_update_tag=digitalocean_update_tag,
-        )
+    load_graph_data(neo4j_session, query, data, digitalocean_update_tag=digitalocean_update_tag)
     return
 
 

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -23,6 +23,7 @@ from oauth2client.client import GoogleCredentials
 from . import label
 from .resources import RESOURCE_FUNCTIONS
 from cartography.config import Config
+from cartography.graph import write_timer
 from cartography.graph.session import Session
 from cartography.intel.gcp import crm
 from cartography.intel.gcp.auth import AuthHelper
@@ -509,6 +510,7 @@ def concurrent_execution(
     shared_neo4j_driver=None,
 ):
     tic = time.perf_counter()
+    _gw0 = write_timer.total()
     _status = "success"
     _err: Dict = {}
     _result = None
@@ -570,6 +572,7 @@ def concurrent_execution(
             "service": service,
             "run_mode": "parallel",
             "duration_seconds": _elapsed,
+            "graph_write_seconds": round(write_timer.total() - _gw0, 4),
             "status": _status,
         }
         if _err:
@@ -623,6 +626,7 @@ def _sync_single_project(
             if func_name in RESOURCE_FUNCTIONS:
                 logger.info(f"Processing {func_name}")
                 _svc_tic = time.perf_counter()
+                _svc_gw0 = write_timer.total()
                 _svc_status = "success"
                 _svc_err: Dict = {}
                 try:
@@ -671,6 +675,7 @@ def _sync_single_project(
                         "service": func_name,
                         "run_mode": "sequential",
                         "duration_seconds": _svc_elapsed,
+                        "graph_write_seconds": round(write_timer.total() - _svc_gw0, 4),
                         "status": _svc_status,
                     }
                     if _svc_err:

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -275,42 +275,30 @@ def load_proxies_tx(
 
 
 @timeit
-def attach_compute_disks_to_instance(
+def attach_compute_disks_to_instances(
     session: neo4j.Session,
-    data_list: List[Dict],
-    instance_id: str,
+    disk_rows: List[Dict],
     update_tag: int,
 ) -> None:
-    session.execute_write(attach_compute_disks_to_instance_tx, data_list, instance_id, update_tag)
-
-
-@timeit
-def attach_compute_disks_to_instance_tx(
-    tx: neo4j.Transaction,
-    data: List[Dict],
-    instance_id: str,
-    gcp_update_tag: int,
-) -> None:
+    """
+    Attach disks to their instances in one batched write. Each row needs 'id' (the disk
+    id) and 'instance_id'.
+    """
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (disk:GCPComputeDisk{id:record.id})
     ON CREATE SET
         disk.firstseen = timestamp()
     SET
         disk.lastupdated = $gcp_update_tag
-    WITH disk
-    MATCH (i:GCPInstance{id: $InstanceId})
+    WITH disk, record
+    MATCH (i:GCPInstance{id: record.instance_id})
     MERGE (i)-[r:USES]->(disk)
     ON CREATE SET
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    tx.run(
-        query,
-        Records=data,
-        InstanceId=instance_id,
-        gcp_update_tag=gcp_update_tag,
-    )
+    load_graph_data(session, query, disk_rows, gcp_update_tag=update_tag)
 
 
 def _get_error_reason(http_error: HttpError) -> str:
@@ -1908,13 +1896,16 @@ def sync_gcp_instances(
 
     load_gcp_instances(neo4j_session, instance_list, gcp_update_tag)
 
-    # attach compute instance to disks
-    for instance in instance_list:
-        disks = []
-        for disk in instance.get("disks", []):
-            disk["id"] = f"projects/{project_id}/disks/{disk.get('initializeParams', {}).get('diskName', '')}"
-            disks.append(disk)
-        attach_compute_disks_to_instance(neo4j_session, disks, instance["partial_uri"], gcp_update_tag)
+    # attach compute instances to disks - one batched write across all instances
+    disk_rows = [
+        {
+            "id": f"projects/{project_id}/disks/{disk.get('initializeParams', {}).get('diskName', '')}",
+            "instance_id": instance["partial_uri"],
+        }
+        for instance in instance_list
+        for disk in instance.get("disks", [])
+    ]
+    attach_compute_disks_to_instances(neo4j_session, disk_rows, gcp_update_tag)
 
     # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gcp_instances(neo4j_session, common_job_parameters)

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -953,105 +953,90 @@ def load_gcp_instances(session: neo4j.Session, instances_list: List[Dict], gcp_u
     for paginated_instances in batch(instances_list, size=500):
         session.execute_write(load_gcp_instances_tx, paginated_instances, gcp_update_tag)
 
-    for instance in instances_list:
-        _attach_instance_tags(session, instance, gcp_update_tag)
-        _attach_gcp_nics(session, instance, gcp_update_tag)
-        _attach_gcp_vpc(session, instance["partial_uri"], gcp_update_tag)
-        _attach_instance_service_account(session, instance, gcp_update_tag)
-        # Link to GKE cluster and node pool when the instance carries GKE metadata labels.
-        # These labels (goog-gke-cluster-name, goog-gke-nodepool) are attached automatically
-        # by GCP to every Compute instance that is a GKE node.
-        if instance.get("gke_cluster_name"):
-            _link_instance_to_gke_cluster(session, instance, gcp_update_tag)
-        if instance.get("gke_cluster_name") and instance.get("gke_node_pool_name"):
-            _link_instance_to_gke_node_pool(session, instance, gcp_update_tag)
+    _attach_instance_tags(session, instances_list, gcp_update_tag)
+    _attach_gcp_nics(session, instances_list, gcp_update_tag)
+    _attach_gcp_nic_access_configs(session, instances_list, gcp_update_tag)
+    _attach_gcp_vpc(session, [i["partial_uri"] for i in instances_list], gcp_update_tag)
+    _attach_instance_service_account(session, instances_list, gcp_update_tag)
+    # Link to GKE cluster and node pool when an instance carries GKE metadata labels.
+    # These labels (goog-gke-cluster-name, goog-gke-nodepool) are attached automatically
+    # by GCP to every Compute instance that is a GKE node.
+    _link_instance_to_gke_cluster(session, instances_list, gcp_update_tag)
+    _link_instance_to_gke_node_pool(session, instances_list, gcp_update_tag)
 
     load_gcp_instance_image_relations(session, instances_list, gcp_update_tag)
 
 
+def _gke_cluster_id(instance: Dict) -> str:
+    """Same format as get_gke_clusters(): projects/{project}/locations/{region}/clusters/{name}."""
+    return (
+        f"projects/{instance['project_id']}/locations/{instance['region']}"
+        f"/clusters/{instance['gke_cluster_name']}"
+    )
+
+
+def _build_gke_cluster_link_rows(instances_list: List[Dict]) -> List[Dict]:
+    return [
+        {"cluster_id": _gke_cluster_id(i), "instance_id": i["partial_uri"]}
+        for i in instances_list if i.get("gke_cluster_name")
+    ]
+
+
+def _build_gke_node_pool_link_rows(instances_list: List[Dict]) -> List[Dict]:
+    return [
+        {
+            "node_pool_id": f"{_gke_cluster_id(i)}/nodePools/{i['gke_node_pool_name']}",
+            "instance_id": i["partial_uri"],
+        }
+        for i in instances_list
+        if i.get("gke_cluster_name") and i.get("gke_node_pool_name")
+    ]
+
+
 @timeit
 def _link_instance_to_gke_cluster(
-    neo4j_session: neo4j.Session, instance: Dict, gcp_update_tag: int,
+    neo4j_session: neo4j.Session, instances_list: List[Dict], gcp_update_tag: int,
 ) -> None:
     """
-    Create a (GKECluster)-[:HAS_NODE]->(GCPInstance) relationship.
+    Create (GKECluster)-[:HAS_NODE]->(GCPInstance) relationships for every instance that
+    carries GKE metadata labels.
 
     Uses MATCH for GKECluster (not MERGE) so that if the GKE sync has not yet
     run for this project the relationship is simply skipped rather than creating
     a dangling, property-less GKECluster stub.
-
-    The cluster ID is reconstructed with the same format as get_gke_clusters():
-        projects/{project_id}/locations/{region}/clusters/{cluster_name}
-
-    :type neo4j_session: neo4j.Session
-    :param neo4j_session: The Neo4j session
-    :type instance: Dict
-    :param instance: A single transformed GCP instance dict.
-                     Must contain 'project_id', 'region', and 'gke_cluster_name'.
-    :type gcp_update_tag: int
-    :param gcp_update_tag: Timestamp to stamp on the relationship
-    :rtype: NoneType
-    :return: Nothing
     """
     query = """
-    MATCH (cluster:GKECluster{id: $ClusterId})
-    MATCH (i:GCPInstance{id: $InstanceId})
+    UNWIND $DictList AS item
+    MATCH (cluster:GKECluster{id: item.cluster_id})
+    MATCH (i:GCPInstance{id: item.instance_id})
     MERGE (cluster)-[r:HAS_NODE]->(i)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    cluster_id = (
-        f"projects/{instance['project_id']}/locations/{instance['region']}"
-        f"/clusters/{instance['gke_cluster_name']}"
-    )
-    neo4j_session.run(
-        query,
-        ClusterId=cluster_id,
-        InstanceId=instance["partial_uri"],
-        gcp_update_tag=gcp_update_tag,
-    )
+    load_graph_data(neo4j_session, query, _build_gke_cluster_link_rows(instances_list), gcp_update_tag=gcp_update_tag)
 
 
 @timeit
 def _link_instance_to_gke_node_pool(
-    neo4j_session: neo4j.Session, instance: Dict, gcp_update_tag: int,
+    neo4j_session: neo4j.Session, instances_list: List[Dict], gcp_update_tag: int,
 ) -> None:
     """
-    Create a (GKENodePool)-[:HAS_NODE]->(GCPInstance) relationship.
+    Create (GKENodePool)-[:HAS_NODE]->(GCPInstance) relationships for every instance that
+    carries GKE cluster + node pool metadata labels.
 
     Uses MATCH for GKENodePool (not MERGE) so that if the GKE sync has not yet
     run for this project the relationship is simply skipped.
-
-    The node pool ID is reconstructed with the same format as _load_gke_node_pools_tx():
-        projects/{project_id}/locations/{region}/clusters/{cluster_name}/nodePools/{pool_name}
-
-    :type neo4j_session: neo4j.Session
-    :param neo4j_session: The Neo4j session
-    :type instance: Dict
-    :param instance: A single transformed GCP instance dict.
-                     Must contain 'project_id', 'region', 'gke_cluster_name', and 'gke_node_pool_name'.
-    :type gcp_update_tag: int
-    :param gcp_update_tag: Timestamp to stamp on the relationship
-    :rtype: NoneType
-    :return: Nothing
     """
     query = """
-    MATCH (pool:GKENodePool{id: $NodePoolId})
-    MATCH (i:GCPInstance{id: $InstanceId})
+    UNWIND $DictList AS item
+    MATCH (pool:GKENodePool{id: item.node_pool_id})
+    MATCH (i:GCPInstance{id: item.instance_id})
     MERGE (pool)-[r:HAS_NODE]->(i)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    cluster_id = (
-        f"projects/{instance['project_id']}/locations/{instance['region']}"
-        f"/clusters/{instance['gke_cluster_name']}"
-    )
-    node_pool_id = f"{cluster_id}/nodePools/{instance['gke_node_pool_name']}"
-    neo4j_session.run(
-        query,
-        NodePoolId=node_pool_id,
-        InstanceId=instance["partial_uri"],
-        gcp_update_tag=gcp_update_tag,
+    load_graph_data(
+        neo4j_session, query, _build_gke_node_pool_link_rows(instances_list), gcp_update_tag=gcp_update_tag,
     )
 
 
@@ -1341,21 +1326,37 @@ def _attach_fwd_rules_to_vpcs(neo4j_session: neo4j.Session, fwd_rules: List[Dict
     load_graph_data(neo4j_session, query, fwd_rules, gcp_update_tag=gcp_update_tag)
 
 
+def _build_instance_tag_rows(instances_list: List[Dict]) -> List[Dict]:
+    """One row per instance x tag x network-interface (this was a nested per-item loop)."""
+    rows = []
+    for instance in instances_list:
+        for tag in instance.get("tags", {}).get("items", []):
+            for nic in instance.get("networkInterfaces", []):
+                rows.append({
+                    "instance_id": instance["partial_uri"],
+                    "tag_id": _create_gcp_network_tag_id(nic["vpc_partial_uri"], tag),
+                    "tag_value": tag,
+                    "vpc_partial_uri": nic["vpc_partial_uri"],
+                })
+    return rows
+
+
 @timeit
-def _attach_instance_tags(neo4j_session: neo4j.Session, instance: Resource, gcp_update_tag: int) -> None:
+def _attach_instance_tags(neo4j_session: neo4j.Session, instances_list: List[Dict], gcp_update_tag: int) -> None:
     """
-    Attach tags to GCP instance and to the VPCs that they are defined in.
+    Attach tags to GCP instances and to the VPCs that they are defined in.
     :param neo4j_session: The session
-    :param instance: The instance object
+    :param instances_list: The transformed instance dicts
     :param gcp_update_tag: The timestamp
     :return: Nothing
     """
     query = """
-    MATCH (i:GCPInstance{id: $InstanceId})
+    UNWIND $DictList AS item
+    MATCH (i:GCPInstance{id: item.instance_id})
 
-    MERGE (t:GCPNetworkTag{id: $TagId})
-    ON CREATE SET t.tag_id = $TagId,
-    t.value = $TagValue,
+    MERGE (t:GCPNetworkTag{id: item.tag_id})
+    ON CREATE SET t.tag_id = item.tag_id,
+    t.value = item.tag_value,
     t.firstseen = timestamp()
     SET t.lastupdated = $gcp_update_tag
 
@@ -1363,171 +1364,176 @@ def _attach_instance_tags(neo4j_session: neo4j.Session, instance: Resource, gcp_
     ON CREATE SET h.firstseen = timestamp()
     SET h.lastupdated = $gcp_update_tag
 
-    WITH t
-    MATCH (vpc:GCPVpc{id: $VpcPartialUri})
+    WITH t, item
+    MATCH (vpc:GCPVpc{id: item.vpc_partial_uri})
 
     MERGE (vpc)<-[d:DEFINED_IN]-(t)
     ON CREATE SET d.firstseen = timestamp()
     SET d.lastupdated = $gcp_update_tag
     """
-    for tag in instance.get("tags", {}).get("items", []):
+    load_graph_data(neo4j_session, query, _build_instance_tag_rows(instances_list), gcp_update_tag=gcp_update_tag)
+
+
+def _nic_id(instance: Dict, nic: Dict) -> str:
+    """GCP doesn't define an ID for network interfaces, so make one to uniquely identify them."""
+    return f"{instance['partial_uri']}/networkinterfaces/{nic['name']}"
+
+
+def _build_nic_rows(instances_list: List[Dict]) -> List[Dict]:
+    return [
+        {
+            "instance_id": instance["partial_uri"],
+            "nic_id": _nic_id(instance, nic),
+            "network": nic.get("network"),
+            "name": nic["name"],
+            "consolelink": nic.get("consolelink"),
+            "subnet_partial_uri": nic["subnet_partial_uri"],
+        }
+        for instance in instances_list
+        for nic in instance.get("networkInterfaces", [])
+    ]
+
+
+def _build_access_config_rows(instances_list: List[Dict]) -> List[Dict]:
+    rows = []
+    for instance in instances_list:
         for nic in instance.get("networkInterfaces", []):
-            tag_id = _create_gcp_network_tag_id(nic["vpc_partial_uri"], tag)
-            neo4j_session.run(
-                query,
-                InstanceId=instance["partial_uri"],
-                TagId=tag_id,
-                TagValue=tag,
-                VpcPartialUri=nic["vpc_partial_uri"],
-                gcp_update_tag=gcp_update_tag,
-            )
+            nic_id = _nic_id(instance, nic)
+            for ac in nic.get("accessConfigs", []):
+                # GCP doesn't define an ID for access configs either.
+                rows.append({
+                    "nic_id": nic_id,
+                    "access_config_id": f"{nic_id}/accessconfigs/{ac['type']}",
+                    "type": ac["type"],
+                    "name": ac["name"],
+                    "consolelink": ac.get("consolelink"),
+                    "nat_ip": ac.get("natIP"),
+                    "set_public_ptr": ac.get("setPublicPtr"),
+                    "public_ptr_domain_name": ac.get("publicPtrDomainName"),
+                    "network_tier": ac.get("networkTier"),
+                })
+    return rows
+
+
+def _build_service_account_rows(instances_list: List[Dict]) -> List[Dict]:
+    return [
+        {"instance_id": instance["partial_uri"], "email": account.get("email", "")}
+        for instance in instances_list
+        for account in instance.get("serviceAccounts", [])
+    ]
 
 
 @timeit
-def _attach_gcp_nics(neo4j_session: neo4j.Session, instance: Resource, gcp_update_tag: int) -> None:
+def _attach_gcp_nics(neo4j_session: neo4j.Session, instances_list: List[Dict], gcp_update_tag: int) -> None:
     """
     Attach GCP Network Interfaces to GCP Instances and GCP Subnets.
-    Then, attach GCP Instances directly to VPCs.
     :param neo4j_session: The Neo4j session
-    :param instance: The GCP instance
+    :param instances_list: The transformed GCP instance dicts
     :param gcp_update_tag: Timestamp to set the nodes
     :return: Nothing
     """
     query = """
-    MATCH (i:GCPInstance{id: $InstanceId})
-    MERGE (nic:GCPNetworkInterface{id: $NicId})
+    UNWIND $DictList AS item
+    MATCH (i:GCPInstance{id: item.instance_id})
+    MERGE (nic:GCPNetworkInterface{id: item.nic_id})
     ON CREATE SET nic.firstseen = timestamp(),
-    nic.nic_id = $NicId
-    SET nic.network = $Network,
-    nic.consolelink=$ConsoleLink,
-    nic.name = $NicName,
+    nic.nic_id = item.nic_id
+    SET nic.network = item.network,
+    nic.consolelink = item.consolelink,
+    nic.name = item.name,
     nic.lastupdated = $gcp_update_tag
     MERGE (i)-[r:NETWORK_INTERFACE]->(nic)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
 
-    MERGE (subnet:GCPSubnet{id: $SubnetPartialUri})
+    MERGE (subnet:GCPSubnet{id: item.subnet_partial_uri})
     ON CREATE SET subnet.firstseen = timestamp(),
-    subnet.partial_uri = $SubnetPartialUri
+    subnet.partial_uri = item.subnet_partial_uri
     SET subnet.lastupdated = $gcp_update_tag
 
     MERGE (nic)-[p:PART_OF_SUBNET]->(subnet)
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $gcp_update_tag
     """
-    for nic in instance.get("networkInterfaces", []):
-        # Make an ID for GCPNetworkInterface nodes because GCP doesn't define one but we need to uniquely identify them
-        nic_id = f"{instance['partial_uri']}/networkinterfaces/{nic['name']}"
-        neo4j_session.run(
-            query,
-            InstanceId=instance["partial_uri"],
-            NicId=nic_id,
-            NetworkIP=nic.get("networkIP"),
-            Network=nic.get("network"),
-            NicName=nic["name"],
-            ConsoleLink=nic.get("consolelink"),
-            gcp_update_tag=gcp_update_tag,
-            SubnetPartialUri=nic["subnet_partial_uri"],
-        )
-        _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag)
+    load_graph_data(neo4j_session, query, _build_nic_rows(instances_list), gcp_update_tag=gcp_update_tag)
 
 
 @timeit
 def _attach_gcp_nic_access_configs(
     neo4j_session: neo4j.Session,
-    nic_id: str,
-    nic: Resource,
+    instances_list: List[Dict],
     gcp_update_tag: int,
 ) -> None:
     """
-    Attach an access configuration to the GCP NIC.
+    Attach access configurations to the GCP NICs.
     :param neo4j_session: The Neo4j session
-    :param instance: The GCP instance
+    :param instances_list: The transformed GCP instance dicts
     :param gcp_update_tag: The timestamp to set updated nodes to
     :return: Nothing
     """
     query = """
-    MATCH (nic:GCPNetworkInterface{id: $NicId})
-    MERGE (ac:GCPNicAccessConfig{id: $AccessConfigId})
+    UNWIND $DictList AS item
+    MATCH (nic:GCPNetworkInterface{id: item.nic_id})
+    MERGE (ac:GCPNicAccessConfig{id: item.access_config_id})
     ON CREATE SET ac.firstseen = timestamp(),
-    ac.access_config_id = $AccessConfigId
-    SET ac.type=$Type,
-    ac.name = $Name,
-    ac.consolelink=$ConsoleLink,
-    ac.public_ip =  $NatIP,
-    ac.set_public_ptr = $SetPublicPtr,
-    ac.public_ptr_domain_name = $PublicPtrDomainName,
-    ac.network_tier = $NetworkTier,
+    ac.access_config_id = item.access_config_id
+    SET ac.type = item.type,
+    ac.name = item.name,
+    ac.consolelink = item.consolelink,
+    ac.public_ip = item.nat_ip,
+    ac.set_public_ptr = item.set_public_ptr,
+    ac.public_ptr_domain_name = item.public_ptr_domain_name,
+    ac.network_tier = item.network_tier,
     ac.lastupdated = $gcp_update_tag
 
     MERGE (nic)-[r:RESOURCE]->(ac)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    for ac in nic.get("accessConfigs", []):
-        # Make an ID for GCPNicAccessConfig nodes because GCP doesn't define one but we need to uniquely identify them
-        access_config_id = f"{nic_id}/accessconfigs/{ac['type']}"
-        neo4j_session.run(
-            query,
-            NicId=nic_id,
-            AccessConfigId=access_config_id,
-            Type=ac["type"],
-            Name=ac["name"],
-            ConsoleLink=ac.get("consolelink"),
-            NatIP=ac.get("natIP", None),
-            SetPublicPtr=ac.get("setPublicPtr", None),
-            PublicPtrDomainName=ac.get("publicPtrDomainName", None),
-            NetworkTier=ac.get("networkTier", None),
-            gcp_update_tag=gcp_update_tag,
-        )
+    load_graph_data(neo4j_session, query, _build_access_config_rows(instances_list), gcp_update_tag=gcp_update_tag)
 
 
 @timeit
-def _attach_gcp_vpc(neo4j_session: neo4j.Session, instance_id: str, gcp_update_tag: int) -> None:
+def _attach_gcp_vpc(neo4j_session: neo4j.Session, instance_ids: List[str], gcp_update_tag: int) -> None:
     """
-    Attach a GCP instance directly to a VPC
+    Attach GCP instances directly to their VPCs.
     :param neo4j_session: neo4j_session
-    :param instance: The GCP instance object
+    :param instance_ids: The instance partial_uris
     :param gcp_update_tag:
     :return: Nothing
     """
     query = """
-    MATCH (i:GCPInstance{id: $InstanceId})-[:NETWORK_INTERFACE]->(nic:GCPNetworkInterface)
+    UNWIND $DictList AS item
+    MATCH (i:GCPInstance{id: item.instance_id})-[:NETWORK_INTERFACE]->(nic:GCPNetworkInterface)
           -[p:PART_OF_SUBNET]->(sn:GCPSubnet)<-[r:RESOURCE]-(vpc:GCPVpc)
     MERGE (i)-[m:MEMBER_OF_GCP_VPC]->(vpc)
     ON CREATE SET m.firstseen = timestamp()
     SET m.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
-        query,
-        InstanceId=instance_id,
-        gcp_update_tag=gcp_update_tag,
-    )
+    rows = [{"instance_id": instance_id} for instance_id in instance_ids]
+    load_graph_data(neo4j_session, query, rows, gcp_update_tag=gcp_update_tag)
 
 
 @timeit
-def _attach_instance_service_account(neo4j_session: neo4j.Session, instance: Resource, gcp_update_tag: int) -> None:
+def _attach_instance_service_account(
+    neo4j_session: neo4j.Session, instances_list: List[Dict], gcp_update_tag: int,
+) -> None:
     """
-    Attach service account to GCP instance
+    Attach service accounts to GCP instances.
     :param neo4j_session: The session
-    :param instance: The instance object
+    :param instances_list: The transformed GCP instance dicts
     :param gcp_update_tag: The timestamp
     :return: Nothing
     """
     query = """
-    MATCH (i:GCPInstance{id: $InstanceId})
-    MERGE (sa:GCPServiceAccount{email: $AccountEmail})
+    UNWIND $DictList AS item
+    MATCH (i:GCPInstance{id: item.instance_id})
+    MERGE (sa:GCPServiceAccount{email: item.email})
     MERGE (i)-[r:USES]->(sa)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    for account in instance.get("serviceAccounts", []):
-        neo4j_session.run(
-            query,
-            InstanceId=instance["partial_uri"],
-            AccountEmail=account.get("email", ""),
-            gcp_update_tag=gcp_update_tag,
-        )
+    load_graph_data(neo4j_session, query, _build_service_account_rows(instances_list), gcp_update_tag=gcp_update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -1270,102 +1270,75 @@ def load_gcp_forwarding_rules(neo4j_session: neo4j.Session, fwd_rules: List[Dict
     """
 
     query = """
-        MERGE (fwd:GCPForwardingRule{id: $PartialUri})
+        UNWIND $DictList AS item
+        MERGE (fwd:GCPForwardingRule{id: item.partial_uri})
         ON CREATE SET fwd.firstseen = timestamp(),
-        fwd.partial_uri = $PartialUri
-        SET fwd.ip_address = $IPAddress,
-        fwd.ip_protocol = $IPProtocol,
-        fwd.load_balancing_scheme = $LoadBalancingScheme,
-        fwd.name = $Name,
-        fwd.network = $NetworkPartialUri,
-        fwd.port_range = $PortRange,
-        fwd.ports = $Ports,
-        fwd.project_id = $ProjectId,
-        fwd.region = $Region,
-        fwd.self_link = $SelfLink,
-        fwd.subnetwork = $SubNetworkPartialUri,
-        fwd.target = $TargetPartialUri,
-        fwd.consolelink = $consolelink,
+        fwd.partial_uri = item.partial_uri
+        SET fwd.ip_address = item.ip_address,
+        fwd.ip_protocol = item.ip_protocol,
+        fwd.load_balancing_scheme = item.load_balancing_scheme,
+        fwd.name = item.name,
+        fwd.network = item.network_partial_uri,
+        fwd.port_range = item.port_range,
+        fwd.ports = item.ports,
+        fwd.project_id = item.project_id,
+        fwd.region = coalesce(item.region, 'global'),
+        fwd.self_link = item.self_link,
+        fwd.subnetwork = item.subnetwork_partial_uri,
+        fwd.target = item.target,
+        fwd.consolelink = item.consolelink,
         fwd.lastupdated = $gcp_update_tag
     """
+    load_graph_data(neo4j_session, query, fwd_rules, gcp_update_tag=gcp_update_tag)
 
-    for fwd in fwd_rules:
-        network = fwd.get("network", None)
-        subnetwork = fwd.get("subnetwork", None)
-
-        neo4j_session.run(
-            query,
-            PartialUri=fwd["partial_uri"],
-            IPAddress=fwd["ip_address"],
-            IPProtocol=fwd["ip_protocol"],
-            LoadBalancingScheme=fwd["load_balancing_scheme"],
-            Name=fwd["name"],
-            Network=network,
-            NetworkPartialUri=fwd.get("network_partial_uri", None),
-            PortRange=fwd.get("port_range", None),
-            Ports=fwd.get("ports", None),
-            ProjectId=fwd["project_id"],
-            Region=fwd.get("region", "global"),
-            SelfLink=fwd["self_link"],
-            SubNetwork=subnetwork,
-            SubNetworkPartialUri=fwd.get("subnetwork_partial_uri", None),
-            TargetPartialUri=fwd["target"],
-            consolelink=fwd.get("consolelink", None),
-            gcp_update_tag=gcp_update_tag,
-        )
-
-        if subnetwork:
-            _attach_fwd_rule_to_subnet(neo4j_session, fwd, gcp_update_tag)
-        elif network:
-            _attach_fwd_rule_to_vpc(neo4j_session, fwd, gcp_update_tag)
+    _attach_fwd_rules_to_subnets(
+        neo4j_session,
+        [fwd for fwd in fwd_rules if fwd.get("subnetwork")],
+        gcp_update_tag,
+    )
+    _attach_fwd_rules_to_vpcs(
+        neo4j_session,
+        [fwd for fwd in fwd_rules if not fwd.get("subnetwork") and fwd.get("network")],
+        gcp_update_tag,
+    )
 
 
 @timeit
-def _attach_fwd_rule_to_subnet(neo4j_session: neo4j.Session, fwd: Dict, gcp_update_tag: int) -> None:
+def _attach_fwd_rules_to_subnets(neo4j_session: neo4j.Session, fwd_rules: List[Dict], gcp_update_tag: int) -> None:
     query = """
-        MERGE (subnet:GCPSubnet{id: $SubNetworkPartialUri})
+        UNWIND $DictList AS item
+        MERGE (subnet:GCPSubnet{id: item.subnetwork_partial_uri})
         ON CREATE SET subnet.firstseen = timestamp(),
-        subnet.partial_uri = $SubNetworkPartialUri
+        subnet.partial_uri = item.subnetwork_partial_uri
         SET subnet.lastupdated = $gcp_update_tag
 
-        WITH subnet
-        MATCH(fwd:GCPForwardingRule{id: $PartialUri})
+        WITH subnet, item
+        MATCH(fwd:GCPForwardingRule{id: item.partial_uri})
 
         MERGE (subnet)-[p:RESOURCE]->(fwd)
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $gcp_update_tag
     """
-
-    neo4j_session.run(
-        query,
-        PartialUri=fwd["partial_uri"],
-        SubNetworkPartialUri=fwd.get("subnetwork_partial_uri", None),
-        gcp_update_tag=gcp_update_tag,
-    )
+    load_graph_data(neo4j_session, query, fwd_rules, gcp_update_tag=gcp_update_tag)
 
 
 @timeit
-def _attach_fwd_rule_to_vpc(neo4j_session: neo4j.Session, fwd: Dict, gcp_update_tag: int) -> None:
+def _attach_fwd_rules_to_vpcs(neo4j_session: neo4j.Session, fwd_rules: List[Dict], gcp_update_tag: int) -> None:
     query = """
-        MERGE (vpc:GCPVpc{id: $NetworkPartialUri})
+        UNWIND $DictList AS item
+        MERGE (vpc:GCPVpc{id: item.network_partial_uri})
         ON CREATE SET vpc.firstseen = timestamp(),
-        vpc.partial_uri = $NetworkPartialUri
+        vpc.partial_uri = item.network_partial_uri
         SET vpc.lastupdated = $gcp_update_tag
 
-        WITH vpc
-        MATCH (fwd:GCPForwardingRule{id: $PartialUri})
+        WITH vpc, item
+        MATCH (fwd:GCPForwardingRule{id: item.partial_uri})
 
         MERGE (vpc)-[r:RESOURCE]->(fwd)
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $gcp_update_tag
     """
-
-    neo4j_session.run(
-        query,
-        PartialUri=fwd["partial_uri"],
-        NetworkPartialUri=fwd.get("network_partial_uri", None),
-        gcp_update_tag=gcp_update_tag,
-    )
+    load_graph_data(neo4j_session, query, fwd_rules, gcp_update_tag=gcp_update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -23,6 +23,7 @@ from googleapiclient.discovery import Resource
 from . import iam
 from . import instance_groups
 from . import label
+from cartography.client.core.tx import load_graph_data
 from cartography.util import batch
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -1194,43 +1195,30 @@ def load_gcp_vpcs(neo4j_session: neo4j.Session, vpcs: List[Dict], gcp_update_tag
     :return: Nothing
     """
     query = """
-    MERGE (p:GCPProject{id: $ProjectId})
+    UNWIND $DictList AS item
+    MERGE (p:GCPProject{id: item.project_id})
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = $gcp_update_tag
 
-    MERGE (vpc:GCPVpc{id: $PartialUri})
+    MERGE (vpc:GCPVpc{id: item.partial_uri})
     ON CREATE SET vpc.firstseen = timestamp(),
-    vpc.partial_uri = $PartialUri
-    SET vpc.self_link = $SelfLink,
-    vpc.region = $region,
-    vpc.name = $VpcName,
-    vpc.project_id =  $ProjectId,
-    vpc.auto_create_subnetworks = $AutoCreateSubnetworks,
-    vpc.routing_config_routing_mode = $RoutingMode,
-    vpc.description = $Description,
-    vpc.consolelink = $consolelink,
+    vpc.partial_uri = item.partial_uri
+    SET vpc.self_link = item.self_link,
+    vpc.region = item.region,
+    vpc.name = item.name,
+    vpc.project_id = item.project_id,
+    vpc.auto_create_subnetworks = item.auto_create_subnetworks,
+    vpc.routing_config_routing_mode = item.routing_config_routing_mode,
+    vpc.description = item.description,
+    vpc.consolelink = item.consolelink,
     vpc.lastupdated = $gcp_update_tag,
-    vpc.is_default = $isDefault
+    vpc.is_default = item.isDefault
 
     MERGE (p)-[r:RESOURCE]->(vpc)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    for vpc in vpcs:
-        neo4j_session.run(
-            query,
-            ProjectId=vpc["project_id"],
-            PartialUri=vpc["partial_uri"],
-            SelfLink=vpc["self_link"],
-            VpcName=vpc["name"],
-            AutoCreateSubnetworks=vpc["auto_create_subnetworks"],
-            RoutingMode=vpc["routing_config_routing_mode"],
-            Description=vpc["description"],
-            region=vpc.get("region"),
-            consolelink=vpc.get("consolelink"),
-            gcp_update_tag=gcp_update_tag,
-            isDefault=vpc.get("isDefault"),
-        )
+    load_graph_data(neo4j_session, query, vpcs, gcp_update_tag=gcp_update_tag)
 
 
 @timeit
@@ -1243,47 +1231,32 @@ def load_gcp_subnets(neo4j_session: neo4j.Session, subnets: List[Dict], gcp_upda
     :return: Nothing
     """
     query = """
-    MERGE (vpc:GCPVpc{id: $VpcPartialUri})
+    UNWIND $DictList AS item
+    MERGE (vpc:GCPVpc{id: item.vpc_partial_uri})
     ON CREATE SET vpc.firstseen = timestamp(),
-    vpc.partial_uri = $VpcPartialUri
+    vpc.partial_uri = item.vpc_partial_uri
     SET vpc.lastupdated = $gcp_update_tag
 
-    MERGE (subnet:GCPSubnet{id: $PartialUri})
+    MERGE (subnet:GCPSubnet{id: item.partial_uri})
     ON CREATE SET subnet.firstseen = timestamp(),
-    subnet.partial_uri = $PartialUri
-    SET subnet.self_link = $SubnetSelfLink,
-    subnet.project_id = $ProjectId,
-    subnet.name = $SubnetName,
-    subnet.region = $Region,
-    subnet.gateway_address = $GatewayAddress,
-    subnet.ip_cidr_range = $IpCidrRange,
-    subnet.private_ip_google_access = $PrivateIpGoogleAccess,
-    subnet.vpc_partial_uri = $VpcPartialUri,
-    subnet.consolelink = $consolelink,
+    subnet.partial_uri = item.partial_uri
+    SET subnet.self_link = item.self_link,
+    subnet.project_id = item.project_id,
+    subnet.name = item.name,
+    subnet.region = item.region,
+    subnet.gateway_address = item.gateway_address,
+    subnet.ip_cidr_range = item.ip_cidr_range,
+    subnet.private_ip_google_access = item.private_ip_google_access,
+    subnet.vpc_partial_uri = item.vpc_partial_uri,
+    subnet.consolelink = item.consolelink,
     subnet.lastupdated = $gcp_update_tag,
-    subnet.is_default = $isDefault
+    subnet.is_default = item.isDefault
 
     MERGE (vpc)-[r:RESOURCE]->(subnet)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    for s in subnets:
-        neo4j_session.run(
-            query,
-            VpcPartialUri=s["vpc_partial_uri"],
-            VpcSelfLink=s["vpc_self_link"],
-            PartialUri=s["partial_uri"],
-            SubnetSelfLink=s["self_link"],
-            ProjectId=s["project_id"],
-            SubnetName=s["name"],
-            Region=s["region"],
-            GatewayAddress=s["gateway_address"],
-            IpCidrRange=s["ip_cidr_range"],
-            PrivateIpGoogleAccess=s["private_ip_google_access"],
-            consolelink=s["consolelink"],
-            gcp_update_tag=gcp_update_tag,
-            isDefault=s["isDefault"],
-        )
+    load_graph_data(neo4j_session, query, subnets, gcp_update_tag=gcp_update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -1798,7 +1798,7 @@ def cleanup_gcp_firewall_rules(neo4j_session: neo4j.Session, common_job_paramete
         run_cleanup_job("gcp_compute_firewall_cleanup.json", neo4j_session, common_job_parameters)
 
     except ClientError as ex:
-        logger.error("error while syncing gcp firewall rules", ex)
+        logger.error("error while syncing gcp firewall rules: %s", ex)
 
 
 @timeit
@@ -1813,7 +1813,7 @@ def cleanup_gcp_proxies(neo4j_session: neo4j.Session, common_job_parameters: Dic
         run_cleanup_job("gcp_compute_proxies_cleanup.json", neo4j_session, common_job_parameters)
 
     except ClientError as ex:
-        logger.error("error while syncing gcp proxies", ex)
+        logger.error("error while syncing gcp proxies: %s", ex)
 
 
 @timeit

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -1544,86 +1544,76 @@ def load_gcp_ingress_firewalls(neo4j_session: neo4j.Session, fw_list: List[Resou
     :return: Nothing
     """
     query = """
-    MERGE (fw:GCPFirewall{id: $FwPartialUri})
+    UNWIND $DictList AS item
+    MERGE (fw:GCPFirewall{id: item.id})
     ON CREATE SET fw.firstseen = timestamp(),
-    fw.partial_uri = $FwPartialUri
-    SET fw.direction = $Direction,
-    fw.disabled = $Disabled,
-    fw.name = $Name,
-    fw.region = $region,
-    fw.priority = $Priority,
-    fw.self_link = $SelfLink,
-    fw.has_target_service_accounts = $HasTargetServiceAccounts,
-    fw.consolelink = $consolelink,
-    fw.network = $Network,
+    fw.partial_uri = item.id
+    SET fw.direction = item.direction,
+    fw.disabled = item.disabled,
+    fw.name = item.name,
+    fw.region = 'global',
+    fw.priority = item.priority,
+    fw.self_link = item.selfLink,
+    fw.has_target_service_accounts = item.has_target_service_accounts,
+    fw.consolelink = item.consolelink,
+    fw.network = item.network,
     fw.lastupdated = $gcp_update_tag
 
-    MERGE (vpc:GCPVpc{id: $VpcPartialUri})
+    MERGE (vpc:GCPVpc{id: item.vpc_partial_uri})
     ON CREATE SET vpc.firstseen = timestamp(),
-    vpc.partial_uri = $VpcPartialUri
+    vpc.partial_uri = item.vpc_partial_uri
     SET vpc.lastupdated = $gcp_update_tag
 
     MERGE (vpc)-[r:RESOURCE]->(fw)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
+    load_graph_data(neo4j_session, query, fw_list, gcp_update_tag=gcp_update_tag)
+    _attach_firewall_rules(neo4j_session, fw_list, gcp_update_tag)
+    _attach_target_tags(neo4j_session, fw_list, gcp_update_tag)
+    _attach_firewall_public_ip_address(neo4j_session, fw_list, gcp_update_tag)
+
+
+def _build_firewall_public_ip_rows(fw_list: List[Dict]) -> List[Dict]:
+    """One row per firewall x public source range."""
+    rows = []
     for fw in fw_list:
-        neo4j_session.run(
-            query,
-            FwPartialUri=fw["id"],
-            Direction=fw["direction"],
-            Disabled=fw["disabled"],
-            Name=fw["name"],
-            Priority=fw["priority"],
-            SelfLink=fw["selfLink"],
-            region="global",
-            VpcPartialUri=fw["vpc_partial_uri"],
-            HasTargetServiceAccounts=fw["has_target_service_accounts"],
-            consolelink=fw["consolelink"],
-            Network=fw["network"],
-            gcp_update_tag=gcp_update_tag,
-        )
-        _attach_firewall_rules(neo4j_session, fw, gcp_update_tag)
-        _attach_target_tags(neo4j_session, fw, gcp_update_tag)
-        _attach_firewall_public_ip_address(neo4j_session, fw, gcp_update_tag)
+        for ip in fw.get("sourceRanges", []):
+            try:
+                if not ipaddress.IPv4Network(str(ip).split("/")[0]).is_private:
+                    rows.append({"fw_id": fw["id"], "ip": ip})
+            except AddressValueError as e:
+                logger.warning(f"failed to check public ip, error related to the address - {e}")
+            except NetmaskValueError as e:
+                logger.warning(f" failed to check public ip, error related to the net mask - {e}")
+            except Exception as e:
+                logger.warning(f"failed to check public ip - {e}")
+    return rows
 
 
 @timeit
-def _attach_firewall_public_ip_address(neo4j_session: neo4j.Session, fw: Resource, gcp_update_tag: int) -> None:
+def _attach_firewall_public_ip_address(neo4j_session: neo4j.Session, fw_list: List[Dict], gcp_update_tag: int) -> None:
     ingest_public_ip_address = """
-    UNWIND $PublicIpAddress as ip
-        MERGE (i:GCPPublicIpAddress{ipAddress:ip})
+    UNWIND $DictList AS item
+        MERGE (i:GCPPublicIpAddress{ipAddress:item.ip})
             ON CREATE SET i.firstseen = timestamp()
             SET i.lastupdated = $gcp_update_tag,
-                i.IpAddress=ip,
-                i.id=ip,
+                i.IpAddress=item.ip,
+                i.id=item.ip,
                 i.type='Internal',
                 i.source='GCP',
                 i.resource='FirewallRule',
                 i.lastupdated = $gcp_update_tag
-        with i
-            MATCH (p:GCPFirewall{id: $FwId})
+        with i, item
+            MATCH (p:GCPFirewall{id: item.fw_id})
         with i,p
          MERGE (p)-[r:MEMBER_OF_PUBLIC_IP_ADDRESS]->(i)
          ON CREATE SET r.firstseen = timestamp()
          SET
          r.lastupdated = $gcp_update_tag
     """
-    public_ip_address = []
-    for ip in fw.get("sourceRanges", []):
-        try:
-            if not ipaddress.IPv4Network(str(ip).split("/")[0]).is_private:
-                public_ip_address.append(ip)
-        except AddressValueError as e:
-            logger.warning(f"failed to check public ip, error related to the address - {e}")
-        except NetmaskValueError as e:
-            logger.warning(f" failed to check public ip, error related to the net mask - {e}")
-        except Exception as e:
-            logger.warning(f"failed to check public ip - {e}")
-    neo4j_session.run(
-        query=ingest_public_ip_address,
-        PublicIpAddress=public_ip_address,
-        FwId=fw["id"],
+    load_graph_data(
+        neo4j_session, ingest_public_ip_address, _build_firewall_public_ip_rows(fw_list),
         gcp_update_tag=gcp_update_tag,
     )
 
@@ -1644,33 +1634,62 @@ def determine_ip_type(ip_range: str) -> str:
         return "IPv4"
 
 
-@timeit
-def _attach_firewall_rules(neo4j_session: neo4j.Session, fw: Resource, gcp_update_tag: int) -> None:
+def _build_firewall_rule_rows(fw_list: List[Dict]) -> Dict[tuple, List[Dict]]:
     """
-    Attach the allow_rules and deny_rules to the Firewall object, forming IpRule nodes.
+    Flatten firewall x rule x source-range (this was a 3-deep per-item loop) into rows,
+    partitioned by (relationship label, ip type) since each combination needs its own
+    query shape.
+    """
+    partitions: Dict[tuple, List[Dict]] = {
+        ("ALLOWED_BY", "IPv4"): [],
+        ("ALLOWED_BY", "IPv6"): [],
+        ("DENIED_BY", "IPv4"): [],
+        ("DENIED_BY", "IPv6"): [],
+    }
+    for fw in fw_list:
+        for list_type, rel_label in (("transformed_allow_list", "ALLOWED_BY"), ("transformed_deny_list", "DENIED_BY")):
+            for rule in fw.get(list_type, []):
+                for ip_range in fw.get("sourceRanges", []):
+                    ip_type = determine_ip_type(ip_range)
+                    if ip_type not in ("IPv4", "IPv6"):
+                        continue
+                    partitions[(rel_label, ip_type)].append({
+                        "fw_id": fw["id"],
+                        "ruleid": rule["ruleid"],
+                        "protocol": rule["protocol"],
+                        "fromport": rule.get("fromport"),
+                        "toport": rule.get("toport"),
+                        "range": ip_range,
+                    })
+    return partitions
+
+
+@timeit
+def _attach_firewall_rules(neo4j_session: neo4j.Session, fw_list: List[Dict], gcp_update_tag: int) -> None:
+    """
+    Attach the allow_rules and deny_rules to the Firewall objects, forming IpRule nodes.
     This function also creates separate IpRange (for IPv4) and Ipv6Range nodes.
 
     :param neo4j_session: The Neo4j session
-    :param fw: The Firewall object
+    :param fw_list: The transformed firewall dicts
     :param gcp_update_tag: The timestamp for updates
     :return: None
     """
+    query_template = Template("""
+    UNWIND $DictList AS item
+    MATCH (fw:GCPFirewall{id: item.fw_id})
 
-    # query that makes
-    query_ipv4 = Template("""
-    MATCH (fw:GCPFirewall{id: $FwPartialUri})
-
-    MERGE (rule:IpRule:IpPermissionInbound:GCPIpRule{id: $RuleId})
+    MERGE (rule:IpRule:IpPermissionInbound:GCPIpRule{id: item.ruleid})
     ON CREATE SET rule.firstseen = timestamp(),
-    rule.ruleid = $RuleId
-    SET rule.protocol = $Protocol,
-    rule.fromport = $FromPort,
-    rule.toport = $ToPort,
+    rule.ruleid = item.ruleid
+    SET rule.protocol = item.protocol,
+    rule.fromport = item.fromport,
+    rule.toport = item.toport,
     rule.lastupdated = $gcp_update_tag
 
-    MERGE (rng:IpRange{id: $Range})
+    MERGE (rng:$range_label{id: item.range})
     ON CREATE SET rng.firstseen = timestamp(),
-    rng.range = $Range
+    rng.range = item.range
     SET rng.lastupdated = $gcp_update_tag
 
     MERGE (rng)-[m:MEMBER_OF_IP_RULE]->(rule)
@@ -1682,100 +1701,51 @@ def _attach_firewall_rules(neo4j_session: neo4j.Session, fw: Resource, gcp_updat
     SET r.lastupdated = $gcp_update_tag
     """)
 
-    query_ipv6 = Template("""
-    MATCH (fw:GCPFirewall{id: $FwPartialUri})
+    range_labels = {"IPv4": "IpRange", "IPv6": "Ipv6Range"}
+    for (rel_label, ip_type), rows in _build_firewall_rule_rows(fw_list).items():
+        query = query_template.safe_substitute(
+            fw_rule_relationship_label=rel_label,
+            range_label=range_labels[ip_type],
+        )
+        load_graph_data(neo4j_session, query, rows, gcp_update_tag=gcp_update_tag)
 
-    MERGE (rule:IpRule:IpPermissionInbound:GCPIpRule{id: $RuleId})
-    ON CREATE SET rule.firstseen = timestamp(),
-    rule.ruleid = $RuleId
-    SET rule.protocol = $Protocol,
-    rule.fromport = $FromPort,
-    rule.toport = $ToPort,
-    rule.lastupdated = $gcp_update_tag
 
-    MERGE (rng:Ipv6Range{id: $Range})
-    ON CREATE SET rng.firstseen = timestamp(),
-    rng.range = $Range
-    SET rng.lastupdated = $gcp_update_tag
-
-    MERGE (rng)-[m:MEMBER_OF_IP_RULE]->(rule)
-    ON CREATE SET m.firstseen = timestamp()
-    SET m.lastupdated = $gcp_update_tag
-
-    MERGE (fw)<-[r:$fw_rule_relationship_label]-(rule)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = $gcp_update_tag
-    """)
-
-    for list_type in ["transformed_allow_list", "transformed_deny_list"]:
-        if list_type == "transformed_allow_list":
-            label = "ALLOWED_BY"
-        else:
-            label = "DENIED_BY"
-
-        for rule in fw.get(list_type, []):
-            # Iterate over all source ranges (IP addresses or CIDRs)
-            for ip_range in fw.get("sourceRanges", []):
-                ip_type = determine_ip_type(ip_range)
-
-                if ip_type == "IPv4":
-                    # Run the query for IPv4 ranges
-                    neo4j_session.run(
-                        query_ipv4.safe_substitute(fw_rule_relationship_label=label),
-                        FwPartialUri=fw["id"],
-                        RuleId=rule["ruleid"],
-                        Protocol=rule["protocol"],
-                        FromPort=rule.get("fromport"),
-                        ToPort=rule.get("toport"),
-                        Range=ip_range,
-                        gcp_update_tag=gcp_update_tag,
-                    )
-
-                elif ip_type == "IPv6":
-                    # Run the query for IPv6 ranges
-                    neo4j_session.run(
-                        query_ipv6.safe_substitute(fw_rule_relationship_label=label),
-                        FwPartialUri=fw["id"],
-                        RuleId=rule["ruleid"],
-                        Protocol=rule["protocol"],
-                        FromPort=rule.get("fromport"),
-                        ToPort=rule.get("toport"),
-                        Range=ip_range,
-                        gcp_update_tag=gcp_update_tag,
-                    )
+def _build_target_tag_rows(fw_list: List[Dict]) -> List[Dict]:
+    return [
+        {
+            "fw_id": fw["id"],
+            "tag_id": _create_gcp_network_tag_id(fw["vpc_partial_uri"], tag),
+            "tag_value": tag,
+        }
+        for fw in fw_list
+        for tag in fw.get("targetTags", [])
+    ]
 
 
 @timeit
-def _attach_target_tags(neo4j_session: neo4j.Session, fw: Resource, gcp_update_tag: int) -> None:
+def _attach_target_tags(neo4j_session: neo4j.Session, fw_list: List[Dict], gcp_update_tag: int) -> None:
     """
-    Attach target tags to the firewall object
+    Attach target tags to the firewall objects
     :param neo4j_session: The neo4j session
-    :param fw: The firewall object
+    :param fw_list: The transformed firewall dicts
     :param gcp_update_tag: The timestamp
     :return: Nothing
     """
     query = """
-    MATCH (fw:GCPFirewall{id: $FwPartialUri})
+    UNWIND $DictList AS item
+    MATCH (fw:GCPFirewall{id: item.fw_id})
 
-    MERGE (t:GCPNetworkTag{id: $TagId})
+    MERGE (t:GCPNetworkTag{id: item.tag_id})
     ON CREATE SET t.firstseen = timestamp(),
-    t.tag_id = $TagId,
-    t.value = $TagValue
+    t.tag_id = item.tag_id,
+    t.value = item.tag_value
     SET t.lastupdated = $gcp_update_tag
 
     MERGE (fw)-[h:TARGET_TAG]->(t)
     ON CREATE SET h.firstseen = timestamp()
     SET h.lastupdated = $gcp_update_tag
     """
-    for tag in fw.get("targetTags", []):
-        tag_id = _create_gcp_network_tag_id(fw["vpc_partial_uri"], tag)
-        neo4j_session.run(
-            query,
-            FwPartialUri=fw["id"],
-            TagId=tag_id,
-            TagValue=tag,
-            gcp_update_tag=gcp_update_tag,
-        )
+    load_graph_data(neo4j_session, query, _build_target_tag_rows(fw_list), gcp_update_tag=gcp_update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/crm.py
+++ b/cartography/intel/gcp/crm.py
@@ -11,6 +11,7 @@ import neo4j
 from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -104,7 +105,8 @@ def load_gcp_organizations(neo4j_session: neo4j.Session, data: List[Dict], gcp_u
     SET o.lastupdated = $gcp_update_tag
     """
     for org_object in data:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             WorkspaceId=common_job_parameters['WORKSPACE_ID'],
             OrgName=org_object['name'],
@@ -152,7 +154,8 @@ def load_gcp_folders(neo4j_session: neo4j.Session, data: List[Dict], gcp_update_
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $gcp_update_tag
         """
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             ParentId=folder['parent'],
             FolderName=folder['name'],
@@ -197,7 +200,8 @@ def load_gcp_projects(
     for project in data:
         if project['projectId'] != common_job_parameters['GCP_PROJECT_ID']:
             continue
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             OrganizationId=common_job_parameters['GCP_ORGANIZATION_ID'],
             ProjectId=project['projectId'],
@@ -241,7 +245,8 @@ def _attach_gcp_project_parent(neo4j_session: neo4j.Session, project: Dict, gcp_
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """)
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         INGEST_PARENT_TEMPLATE.safe_substitute(parent_label=parent_label),
         ParentId=parent_id,
         ProjectId=project['projectId'],

--- a/cartography/intel/gcp/dns.py
+++ b/cartography/intel/gcp/dns.py
@@ -10,6 +10,7 @@ from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
 from . import label
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -251,7 +252,7 @@ def load_dns_zones(neo4j_session: neo4j.Session, dns_zones: List[Dict], project_
     """
 
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (zone:GCPDNSZone{id:record.id})
     ON CREATE SET
         zone.firstseen = timestamp(),
@@ -273,9 +274,10 @@ def load_dns_zones(neo4j_session: neo4j.Session, dns_zones: List[Dict], project_
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=dns_zones,
+        dns_zones,
         region="global",
         ProjectId=project_id,
         gcp_update_tag=gcp_update_tag,
@@ -304,7 +306,7 @@ def load_rrs(neo4j_session: neo4j.Session, dns_rrs: List[Resource], project_id: 
     """
 
     ingest_records = """
-    UNWIND $records as record
+    UNWIND $DictList as record
     MERGE (rrs:GCPRecordSet{id:record.id})
     ON CREATE SET
         rrs.firstseen = timestamp()
@@ -323,9 +325,10 @@ def load_rrs(neo4j_session: neo4j.Session, dns_rrs: List[Resource], project_id: 
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_records,
-        records=dns_rrs,
+        dns_rrs,
         region="global",
         gcp_update_tag=gcp_update_tag,
     )
@@ -352,7 +355,7 @@ def load_dns_polices(neo4j_session: neo4j.Session, policies: List[Dict], project
     :return: Nothing
     """
     ingest_policies = """
-    UNWIND $DNSPolicies as policy
+    UNWIND $DictList as policy
     MERGE (pol:GCPDNSPolicy{id:policy.id})
     ON CREATE SET
         pol.firstseen = timestamp()
@@ -371,9 +374,10 @@ def load_dns_polices(neo4j_session: neo4j.Session, policies: List[Dict], project
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_policies,
-        DNSPolicies=policies,
+        policies,
         region="global",
         ProjectId=project_id,
         gcp_update_tag=gcp_update_tag,
@@ -401,7 +405,7 @@ def load_dns_keys(neo4j_session: neo4j.Session, dns_keys: List[Dict], project_id
     :return: Nothing
     """
     ingest_keys = """
-    UNWIND $DNSKeys as key
+    UNWIND $DictList as key
     MERGE (ky:GCPDNSKey{id:key.id})
     ON CREATE SET
         ky.firstseen = timestamp()
@@ -420,9 +424,10 @@ def load_dns_keys(neo4j_session: neo4j.Session, dns_keys: List[Dict], project_id
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_keys,
-        DNSKeys=dns_keys,
+        dns_keys,
         region="global",
         ProjectId=project_id,
         gcp_update_tag=gcp_update_tag,

--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -10,6 +10,7 @@ from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
 from . import label
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -143,7 +144,8 @@ def load_gke_clusters(
     for cluster in cluster_resp:
         cluster["region"] = get_region_from_location(cluster.get("location"))
 
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             ProjectId=project_id,
             ClusterId=cluster["id"],

--- a/cartography/intel/gcp/iam.py
+++ b/cartography/intel/gcp/iam.py
@@ -11,6 +11,8 @@ from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
 from . import label
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.intel.gcp import external_idp
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -444,7 +446,7 @@ def load_api_keys(
 ) -> None:
 
     query = """
-    UNWIND $ApiKeys as key
+    UNWIND $DictList as key
     MERGE (apikey:GCPAPIKey{id: key.id})
     ON CREATE SET
         apikey.firstseen = timestamp()
@@ -462,9 +464,10 @@ def load_api_keys(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        ApiKeys=api_keys,
+        api_keys,
         project_id=project_id,
         region="global",
         gcp_update_tag=gcp_update_tag,
@@ -484,7 +487,7 @@ def load_service_accounts(
 
 ) -> None:
     ingest_service_accounts = """
-    UNWIND $service_accounts_list AS sa
+    UNWIND $DictList AS sa
     MERGE (u:GCPServiceAccount{id: sa.id})
     ON CREATE SET u:GCPPrincipal, u.firstseen = timestamp()
     SET u.name = sa.name, u.displayname = sa.displayName,
@@ -505,9 +508,10 @@ def load_service_accounts(
     SET r.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_service_accounts,
-        service_accounts_list=service_accounts,
+        service_accounts,
         parent=['project'],
         parentId=[f'projects/{project_id}'],
         project_id=project_id,
@@ -528,7 +532,7 @@ def load_service_account_keys(
     service_account: str, project_id: str, gcp_update_tag: int,
 ) -> None:
     ingest_service_accounts = """
-    UNWIND $service_account_keys_list AS sa
+    UNWIND $DictList AS sa
     MERGE (u:GCPServiceAccountKey{id: sa.id})
     ON CREATE SET u.firstseen = timestamp()
     SET u.name=sa.name, u.serviceaccountid= $serviceaccount,
@@ -549,9 +553,10 @@ def load_service_account_keys(
     SET r.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_service_accounts,
-        service_account_keys_list=service_account_keys,
+        service_account_keys,
         serviceaccount=service_account,
         createDate=datetime.utcnow(),
         region="global",
@@ -568,7 +573,7 @@ def cleanup_service_account_keys(neo4j_session: neo4j.Session, common_job_parame
 @timeit
 def load_project_roles(neo4j_session: neo4j.Session, roles: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     ingest_roles = """
-    UNWIND $roles_list AS d
+    UNWIND $DictList AS d
     MERGE (u:GCPRole{id: d.id})
     ON CREATE SET u.firstseen = timestamp()
     SET u.name = d.name,
@@ -592,9 +597,10 @@ def load_project_roles(neo4j_session: neo4j.Session, roles: List[Dict], project_
     SET r.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_roles,
-        roles_list=roles,
+        roles,
         region="global",
         createDate=datetime.utcnow(),
         project_id=project_id,
@@ -605,7 +611,7 @@ def load_project_roles(neo4j_session: neo4j.Session, roles: List[Dict], project_
 @timeit
 def load_sso_roles(neo4j_session: neo4j.Session, roles: List[Dict], org_id: str, gcp_update_tag: int) -> None:
     ingest_roles = """
-    UNWIND $roles_list AS d
+    UNWIND $DictList AS d
     MERGE (u:GCPRole{id: d.id})
     ON CREATE SET u.firstseen = timestamp()
     SET u.name = d.name,
@@ -629,9 +635,10 @@ def load_sso_roles(neo4j_session: neo4j.Session, roles: List[Dict], org_id: str,
     SET r.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_roles,
-        roles_list=roles,
+        roles,
         region="global",
         createDate=datetime.utcnow(),
         org_id=org_id,
@@ -896,7 +903,8 @@ def attach_project_role_to_user(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         UserId=user['id'],
@@ -947,7 +955,8 @@ def attach_sso_role_to_user(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         UserId=user['id'],
@@ -980,7 +989,8 @@ def attach_project_role_to_service_account(
     SET r.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         isDeleted=serviceAccount.get('is_deleted', False),
@@ -1011,7 +1021,8 @@ def attach_sso_role_to_service_account(
     r2.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         isDeleted=serviceAccount.get('is_deleted', False),
@@ -1055,7 +1066,8 @@ def attach_project_role_to_group(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         GroupId=group['id'],
@@ -1106,7 +1118,8 @@ def attach_sso_role_to_group(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         GroupId=group['id'],
@@ -1154,7 +1167,8 @@ def attach_project_role_to_domain(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         DomainId=domain['id'],
@@ -1204,7 +1218,8 @@ def attach_sso_role_to_domain(
     SET pr.lastupdated = $gcp_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_script,
         RoleId=role_id,
         DomainId=domain['id'],

--- a/cartography/intel/gcp/spanner.py
+++ b/cartography/intel/gcp/spanner.py
@@ -10,6 +10,7 @@ from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
 from . import label
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -56,13 +57,8 @@ def transform_instances(instances: List[Dict], project_id: str) -> List[Dict]:
 
 @timeit
 def load_spanner_instances(session: neo4j.Session, data_list: List[Dict], project_id: str, update_tag: int) -> None:
-    session.execute_write(load_spanner_instances_tx, data_list, project_id, update_tag)
-
-
-@timeit
-def load_spanner_instances_tx(tx: neo4j.Transaction, data: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (instance:GCPSpannerInstance{id:record.id})
     ON CREATE SET
         instance.firstseen = timestamp()
@@ -86,7 +82,7 @@ def load_spanner_instances_tx(tx: neo4j.Transaction, data: List[Dict], project_i
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    tx.run(query=query, Records=data, ProjectId=project_id, gcp_update_tag=gcp_update_tag)
+    load_graph_data(session, query, data_list, ProjectId=project_id, gcp_update_tag=update_tag)
 
 
 @timeit
@@ -133,13 +129,8 @@ def transform_instance_configs(instance_configs: List[Dict], project_id: str) ->
 
 @timeit
 def load_spanner_instance_configs(session: neo4j.Session, data_list: List[Dict], project_id: str, update_tag: int) -> None:
-    session.execute_write(load_spanner_instance_configs_tx, data_list, project_id, update_tag)
-
-
-@timeit
-def load_spanner_instance_configs_tx(tx: neo4j.Transaction, data: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (instance_config:GCPSpannerInstanceConfig{id: record.id})
     ON CREATE SET
         instance_config.firstseen = timestamp()
@@ -160,7 +151,7 @@ def load_spanner_instance_configs_tx(tx: neo4j.Transaction, data: List[Dict], pr
         rt.firstseen = timestamp()
     SET rt.lastupdated = $gcp_update_tag
     """
-    tx.run(query=query, Records=data, ProjectId=project_id, gcp_update_tag=gcp_update_tag)
+    load_graph_data(session, query, data_list, ProjectId=project_id, gcp_update_tag=update_tag)
 
 
 @timeit
@@ -182,13 +173,8 @@ def transform_spanner_instance_configs_replicas(instance_configs: List[Dict], pr
 
 @timeit
 def load_spanner_instance_configs_replicas(session: neo4j.Session, data_list: List[Dict], project_id: str, update_tag: int) -> None:
-    session.execute_write(load_spanner_instance_configs_replicas_tx, data_list, project_id, update_tag)
-
-
-@timeit
-def load_spanner_instance_configs_replicas_tx(tx: neo4j.Transaction, data: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (replica:GCPSpannerInstanceConfigReplica{id: record.id})
     ON CREATE SET
         replica.firstseen = timestamp()
@@ -204,7 +190,7 @@ def load_spanner_instance_configs_replicas_tx(tx: neo4j.Transaction, data: List[
         rt.firstseen = timestamp()
     SET rt.lastupdated = $gcp_update_tag
     """
-    tx.run(query=query, Records=data, ProjectId=project_id, gcp_update_tag=gcp_update_tag)
+    load_graph_data(session, query, data_list, ProjectId=project_id, gcp_update_tag=update_tag)
 
 
 @timeit
@@ -252,13 +238,8 @@ def transform_instances_databases(databases: List[Dict], project_id: str) -> Lis
 
 @timeit
 def load_spanner_instances_databases(session: neo4j.Session, data_list: List[Dict], project_id: str, update_tag: int) -> None:
-    session.execute_write(load_spanner_instances_databases_tx, data_list, project_id, update_tag)
-
-
-@timeit
-def load_spanner_instances_databases_tx(tx: neo4j.Transaction, data: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (database:GCPSpannerInstanceDatabase{id: record.id})
     ON CREATE SET
         database.firstseen = timestamp()
@@ -289,7 +270,7 @@ def load_spanner_instances_databases_tx(tx: neo4j.Transaction, data: List[Dict],
         rt.firstseen = timestamp()
     SET rt.lastupdated = $gcp_update_tag
     """
-    tx.run(query=query, Records=data, ProjectId=project_id, gcp_update_tag=gcp_update_tag)
+    load_graph_data(session, query, data_list, ProjectId=project_id, gcp_update_tag=update_tag)
 
 
 @timeit
@@ -337,13 +318,8 @@ def transform_instances_backups(backups: List[Dict], project_id: str) -> List[Di
 
 @timeit
 def load_spanner_instances_backups(session: neo4j.Session, data_list: List[Dict], project_id: str, update_tag: int) -> None:
-    session.execute_write(load_spanner_instances_backups_tx, data_list, project_id, update_tag)
-
-
-@timeit
-def load_spanner_instances_backups_tx(tx: neo4j.Transaction, data: List[Dict], project_id: str, gcp_update_tag: int) -> None:
     query = """
-    UNWIND $Records as record
+    UNWIND $DictList as record
     MERGE (backup:GCPSpannerInstanceBackup{id: record.id})
     ON CREATE SET
         backup.firstseen = timestamp()
@@ -371,7 +347,7 @@ def load_spanner_instances_backups_tx(tx: neo4j.Transaction, data: List[Dict], p
         r.firstseen = timestamp()
     SET r.lastupdated = $gcp_update_tag
     """
-    tx.run(query=query, Records=data, ProjectId=project_id, gcp_update_tag=gcp_update_tag)
+    load_graph_data(session, query, data_list, ProjectId=project_id, gcp_update_tag=update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/storage.py
+++ b/cartography/intel/gcp/storage.py
@@ -9,6 +9,7 @@ from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
 from . import label
+from cartography.client.core.tx import run_write_query
 from cartography.intel.gcp import compute
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -178,7 +179,8 @@ def load_gcp_buckets(neo4j_session: neo4j.Session, buckets: List[Dict], project_
     SET r.lastupdated = $gcp_update_tag
     """
     for bucket in buckets:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             ProjectId=project_id,
             BucketId=bucket['id'],

--- a/cartography/intel/gcp/workspace.py
+++ b/cartography/intel/gcp/workspace.py
@@ -8,6 +8,7 @@ import neo4j
 from googleapiclient.discovery import HttpError
 from googleapiclient.discovery import Resource
 
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 logger = logging.getLogger(__name__)
@@ -273,7 +274,7 @@ def _load_groups_tx(tx: neo4j.Transaction, groups: List[Dict], organization_id: 
 @timeit
 def load_groups_members(neo4j_session: neo4j.Session, group: Dict, members: List[Dict], gsuite_update_tag: int) -> None:
     ingestion_qry = """
-        UNWIND $MemberData as member
+        UNWIND $DictList as member
         MERGE (user:GCPUser {userId: member.id})
         ON CREATE SET
         user:GCPPrincipal,
@@ -288,14 +289,15 @@ def load_groups_members(neo4j_session: neo4j.Session, group: Dict, members: List
         SET
         r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingestion_qry,
-        MemberData=members,
+        members,
         GroupID=group.get("id"),
         UpdateTag=gsuite_update_tag,
     )
     membership_qry = """
-        UNWIND $MemberData as member
+        UNWIND $DictList as member
         MATCH(group_1: GCPGroup{groupId: member.id}), (group_2:GCPGroup {groupId: $GroupID})
         MERGE (group_1)-[r:MEMBER_GROUP]->(group_2)
         ON CREATE SET
@@ -303,7 +305,7 @@ def load_groups_members(neo4j_session: neo4j.Session, group: Dict, members: List
         SET
         r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(membership_qry, MemberData=members, GroupID=group.get("id"), UpdateTag=gsuite_update_tag)
+    load_graph_data(neo4j_session, membership_qry, members, GroupID=group.get("id"), UpdateTag=gsuite_update_tag)
 
 
 @timeit

--- a/cartography/intel/github/organization.py
+++ b/cartography/intel/github/organization.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.github.util import call_github_api
 from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import fetch_page
@@ -81,7 +82,8 @@ def load_organization(
     ON CREATE SET o.firstseen = timestamp()
     SET o.lastupdated = $UpdateTag;
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         query,
         OrgLogin=org_data['login'],
         OrgUrl=org_data['url'],

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -16,6 +16,7 @@ from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.github.util import describe_request_error
 from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import get_retry_delay_seconds
@@ -607,28 +608,33 @@ def load_github_owners(neo4j_session: neo4j.Session, update_tag: int, repo_owner
     :param repo_owners: list of owner to repo mappings
     :return: Nothing
     """
-    for owner in repo_owners:
-        ingest_owner_template = Template("""
-            MERGE (node:$account_type{id: $Id})
-            ON CREATE SET node.firstseen = timestamp()
-            SET node.username = $UserName,
-            node.lastupdated = $UpdateTag
-            WITH node
+    ingest_owner_template = Template("""
+        UNWIND $DictList AS item
+        MERGE (node:$account_type{id: item.owner})
+        ON CREATE SET node.firstseen = timestamp()
+        SET node.username = item.owner,
+        node.lastupdated = $UpdateTag
+        WITH node, item
 
-            MATCH (repo:GitHubRepository{id: $RepoId})
-            MERGE (node)-[r:RESOURCE]->(repo)
-            ON CREATE SET r.firstseen = timestamp()
-            SET r.lastupdated = $UpdateTag""")
+        MATCH (repo:GitHubRepository{id: item.repo_id})
+        MERGE (node)-[r:RESOURCE]->(repo)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = $UpdateTag""")
 
-        # INFO: Only Organization is supported
-        # account_type = {'User': "GitHubUser", 'Organization': "GitHubOrganization"}
-        account_type = {"Organization": "GitHubOrganization"}
+    # INFO: Only Organization is supported
+    # account_type = {'User': "GitHubUser", 'Organization': "GitHubOrganization"}
+    account_type = {"Organization": "GitHubOrganization"}
 
-        neo4j_session.run(
-            ingest_owner_template.safe_substitute(account_type=account_type[owner["type"]]),
-            Id=owner["owner"],
-            UserName=owner["owner"],
-            RepoId=owner["repo_id"],
+    for owner_type, type_label in account_type.items():
+        rows = [
+            {"owner": owner["owner"], "repo_id": owner["repo_id"]}
+            for owner in repo_owners
+            if owner["type"] == owner_type
+        ]
+        load_graph_data(
+            neo4j_session,
+            ingest_owner_template.safe_substitute(account_type=type_label),
+            rows,
             UpdateTag=update_tag,
         )
 

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -525,7 +525,7 @@ def load_github_repos(neo4j_session: neo4j.Session, update_tag: int, repo_data: 
     :return: None
     """
     ingest_repo = """
-    UNWIND $RepoData as repository
+    UNWIND $DictList as repository
 
     MERGE (repo:GitHubRepository{id: repository.id})
     ON CREATE SET repo.firstseen = timestamp(),
@@ -562,9 +562,10 @@ def load_github_repos(neo4j_session: neo4j.Session, update_tag: int, repo_data: 
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_repo,
-        RepoData=repo_data,
+        repo_data,
         UpdateTag=update_tag,
     )
 
@@ -579,7 +580,7 @@ def load_github_languages(neo4j_session: neo4j.Session, update_tag: int, repo_la
     :return: Nothing
     """
     ingest_languages = """
-        UNWIND $Languages as lang
+        UNWIND $DictList as lang
 
         MERGE (pl:ProgrammingLanguage{id: lang.language_name})
         ON CREATE SET pl.firstseen = timestamp(),
@@ -592,9 +593,10 @@ def load_github_languages(neo4j_session: neo4j.Session, update_tag: int, repo_la
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $UpdateTag"""
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_languages,
-        Languages=repo_languages,
+        repo_languages,
         UpdateTag=update_tag,
     )
 
@@ -642,7 +644,7 @@ def load_github_owners(neo4j_session: neo4j.Session, update_tag: int, repo_owner
 @timeit
 def load_collaborators(neo4j_session: neo4j.Session, update_tag: int, collaborators: Dict) -> None:
     query = Template("""
-    UNWIND $UserData as user
+    UNWIND $DictList as user
 
     MERGE (u:GitHubUser{id: user.url})
     ON CREATE SET u.firstseen = timestamp()
@@ -661,9 +663,10 @@ def load_collaborators(neo4j_session: neo4j.Session, update_tag: int, collaborat
     """)
     for collab_type in collaborators.keys():
         relationship_label = f"OUTSIDE_COLLAB_{collab_type}"
-        neo4j_session.run(
+        load_graph_data(
+            neo4j_session,
             query.safe_substitute(rel_label=relationship_label),
-            UserData=collaborators[collab_type],
+            collaborators[collab_type],
             UpdateTag=update_tag,
         )
 
@@ -688,7 +691,7 @@ def load_github_branches(neo4j_session: neo4j.Session, update_tag: int, branch_d
     :return: None
     """
     ingest_branches = """
-    UNWIND $BranchData as branch_info
+    UNWIND $DictList as branch_info
     MERGE (branch:GitHubBranch{id: branch_info.branch_id})
     ON CREATE SET branch.firstseen = timestamp()
     SET branch.name = branch_info.name,
@@ -701,9 +704,10 @@ def load_github_branches(neo4j_session: neo4j.Session, update_tag: int, branch_d
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_branches,
-        BranchData=branch_data,
+        branch_data,
         UpdateTag=update_tag,
     )
 
@@ -711,7 +715,7 @@ def load_github_branches(neo4j_session: neo4j.Session, update_tag: int, branch_d
 @timeit
 def load_python_requirements(neo4j_session: neo4j.Session, update_tag: int, requirements_objects: List[Dict]) -> None:
     query = """
-    UNWIND $Requirements AS req
+    UNWIND $DictList AS req
         MERGE (lib:PythonLibrary:Dependency{id: req.id})
         ON CREATE SET lib.firstseen = timestamp(),
         lib.name = req.name
@@ -725,9 +729,10 @@ def load_python_requirements(neo4j_session: neo4j.Session, update_tag: int, requ
         SET r.lastupdated = $UpdateTag,
         r.specifier = req.specifier
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
-        Requirements=requirements_objects,
+        requirements_objects,
         UpdateTag=update_tag,
     )
 

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import neo4j
 
+from cartography.client.core.tx import load_graph_data
 from cartography.intel.github.util import fetch_all
 from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
@@ -80,7 +81,7 @@ def load_organization_users(
     SET org.lastupdated = $UpdateTag
     WITH org
 
-    UNWIND $UserData as user
+    UNWIND $DictList as user
 
     MERGE (u:GitHubUser{id: user.node.url})
     ON CREATE SET u.firstseen = timestamp()
@@ -102,11 +103,12 @@ def load_organization_users(
     ON CREATE SET o.firstseen = timestamp()
     SET o.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         query,
+        user_data,
         OrgUrl=org_data["url"],
         OrgLogin=org_data["login"],
-        UserData=user_data,
         UpdateTag=common_job_parameters["UPDATE_TAG"],
         workspace_id=common_job_parameters["WORKSPACE_ID"],
     )

--- a/cartography/intel/oci/audit_logging.py
+++ b/cartography/intel/oci/audit_logging.py
@@ -27,6 +27,7 @@ import oci.object_storage
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -85,7 +86,8 @@ def load_audit_configuration(
     SET r.lastupdated = $oci_update_tag
     """
     retention = config_data.get("retention-period-days", 0)
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_audit_config,
         CONFIG_ID=f"oci.audit.config.{tenancy_id}.{region}",
         TENANCY_ID=tenancy_id,
@@ -471,7 +473,8 @@ def load_logging_configuration(
     """
 
     config_id = f"oci.logging.config.{config['compartment_id']}.{config['region']}"
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_config,
         CONFIG_ID=config_id,
         COMPARTMENT_ID=config["compartment_id"],
@@ -571,7 +574,8 @@ def enrich_bucket_logging_status(
             b.logging_enabled = false,
             b.logging_resource_type = 'oci-storage-objectstorage-bucket'
         """
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             mark_unlogged_buckets,
             COMPARTMENT_ID=compartment_id,
             REGION=region,

--- a/cartography/intel/oci/containerregistry.py
+++ b/cartography/intel/oci/containerregistry.py
@@ -19,6 +19,7 @@ import oci.artifacts
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,8 @@ def load_container_repositories(
     """
 
     for repo in repositories:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_repo,
             OCID=repo.get("id"),
             DISPLAY_NAME=repo.get("display-name", ""),
@@ -227,7 +229,8 @@ def load_container_images(
     """
 
     for image in images:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_image,
             OCID=image.get("id"),
             DISPLAY_NAME=image.get("display-name", image.get("repository-name", "")),

--- a/cartography/intel/oci/database.py
+++ b/cartography/intel/oci/database.py
@@ -12,6 +12,7 @@ import oci
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
 logger = logging.getLogger(__name__)
@@ -210,7 +211,7 @@ def load_autonomous_databases(
     upstream nodes have not been synced yet).
     """
     ingest_adb = """
-    UNWIND $items AS adb
+    UNWIND $DictList AS adb
         MERGE (a:OCIAutonomousDatabase{id: adb.id})
         ON CREATE SET a.firstseen = timestamp(),
                       a.createdate = adb.time_created
@@ -270,9 +271,10 @@ def load_autonomous_databases(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_adb,
-        items=autonomous_databases,
+        autonomous_databases,
         COMPARTMENT_ID=compartment_id,
         oci_update_tag=oci_update_tag,
     )
@@ -417,7 +419,7 @@ def load_db_systems(
     oci_update_tag: int,
 ) -> None:
     ingest_db_system = """
-    UNWIND $items AS s
+    UNWIND $DictList AS s
         MERGE (sys:OCIDbSystem{id: s.id})
         ON CREATE SET sys.firstseen = timestamp(),
                       sys.createdate = s.time_created
@@ -468,9 +470,10 @@ def load_db_systems(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingest_db_system,
-        items=db_systems,
+        db_systems,
         COMPARTMENT_ID=compartment_id,
         oci_update_tag=oci_update_tag,
     )
@@ -560,7 +563,7 @@ def load_db_homes(
     (e.g. a system in a state we filter out) silently no-op.
     """
     ingest_db_home = """
-    UNWIND $items AS h
+    UNWIND $DictList AS h
         MERGE (dh:OCIDbHome{id: h.id})
         ON CREATE SET dh.firstseen = timestamp(),
                       dh.createdate = h.time_created
@@ -584,8 +587,8 @@ def load_db_homes(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
-        ingest_db_home, items=db_homes, oci_update_tag=oci_update_tag,
+    load_graph_data(
+        neo4j_session, ingest_db_home, db_homes, oci_update_tag=oci_update_tag,
     )
 
     _link_kms_key(
@@ -672,7 +675,7 @@ def load_db_nodes(
     HAS_DB_NODE.
     """
     ingest_db_node = """
-    UNWIND $items AS n
+    UNWIND $DictList AS n
         MERGE (dn:OCIDbNode{id: n.id})
         ON CREATE SET dn.firstseen = timestamp(),
                       dn.createdate = n.time_created
@@ -699,8 +702,8 @@ def load_db_nodes(
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
-        ingest_db_node, items=db_nodes, oci_update_tag=oci_update_tag,
+    load_graph_data(
+        neo4j_session, ingest_db_node, db_nodes, oci_update_tag=oci_update_tag,
     )
 
 
@@ -725,15 +728,15 @@ def _link_subnet_and_nsg(
     ]
     if subnet_links:
         link_subnet = f"""
-        UNWIND $links AS link
+        UNWIND $DictList AS link
             MATCH (r:{label}{{id: link.resource_id}})
             MATCH (s:OCISubnet{{id: link.subnet_id}})
             MERGE (r)-[rel:OCI_SUBNET]->(s)
             ON CREATE SET rel.firstseen = timestamp()
             SET rel.lastupdated = $oci_update_tag
         """
-        neo4j_session.run(
-            link_subnet, links=subnet_links, oci_update_tag=oci_update_tag,
+        load_graph_data(
+            neo4j_session, link_subnet, subnet_links, oci_update_tag=oci_update_tag,
         )
 
     nsg_links: List[Dict[str, str]] = []
@@ -742,15 +745,15 @@ def _link_subnet_and_nsg(
             nsg_links.append({"resource_id": item["id"], "nsg_id": nsg_id})
     if nsg_links:
         link_nsg = f"""
-        UNWIND $links AS link
+        UNWIND $DictList AS link
             MATCH (r:{label}{{id: link.resource_id}})
             MATCH (n:OCINetworkSecurityGroup{{id: link.nsg_id}})
             MERGE (r)-[rel:OCI_NSG]->(n)
             ON CREATE SET rel.firstseen = timestamp()
             SET rel.lastupdated = $oci_update_tag
         """
-        neo4j_session.run(
-            link_nsg, links=nsg_links, oci_update_tag=oci_update_tag,
+        load_graph_data(
+            neo4j_session, link_nsg, nsg_links, oci_update_tag=oci_update_tag,
         )
 
 
@@ -771,14 +774,14 @@ def _link_kms_key(
     if not links:
         return
     link_kms = f"""
-    UNWIND $links AS link
+    UNWIND $DictList AS link
         MATCH (r:{label}{{id: link.resource_id}})
         MATCH (k:OCIKmsKey{{id: link.kms_key_id}})
         MERGE (r)-[rel:OCI_KMS_KEY]->(k)
         ON CREATE SET rel.firstseen = timestamp()
         SET rel.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(link_kms, links=links, oci_update_tag=oci_update_tag)
+    load_graph_data(neo4j_session, link_kms, links, oci_update_tag=oci_update_tag)
 
 
 # ---------------------------------------------------------------------------

--- a/cartography/intel/oci/encryption.py
+++ b/cartography/intel/oci/encryption.py
@@ -11,6 +11,7 @@ import oci.key_management
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -243,8 +244,8 @@ def sync_keys(
             "WHERE v.region = $REGION AND v.lifecycle_state = 'ACTIVE' "
             "RETURN v.ocid as ocid, v.management_endpoint as endpoint"
         )
-        vaults = neo4j_session.run(
-            query, COMPARTMENT_ID=compartment["ocid"], REGION=region,
+        vaults = neo4j_session.execute_read(
+            read_list_of_dicts_tx, query, COMPARTMENT_ID=compartment["ocid"], REGION=region,
         )
         for vault in vaults:
             endpoint = vault["endpoint"]

--- a/cartography/intel/oci/iam.py
+++ b/cartography/intel/oci/iam.py
@@ -12,6 +12,8 @@ import neo4j
 import oci
 
 from . import utils
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -286,7 +288,7 @@ def sync_group_memberships(
     logger.debug("Syncing IAM group membership for account '%s'.", current_tenancy_id)
     query = "MATCH (group:OCIGroup)<-[:RESOURCE]-(OCITenancy{id: $OCI_TENANCY_ID}) " \
             "return group.name as name, group.ocid as ocid;"
-    groups = neo4j_session.run(query, OCI_TENANCY_ID=current_tenancy_id)
+    groups = neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=current_tenancy_id)
     groups_membership = {
         group["ocid"]: get_group_membership_data(iam, group['ocid'], current_tenancy_id) for group in groups
     }
@@ -407,7 +409,8 @@ def load_oci_policy_group_reference(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_policy_group_reference,
         POLICY_ID=policy_id,
         GROUP_ID=group_id,
@@ -429,7 +432,8 @@ def load_oci_policy_compartment_reference(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_policy_compartment_reference,
         POLICY_ID=policy_id,
         COMPARTMENT_ID=compartment_id,

--- a/cartography/intel/oci/monitoring.py
+++ b/cartography/intel/oci/monitoring.py
@@ -13,6 +13,7 @@ import oci.ons
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -172,7 +173,8 @@ def load_cloud_guard(
     SET r.lastupdated = $oci_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_cg,
         CONFIG_ID=f"oci.cloudguard.{compartment_id}.{region}",
         COMPARTMENT_ID=compartment_id,

--- a/cartography/intel/oci/network.py
+++ b/cartography/intel/oci/network.py
@@ -12,6 +12,7 @@ import oci.logging
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -538,7 +539,9 @@ def sync_nsg_security_rules(
         "WHERE nsg.region = $REGION "
         "RETURN nsg.ocid as ocid"
     )
-    nsgs = neo4j_session.run(query, COMPARTMENT_ID=compartment_ocid, REGION=region)
+    nsgs = neo4j_session.execute_read(
+        read_list_of_dicts_tx, query, COMPARTMENT_ID=compartment_ocid, REGION=region,
+    )
     for nsg in nsgs:
         data = get_nsg_security_rules_data(network_client, nsg["ocid"])
         if data["SecurityRules"]:
@@ -877,7 +880,9 @@ def sync_subnet_associations(
         "subnet.security_list_ids as security_list_ids"
     )
     for compartment in compartments:
-        subnets = neo4j_session.run(query, COMPARTMENT_ID=compartment["ocid"], REGION=region)
+        subnets = neo4j_session.execute_read(
+            read_list_of_dicts_tx, query, COMPARTMENT_ID=compartment["ocid"], REGION=region,
+        )
         rt_rows = []
         sl_rows = []
         for subnet in subnets:
@@ -1002,7 +1007,9 @@ def sync_vnics(
         "RETURN DISTINCT attachment.vnic_id as vnic_id"
     )
     for compartment in compartments:
-        attachments = neo4j_session.run(query, COMPARTMENT_ID=compartment["ocid"], REGION=region)
+        attachments = neo4j_session.execute_read(
+            read_list_of_dicts_tx, query, COMPARTMENT_ID=compartment["ocid"], REGION=region,
+        )
         vnics = []
         for attachment in attachments:
             vnic = get_vnic_data(network_client, attachment["vnic_id"])

--- a/cartography/intel/oci/storage.py
+++ b/cartography/intel/oci/storage.py
@@ -18,6 +18,7 @@ import oci
 
 from . import tags
 from . import utils
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import load_graph_data
 from cartography.util import run_cleanup_job
 
@@ -385,7 +386,7 @@ def load_block_volumes(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(link_instances, oci_update_tag=oci_update_tag)
+    run_write_query(neo4j_session, link_instances, oci_update_tag=oci_update_tag)
 
 
 def sync_block_volumes(
@@ -543,7 +544,7 @@ def load_boot_volumes(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(link_instances, oci_update_tag=oci_update_tag)
+    run_write_query(neo4j_session, link_instances, oci_update_tag=oci_update_tag)
 
 
 def sync_boot_volumes(
@@ -1034,7 +1035,7 @@ def link_instances_to_file_systems(
                   r.inference_method = 'shared_subnet'
     SET r.lastupdated = $oci_update_tag
     """
-    neo4j_session.run(link_query, oci_update_tag=oci_update_tag)
+    run_write_query(neo4j_session, link_query, oci_update_tag=oci_update_tag)
 
 
 def sync_file_storage(

--- a/cartography/intel/oci/utils.py
+++ b/cartography/intel/oci/utils.py
@@ -39,7 +39,7 @@ def replace_char_in_dict(in_dict: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # Grab list of all compartments and sub-compartments in neo4j already populated by iam.
-def get_compartments_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
+def get_compartments_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> List[Dict[str, Any]]:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(compartment:OCICompartment) " \
             "return DISTINCT compartment.name as name, compartment.ocid as ocid, " \
             "compartment.compartmentid as compartmentid;"
@@ -47,14 +47,14 @@ def get_compartments_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -
 
 
 # Grab list of all groups in neo4j already populated by iam.
-def get_groups_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
+def get_groups_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> List[Dict[str, Any]]:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[*]->(group:OCIGroup)" \
             "return DISTINCT group.name as name, group.ocid as ocid;"
     return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
 
 
 # Grab list of all policies in neo4j already populated by iam.
-def get_policies_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
+def get_policies_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> List[Dict[str, Any]]:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[*]->(policy:OCIPolicy)" \
             "return DISTINCT policy.name as name, policy.ocid as ocid, policy.statements as statements, " \
             "policy.compartmentid as compartmentid;"
@@ -62,7 +62,7 @@ def get_policies_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> ne
 
 
 # Grab list of all regions in neo4j already populated by iam.
-def get_regions_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
+def get_regions_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> List[Dict[str, Any]]:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-->(region:OCIRegion)" \
             "return DISTINCT region.name as name, region.key as key;"
     return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
@@ -72,7 +72,7 @@ def get_regions_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo
 def get_security_groups_in_tenancy(
     neo4j_session: neo4j.Session,
     tenancy_id: str, region: str,
-) -> neo4j.Result:
+) -> List[Dict[str, Any]]:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[*]->(security_group:OCINetworkSecurityGroup)-[OCI_REGION]->" \
             "(region:OCIRegion{name: $OCI_REGION})" \
             "return DISTINCT security_group.name as name, security_group.ocid as ocid, security_group.compartmentid " \

--- a/cartography/intel/oci/utils.py
+++ b/cartography/intel/oci/utils.py
@@ -7,6 +7,8 @@ from typing import List
 
 import neo4j
 
+from cartography.client.core.tx import read_list_of_dicts_tx
+
 
 # Generic way to turn a OCI python object into the json response that you would see from calling the REST API.
 def oci_object_to_json(in_obj: Any) -> List[Dict[str, Any]]:
@@ -41,14 +43,14 @@ def get_compartments_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[:OWNER]->(compartment:OCICompartment) " \
             "return DISTINCT compartment.name as name, compartment.ocid as ocid, " \
             "compartment.compartmentid as compartmentid;"
-    return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id)
+    return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
 
 
 # Grab list of all groups in neo4j already populated by iam.
 def get_groups_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[*]->(group:OCIGroup)" \
             "return DISTINCT group.name as name, group.ocid as ocid;"
-    return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id)
+    return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
 
 
 # Grab list of all policies in neo4j already populated by iam.
@@ -56,14 +58,14 @@ def get_policies_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> ne
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-[*]->(policy:OCIPolicy)" \
             "return DISTINCT policy.name as name, policy.ocid as ocid, policy.statements as statements, " \
             "policy.compartmentid as compartmentid;"
-    return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id)
+    return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
 
 
 # Grab list of all regions in neo4j already populated by iam.
 def get_regions_in_tenancy(neo4j_session: neo4j.Session, tenancy_id: str) -> neo4j.Result:
     query = "MATCH (OCITenancy{id: $OCI_TENANCY_ID})-->(region:OCIRegion)" \
             "return DISTINCT region.name as name, region.key as key;"
-    return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id)
+    return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id)
 
 
 # Grab list of all security groups in neo4j already populated by network. Need to handle regions for this one.
@@ -75,4 +77,4 @@ def get_security_groups_in_tenancy(
             "(region:OCIRegion{name: $OCI_REGION})" \
             "return DISTINCT security_group.name as name, security_group.ocid as ocid, security_group.compartmentid " \
             "as compartmentid;"
-    return neo4j_session.run(query, OCI_TENANCY_ID=tenancy_id, OCI_REGION=region)
+    return neo4j_session.execute_read(read_list_of_dicts_tx, query, OCI_TENANCY_ID=tenancy_id, OCI_REGION=region)

--- a/cartography/intel/pagerduty/services.py
+++ b/cartography/intel/pagerduty/services.py
@@ -7,6 +7,7 @@ import dateutil.parser
 import neo4j
 from pdpyras import APISession
 
+from cartography.client.core.tx import load_graph_data
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ def load_service_data(
     Transform and load service information
     """
     ingestion_cypher_query = """
-    UNWIND $Services AS service
+    UNWIND $DictList AS service
         MERGE (s:PagerDutyService{id: service.id})
         ON CREATE SET s.html_url = service.html_url,
             s.firstseen = timestamp()
@@ -93,9 +94,10 @@ def load_service_data(
             for team in service["teams"]:
                 team_relations.append({"service": service["id"], "team": team["id"]})
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingestion_cypher_query,
-        Services=data,
+        data,
         update_tag=update_tag,
     )
 
@@ -110,14 +112,15 @@ def _attach_teams(
     Add relationship between teams and services.
     """
     ingestion_cypher_query = """
-    UNWIND $Relations AS relation
+    UNWIND $DictList AS relation
         MATCH (t:PagerDutyTeam{id: relation.team}), (s:PagerDutyService{id: relation.service})
         MERGE (t)-[r:ASSOCIATED_WITH]->(s)
         ON CREATE SET r.firstseen = timestamp()
     """
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingestion_cypher_query,
-        Relations=data,
+        data,
         update_tag=update_tag,
     )
 
@@ -129,7 +132,7 @@ def load_integration_data(
     Transform and load integration information
     """
     ingestion_cypher_query = """
-    UNWIND $Integrations AS integration
+    UNWIND $DictList AS integration
         MERGE (i:PagerDutyIntegration{id: integration.id})
         ON CREATE SET i.html_url = integration.html_url,
             i.firstseen = timestamp()
@@ -155,8 +158,9 @@ def load_integration_data(
         created_at = dateutil.parser.parse(integration["created_at"])
         integration["created_at"] = int(created_at.timestamp())
 
-    neo4j_session.run(
+    load_graph_data(
+        neo4j_session,
         ingestion_cypher_query,
-        Integrations=data,
+        data,
         update_tag=update_tag,
     )

--- a/cartography/models/core/relationships.py
+++ b/cartography/models/core/relationships.py
@@ -6,6 +6,7 @@ from enum import auto
 from enum import Enum
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from cartography.models.core.common import PropertyRef
 
@@ -85,6 +86,27 @@ def make_target_node_matcher(key_ref_dict: Dict[str, PropertyRef]) -> TargetNode
 
 
 @dataclass(frozen=True)
+class SourceNodeMatcher:
+    """
+    Identical shape to TargetNodeMatcher but used to match the *source* node of a
+    relationship. Only used with load_matchlinks() operations, where a relationship is
+    drawn between two nodes that already exist in the graph. It has no effect on
+    CartographyRelSchema objects composed into a CartographyNodeSchema.
+    See `make_source_node_matcher()`.
+    """
+    pass
+
+
+def make_source_node_matcher(key_ref_dict: Dict[str, PropertyRef]) -> SourceNodeMatcher:
+    """
+    :param key_ref_dict: A Dict mapping keys present on the node to PropertyRef objects.
+    :return: A SourceNodeMatcher used for load_matchlinks() to match the source node.
+    """
+    fields = [(key, PropertyRef, field(default=prop_ref)) for key, prop_ref in key_ref_dict.items()]
+    return make_dataclass(SourceNodeMatcher.__name__, fields, frozen=True)()
+
+
+@dataclass(frozen=True)
 class CartographyRelSchema(abc.ABC):
     """
     Abstract base dataclass that represents a cartography relationship.
@@ -131,6 +153,24 @@ class CartographyRelSchema(abc.ABC):
         :return: The LinkDirection of the query. Please see the `LinkDirection` docs for a detailed explanation.
         """
         pass
+
+    @property
+    def source_node_label(self) -> Optional[str]:
+        """
+        Only used with load_matchlinks(), where a relationship is drawn between two
+        existing nodes: the label of the source node. Ignored (None) for rel schemas
+        composed into a CartographyNodeSchema.
+        """
+        return None
+
+    @property
+    def source_node_matcher(self) -> Optional[SourceNodeMatcher]:
+        """
+        Only used with load_matchlinks(): how to find the source node of the
+        relationship. See `make_source_node_matcher()`. Ignored (None) for rel schemas
+        composed into a CartographyNodeSchema.
+        """
+        return None
 
 
 @dataclass(frozen=True)

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -67,8 +67,9 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 |-------|-------|--------|
 | 1 | Query/index fixes + `ensure_indexes` managed-tx wrap | ✅ done — unit + integration green in CI |
 | 2 | Integration EXPLAIN plan guard (+ self-test) | ✅ done — unit + real-EXPLAIN sweep green in CI |
-| 3 | Migrate per-item loaders to `tx.load()` | ⚪ not started — **unblocked**, and **re-scoped 2026-08-06** (see below) |
-| 4 | PROFILE unanchored cleanup queries | ⚪ not started — next up |
+| 3.0 | Foundation: `session.py` silent-fail fix, `graph_write_seconds` split, upstream `tx.py` backport (batch 10k + retry + matchlinks), `ensure_indexes` memoize | ⚪ not started — **next up; blocks 3.1+** |
+| 3 | Migrate per-item loaders to `tx.load()` (re-scoped 2026-08-06) | ⚪ not started — blocked on 3.0 |
+| 4 | PROFILE unanchored cleanup queries | ⚪ not started — after Phase 3 |
 
 > **CI update (2026-08-06):** the integration suite has run for Phases 1 and 2. Every item
 > previously marked ⏳ pending CI is green. The Phase 2 sweep is a hard gate
@@ -207,10 +208,31 @@ per-item writes; count `UNWIND` occurrences = already-batched queries):
   loops, e.g. `_attach_gcp_vpc_tags` (`gcp/compute.py:1427`) runs one query per
   `instance × tag × network-interface`, so round-trips grow multiplicatively, not linearly.
 
+### Phase 3.0 checklist — foundation (do first)
+
+Implements the **Recommended order** step 1 (strategic Options 2 + 5 + the `session.py`
+fix — see Strategic options section). Blocks 3.1+: migrations cannot be verified while
+writes fail silently, and the `tx.py` backport changes the target they migrate onto.
+
+| # | Task | Scope / key files | Est. | Status |
+|---|------|-------------------|------|--------|
+| 3.0.1 | Fix silent exception swallowing — every wrapper that logs + `return self` must re-raise (or retry, then raise): `run()`, `execute_write()`, `execute_read()` | `cartography/graph/session.py` | S | ⚪ |
+| 3.0.2 | Split graph-write time from API time: emit `graph_write_seconds` alongside `duration_seconds` via `ServiceTimingContext`; then re-rank remaining work with real numbers | provider timing contexts (`docs/azure-timing-instrumentation.md`) | S | ⚪ |
+| 3.0.3 | Backport upstream `client/core/tx.py`: `batch_size=10000` tunable per call (supersedes decision 14A), retry classification (network, `TransientError`, `BufferError`, `EntityNotFound`), empty-input short-circuit | `cartography/client/core/tx.py` + call sites | M | ⚪ |
+| 3.0.4 | Backport `load_matchlinks()` + `build_matchlink_query()` — relationship-only loader; migration target for hand-written linkers (AKS, route53) | `tx.py`, `querybuilder.py` | S | ⚪ |
+| 3.0.5 | Memoize `ensure_indexes()` per process (Option 5) | `tx.py:232` | XS | ⚪ |
+
+> **3.0.1 scope note (2026-08-06):** `session.py` has since gained a `TransientError`
+> retry loop (`session.py:50-63`), but the retry returns `self` on exhaustion instead of
+> raising, non-transient exceptions are still swallowed (`:64-69`), and the
+> `execute_write`/`execute_read` wrappers (`:76+`) swallow too. Scope = all of them —
+> log, then **raise**.
+
 ### Phase 3 checklist
 
-Chain-migrate whole dependency chains atomically (decisions 4, 8). Guard sweep green
-before each merge (12A).
+Prereq: **Phase 3.0 complete.** Chain-migrate whole dependency chains atomically
+(decisions 4, 8). Guard sweep green before each merge (12A). Use upstream's schema
+definitions as donor code where the fork has no custom logic (Option 3, selectively).
 
 | # | Module | Per-item writes | Est. | Status |
 |---|--------|----------------:|------|--------|
@@ -430,12 +452,21 @@ CI** (2026-08-06); line numbers updated to their post-fix locations.
 - EXPLAIN plan-guard test over querybuilder + cleanupbuilder outputs.
 - Index-coverage enforced by the guard (decision 6A — no separate static lint).
 
-**Phase 3 — migration (incremental, weeks):** ⚪ next
+**Phase 3.0 — foundation (days):** ⚪ next up
+- Fix `session.py` swallowed exceptions (all wrappers) — prerequisite: migrations cannot
+  be verified while writes fail silently.
+- Add `graph_write_seconds` timing split; re-rank remaining work with real numbers.
+- Backport upstream `tx.py` (batch 10k tunable, retry classification, `load_matchlinks`,
+  empty short-circuit); memoize `ensure_indexes()`. Tracked in the **Phase 3.0 checklist**.
+
+**Phase 3 — migration (incremental, weeks):** ⚪ after 3.0
 - Migrate **per-item** loaders to `tx.load()`, ranked by measured per-item write count:
-  `gcp/compute.py` → `aws/iam.py` → AWS ELB/SG/redshift → misc. Then wrap the
-  already-batched raw writes (Azure, s3, route53, spanner, pagerduty) in `execute_write`.
-  Each migration removes raw writes (§2) and gains UNWIND batching (§1) + auto-indexes (§3)
-  at once. Full ranking and checklist: **Phase 3 re-scope** section above.
+  `gcp/compute.py` → `aws/iam.py` → AWS ELB/SG/redshift → misc, taking upstream's schema
+  definitions as the starting point where the fork has no custom logic (Option 3,
+  selectively). Then wrap the already-batched raw writes (Azure, s3, route53, spanner,
+  pagerduty) in `execute_write` (3.7). Each migration removes raw writes (§2) and gains
+  UNWIND batching (§1) + auto-indexes (§3) at once. Full ranking and checklist:
+  **Phase 3 re-scope** section above.
 
 **Phase 4 — cleanup-scan optimization (narrowed, after measurement):**
 - PROFILE only the generated `cleanupbuilder.py` queries + any unanchored hand-written job.
@@ -543,6 +574,9 @@ independent of which option below is chosen.
 2. **Option 1**, module by module, taking upstream's schema definitions as the starting
    point wherever the fork has not customised the module (Option 3 applied selectively).
 3. **Option 4** for the remaining already-UNWIND raw writes.
+
+Status is tracked at task level in the **Phase 3.0 checklist** (foundation) and the
+**Phase 3 checklist** (migrations) above — update those tables as code lands.
 
 ### The measurement gap that ranks 1 vs 2
 

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -67,8 +67,8 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 |-------|-------|--------|
 | 1 | Query/index fixes + `ensure_indexes` managed-tx wrap | ✅ done — unit + integration green in CI |
 | 2 | Integration EXPLAIN plan guard (+ self-test) | ✅ done — unit + real-EXPLAIN sweep green in CI |
-| 3.0 | Foundation: `session.py` silent-fail fix, `graph_write_seconds` split, upstream `tx.py` backport (batch 10k + retry + matchlinks), `ensure_indexes` memoize | ⚪ not started — **next up; blocks 3.1+** |
-| 3 | Migrate per-item loaders to `tx.load()` (re-scoped 2026-08-06) | ⚪ not started — blocked on 3.0 |
+| 3.0 | Foundation: `session.py` silent-fail fix, `graph_write_seconds` split, upstream `tx.py` backport (batch 10k + retry + matchlinks), `ensure_indexes` memoize | ✅ done 2026-08-06 — unit tests green locally; integration pending CI |
+| 3 | Migrate per-item loaders to `tx.load()` (re-scoped 2026-08-06) | ⚪ not started — **unblocked, next up** (after 3.0 CI run) |
 | 4 | PROFILE unanchored cleanup queries | ⚪ not started — after Phase 3 |
 
 > **CI update (2026-08-06):** the integration suite has run for Phases 1 and 2. Every item
@@ -216,17 +216,27 @@ writes fail silently, and the `tx.py` backport changes the target they migrate o
 
 | # | Task | Scope / key files | Est. | Status |
 |---|------|-------------------|------|--------|
-| 3.0.1 | Fix silent exception swallowing — every wrapper that logs + `return self` must re-raise (or retry, then raise): `run()`, `execute_write()`, `execute_read()` | `cartography/graph/session.py` | S | ⚪ |
-| 3.0.2 | Split graph-write time from API time: emit `graph_write_seconds` alongside `duration_seconds` via `ServiceTimingContext`; then re-rank remaining work with real numbers | provider timing contexts (`docs/azure-timing-instrumentation.md`) | S | ⚪ |
-| 3.0.3 | Backport upstream `client/core/tx.py`: `batch_size=10000` tunable per call (supersedes decision 14A), retry classification (network, `TransientError`, `BufferError`, `EntityNotFound`), empty-input short-circuit | `cartography/client/core/tx.py` + call sites | M | ⚪ |
-| 3.0.4 | Backport `load_matchlinks()` + `build_matchlink_query()` — relationship-only loader; migration target for hand-written linkers (AKS, route53) | `tx.py`, `querybuilder.py` | S | ⚪ |
-| 3.0.5 | Memoize `ensure_indexes()` per process (Option 5) | `tx.py:232` | XS | ⚪ |
+| 3.0.1 | Fix silent exception swallowing — every wrapper that logs + `return self` must re-raise (or retry, then raise): `run()`, `execute_write()`, `execute_read()` | `cartography/graph/session.py` | S | ✅ `92d62da40`, `bc0693378` |
+| 3.0.2 | Split graph-write time from API time: emit `graph_write_seconds` alongside `duration_seconds`; then re-rank remaining work with real numbers | `graph/write_timer.py` (new), `graph/session.py`, azure `util/timing.py`, aws/gcp `__init__.py` | S | ✅ `8efe6aec0`, `8d66b5960`, `52e8278ff` |
+| 3.0.3 | Backport upstream `client/core/tx.py`: `batch_size=10000` tunable per call (supersedes decision 14A), retry classification (network, `TransientError`, `BufferError`, `EntityNotFound`), empty-input short-circuit, index-race tolerance | `cartography/client/core/tx.py` | M | ✅ `e1f90f7ca`, `50453c34b`, `82b166502`, `f649917d9` |
+| 3.0.4 | Backport `load_matchlinks()` + `build_matchlink_query()` — relationship-only loader; migration target for hand-written linkers (AKS, route53) | `models/core/relationships.py`, `querybuilder.py`, `tx.py` | S | ✅ `1fc2e87ec`, `acfa2eb89`, `fd3f314dc` |
+| 3.0.5 | Memoize `ensure_indexes()` per process (Option 5) | `tx.py` | XS | ✅ `e52b15207` |
 
-> **3.0.1 scope note (2026-08-06):** `session.py` has since gained a `TransientError`
-> retry loop (`session.py:50-63`), but the retry returns `self` on exhaustion instead of
-> raising, non-transient exceptions are still swallowed (`:64-69`), and the
-> `execute_write`/`execute_read` wrappers (`:76+`) swallow too. Scope = all of them —
-> log, then **raise**.
+> **3.0.1 scope note (2026-08-06):** `session.py` had gained a `TransientError`
+> retry loop, but the retry returned `self` on exhaustion instead of raising,
+> non-transient exceptions were still swallowed, and the `execute_write`/
+> `execute_read` wrappers swallowed too. All of them now log and **raise**.
+
+> **Phase 3.0 implementation notes (2026-08-06):** all tasks landed with unit tests
+> (`test_session.py`, `test_write_timer.py`, `test_tx.py`, `test_querybuilder_matchlink.py`,
+> `test_relationships.py`, `test_timing.py`) — 60+ new assertions, one atomic commit per
+> change. New helpers for Phase 3.7: `run_write_query()` (drop-in for raw auto-commit
+> `session.run`) and `execute_write_with_retry()`. The matchlink backport is the minimal
+> core: upstream's optional sub-resource-scoped endpoint matching is deferred until a
+> call site needs it. Run integration in CI before starting 3.1 (sandbox has no neo4j;
+> `test_plan_guard.py::test_iter_generated_queries_builds_all` has a pre-existing,
+> ordering-dependent failure when run with the querybuilder-excs test module — verified
+> present before these changes at `7f4bcddd8`).
 
 ### Phase 3 checklist
 
@@ -537,7 +547,7 @@ migration that exists, is tested, and is running in production elsewhere.
 - **Structured JSON timing logs** per service/subscription.
 - **EXPLAIN plan guard** (Phase 2) — upstream has no equivalent.
 
-### ⚠️ Correctness defect found during this analysis
+### ⚠️ Correctness defect found during this analysis — ✅ FIXED 2026-08-06 (3.0.1)
 
 `cartography/graph/session.py:67` — the fork's `Session.run()` wrapper catches
 `Exception`, logs a warning, and **returns `self`**:
@@ -638,7 +648,9 @@ Re-run it before starting a module; the counts move as migrations land.
 
 | Concern | File:line |
 |---------|-----------|
-| Batched load entrypoint | `cartography/client/core/tx.py:252` (`load`), `:208` (`load_graph_data`), `:223` (batch=500) |
+| Batched load entrypoint | `cartography/client/core/tx.py` (`load`, `load_graph_data`; batch_size=10000 default, tunable) |
+| Matchlink loader (3.0.4) | `tx.py` (`load_matchlinks`), `querybuilder.py` (`build_matchlink_query`) |
+| Graph-write timing split | `cartography/graph/write_timer.py`, fed by `graph/session.py` |
 | ~~Raw run in ensure_indexes~~ (now managed) | `cartography/client/core/tx.py:232` |
 | Ingestion query (UNWIND) | `cartography/graph/querybuilder.py:347` |
 | Auto index generation | `cartography/graph/querybuilder.py:402` |

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -251,9 +251,9 @@ definitions as donor code where the fork has no custom logic (Option 3, selectiv
 | 3.3 | `aws/ec2/security_groups.py` | 5 | S | ✅ `38fda6601` |
 | 3.4 | `aws/ec2/load_balancers.py` + `load_balancer_v2s.py` | 9 | M | ✅ `64cf92c2b`, `1da1d1ad1` |
 | 3.5 | `aws/redshift.py` | 5 | S | ✅ `dcfeb5caa` |
-| 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ✅ `dcd217064` |
-| 3.7 | Already-UNWIND raw writes → `load_graph_data` (10k chunks + retry) / `run_write_query` (azure ×3, aws s3/route53, gcp spanner, pagerduty) | n/a | M | ✅ `3f637d91c`, `affa89d32`, `05de80069` |
-| 3.8 | **Uniform neo4j interactions** (plan items 5+6): every remaining raw `session.run` in the in-scope providers → `load_graph_data` / `run_write_query` / `execute_read` | n/a | M | ✅ 8 commits, `249da0f8f`..`2408593c5` |
+| 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ✅ `deb9f6a51` |
+| 3.7 | Already-UNWIND raw writes → `load_graph_data` (10k chunks + retry) / `run_write_query` (azure ×3, aws s3/route53, gcp spanner, pagerduty) | n/a | M | ✅ `e94238e46`, `24634c457`, `01f681ecd` |
+| 3.8 | **Uniform neo4j interactions** (plan items 5+6): every remaining raw `session.run` in the in-scope providers → `load_graph_data` / `run_write_query` / `execute_read` | n/a | M | ✅ 8 commits, `522ea1081`..`88a34899a` |
 
 > **Phase 3.8 — uniform interactions (2026-08-06).** Sweep over aws, gcp, azure, oci,
 > github, bitbucket, gitlab and azuredevops (okta and other low-priority providers left

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -68,8 +68,8 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 | 1 | Query/index fixes + `ensure_indexes` managed-tx wrap | ✅ done — unit + integration green in CI |
 | 2 | Integration EXPLAIN plan guard (+ self-test) | ✅ done — unit + real-EXPLAIN sweep green in CI |
 | 3.0 | Foundation: `session.py` silent-fail fix, `graph_write_seconds` split, upstream `tx.py` backport (batch 10k + retry + matchlinks), `ensure_indexes` memoize | ✅ done 2026-08-06 — unit tests green locally; integration pending CI |
-| 3 | Migrate per-item loaders to `tx.load()` (re-scoped 2026-08-06) | ⚪ not started — **unblocked, next up** (after 3.0 CI run) |
-| 4 | PROFILE unanchored cleanup queries | ⚪ not started — after Phase 3 |
+| 3 | Batch per-item loaders + wrap already-UNWIND raw writes (re-scoped 2026-08-06) | ✅ done 2026-08-06 — unit tests green locally; integration + guard sweep pending CI |
+| 4 | PROFILE unanchored cleanup queries | ⚪ not started — **next up** (after Phase 3 CI run) |
 
 > **CI update (2026-08-06):** the integration suite has run for Phases 1 and 2. Every item
 > previously marked ⏳ pending CI is green. The Phase 2 sweep is a hard gate
@@ -246,13 +246,23 @@ definitions as donor code where the fork has no custom logic (Option 3, selectiv
 
 | # | Module | Per-item writes | Est. | Status |
 |---|--------|----------------:|------|--------|
-| 3.1 | `gcp/compute.py` (instance/NIC/subnet/VPC/tag chain) | 11 (incl. nested) | L | ⚪ |
-| 3.2 | `aws/iam.py` (user/group/role/policy/access-key chain) | 10 | L | ⚪ |
-| 3.3 | `aws/ec2/security_groups.py` | 5 | S | ⚪ |
-| 3.4 | `aws/ec2/load_balancers.py` + `load_balancer_v2s.py` | 9 | M | ⚪ |
-| 3.5 | `aws/redshift.py` | 5 | S | ⚪ |
-| 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ⚪ |
-| 3.7 | Already-UNWIND raw writes: wrap in `execute_write` **and** chunk the list at 500 (azure ×3, aws s3/route53, gcp spanner, pagerduty) — buys retry + OOM safety without a schema | n/a | M | ⚪ |
+| 3.1 | `gcp/compute.py` (instance/NIC/subnet/VPC/tag chain) | 11 (incl. nested) | L | ✅ `2d318fc17`..`37dfbfb07` (5 commits) |
+| 3.2 | `aws/iam.py` (user/group/role/policy/access-key chain) | 10 | L | ✅ `b6bdc8cf2`, `1abf8046e`, `dc8bf7393` |
+| 3.3 | `aws/ec2/security_groups.py` | 5 | S | ✅ `38fda6601` |
+| 3.4 | `aws/ec2/load_balancers.py` + `load_balancer_v2s.py` | 9 | M | ✅ `64cf92c2b`, `1da1d1ad1` |
+| 3.5 | `aws/redshift.py` | 5 | S | ✅ `dcfeb5caa` |
+| 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ✅ `dcd217064` |
+| 3.7 | Already-UNWIND raw writes → `load_graph_data` (10k chunks + retry) / `run_write_query` (azure ×3, aws s3/route53, gcp spanner, pagerduty) | n/a | M | ✅ `3f637d91c`, `affa89d32`, `05de80069` |
+
+> **Phase 3 implementation notes (2026-08-06):** executed via the plan §1.3 "intermediate
+> win": each per-item loop rewritten as one UNWIND batch through `load_graph_data`
+> (managed tx, retry, 10k-row chunks), preserving query text, labels, and consolelink
+> props — not full schema migrations (those remain available selectively via upstream
+> donors). Public loader signatures used by integration tests are preserved. ~30 new
+> unit tests over row builders and write batching; the full unit suite shows zero new
+> failures vs the pre-Phase-3 baseline (one pre-existing failure fixed:
+> `test_principal_policies`). Integration suite + Phase 2 guard sweep must run in CI
+> before Phase 4.
 
 ---
 

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -1,10 +1,11 @@
 # Neo4j Scaling — Performance Improvement Plan
 
-Status: draft · Owner: backend · Last updated: 2026-06-21
+Status: active · Owner: backend · Last updated: 2026-08-06
 
 This plan analyzes the cartography codebase against four well-known Neo4j scaling
 remediations and lays out concrete, prioritized work. Every finding below is
-backed by a `file:line` reference verified against the current `main`.
+backed by a `file:line` reference. **All references re-verified 2026-08-06** against
+`bug-fixes` (drifted line numbers corrected; resolved offenders struck through).
 
 The four remediations:
 
@@ -19,9 +20,9 @@ The four remediations:
 
 | # | Fix | Why | Effort | Impact |
 |---|-----|-----|--------|--------|
-| 1 | Add labels to label-less / unindexed `MATCH`es (`azure/compute.py:988,998`, `gcp/compute.py:1501`, `gcp/spanner.py:157`) | AllNodesScan / full-label-scan on every run | S | 🔴 High |
-| 2 | Index properties used in loader `MATCH`/`WHERE` that aren't `id`/relationship targets (e.g. `GCPSpannerInstance.config`, `AzureCluster.name`) | Full label scan per UNWIND batch | S | 🔴 High |
-| 3 | Migrate hottest hand-written per-item loops to `load()` / `load_graph_data()` (GCP compute, AWS iam/rds, Azure) | One round-trip per row instead of per 500-row batch | L | 🔴 High |
+| 1 | ~~Add labels to label-less / unindexed `MATCH`es~~ | AllNodesScan on every run | S | ✅ **shipped (Phase 1)** |
+| 2 | ~~Index non-`id` loader `MATCH` properties (`GCPSpannerInstance.config`, `AzureCluster.name`)~~ | Full label scan per batch | S | ✅ **shipped (Phase 1)** |
+| 3 | Migrate hand-written **per-item** loops to `load()` — `gcp/compute.py`, `aws/iam.py`, then `aws/redshift.py` + `aws/ec2/{load_balancers,load_balancer_v2s,security_groups}.py` | One round-trip per row instead of per 500-row batch | L | 🔴 High |
 | 4 | Wrap remaining raw `session.run()` writes in managed transactions (incl. `ensure_indexes`) | No retry on `TransientError` | M | 🟠 Med |
 | 5 | Add an integration EXPLAIN plan guard (with self-test) in CI | Catch AllNodesScan regressions before deploy; merge gate for migrations | M | 🟠 Med |
 | 6 | PROFILE only the *unanchored* cleanup queries (NOT the 247 anchored ones) | Most cleanup jobs already traverse indexed roots — see correction below | S | 🟢 Low |
@@ -64,28 +65,35 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 1 | Query/index fixes + `ensure_indexes` managed-tx wrap | ✅ done (integration tests pending CI) |
-| 2 | Integration EXPLAIN plan guard (+ self-test) | ✅ done (unit green; integration pending CI) |
-| 3 | Migrate per-item loaders to `tx.load()` | ⛔ deferred — unblocks once Phase 2 guard is green in CI |
-| 4 | PROFILE unanchored cleanup queries | ⚪ not started |
+| 1 | Query/index fixes + `ensure_indexes` managed-tx wrap | ✅ done — unit + integration green in CI |
+| 2 | Integration EXPLAIN plan guard (+ self-test) | ✅ done — unit + real-EXPLAIN sweep green in CI |
+| 3 | Migrate per-item loaders to `tx.load()` | ⚪ not started — **unblocked**, and **re-scoped 2026-08-06** (see below) |
+| 4 | PROFILE unanchored cleanup queries | ⚪ not started — next up |
+
+> **CI update (2026-08-06):** the integration suite has run for Phases 1 and 2. Every item
+> previously marked ⏳ pending CI is green. The Phase 2 sweep is a hard gate
+> (`KNOWN_OFFENDERS = set()`) and passed, so no generated schema currently plans an
+> `AllNodesScan`. Phase 3 is therefore no longer blocked (decision 4); each migration must
+> show zero `*Scan` on its new ingestion query before merge (decision 12A).
 
 ### Phase 1 checklist
 
 | # | Change | Test | Unit/lint here | Integration (CI) | Commit |
 |---|--------|------|----------------|------------------|--------|
 | 1.1 | `ensure_indexes` raw `run` → `execute_write` (`tx.py:234`) | unit (mock session) | ✅ 3 pass | n/a | ✅ |
-| 1.2 | `gcp/compute.py:1501` `MATCH (nic)` → `:GCPNetworkInterface` | existing `test_compute.py:346` | flake8 ✅ | ⏳ pending CI | ✅ |
-| 1.3 | `gcp/spanner.py:157` + index `GCPSpannerInstance(config)` | existing `test_spanner.py` | n/a | ⏳ pending CI | ✅ |
-| 1.4 | `azure/compute.py` AKS per-label queries + `AzureCluster(name,resourcegroup)` index | new red-first `test_aks.py::test_link_compute_to_aks` (9A) | flake8 ✅ (net −1 E501), compile ✅ | ⏳ pending CI | ✅ |
+| 1.2 | `gcp/compute.py:1501` `MATCH (nic)` → `:GCPNetworkInterface` | existing `test_compute.py:346` | flake8 ✅ | ✅ green | ✅ |
+| 1.3 | `gcp/spanner.py:157` + index `GCPSpannerInstance(config)` | existing `test_spanner.py` | n/a | ✅ green | ✅ |
+| 1.4 | `azure/compute.py` AKS per-label queries + `AzureCluster(name,resourcegroup)` index | new red-first `test_aks.py::test_link_compute_to_aks` (9A) | flake8 ✅ (net −1 E501), compile ✅ | ✅ green | ✅ |
 
 > **1.4 note:** Cypher forbids `UNION` around write clauses, so decision 7A's "templated UNION"
 > is realized as a template run once per label (same DRY win, valid Cypher). Azure modules can't
-> be imported in the dev sandbox (missing `cloudconsolelink`), so the rewrite is validated by the
-> new integration test in CI; locally confirmed via flake8 + byte-compile + `.format` render check.
+> be imported in the dev sandbox (missing `cloudconsolelink`), so the rewrite was validated by the
+> new integration test in CI — now green. Locally confirmed via flake8 + byte-compile + `.format`
+> render check.
 
-> **Validation note:** neo4j/docker unavailable in the dev sandbox, so integration tests can't
-> run here (decision: unit-validate + lint locally, run `make test_integration` in CI). Each
-> Phase 1 commit notes its integration test as pending CI.
+> **Validation note:** neo4j/docker is unavailable in the dev sandbox, so integration tests were
+> unit-validated + linted locally and run via `make test_integration` in CI. That CI run has since
+> completed — all Phase 1 integration tests pass.
 
 ### Phase 2 checklist — EXPLAIN plan guard
 
@@ -93,8 +101,8 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 |---|------|----------|--------|
 | 2.1 | Pure plan-walk + banned-operator detection (`plan_guard.py`) | 1A | ✅ unit 5/5 |
 | 2.2 | Enumerate all generated ingestion + cleanup queries | 13A | ✅ unit (37 schemas, all build) |
-| 2.3 | Guard self-test: label-less fails, indexed passes | 10A | ✅ unit fixtures; ⏳ real-EXPLAIN fixtures in CI |
-| 2.4 | Sweep all generated queries via real EXPLAIN, fail on `AllNodesScan` | 13A | ⏳ pending CI (`test_query_plans.py`) |
+| 2.3 | Guard self-test: label-less fails, indexed passes | 10A | ✅ unit fixtures + real-EXPLAIN fixtures green in CI |
+| 2.4 | Sweep all generated queries via real EXPLAIN, fail on `AllNodesScan` | 13A | ✅ green in CI (`test_query_plans.py`), 0 offenders |
 
 > **Phase 2 notes:**
 > - Detection logic is neo4j-free (`tests/integration/.../graph/plan_guard.py`) so it unit-tests
@@ -110,6 +118,110 @@ Legend: ✅ done · 🔵 in progress · ⚪ not started · ⛔ blocked/deferred
 > - **Migrate-OOM gate (12A):** Phase 3 migrations run this sweep on the new ingestion query and
 >   must show zero `*Scan` before merge — prevents reproducing CDX-INVENTORY-887.
 
+
+### Phase 3 — what it actually is, in plain English
+
+**The problem.** For resources that were never migrated to the schema/`load()` path,
+cartography writes one row per network round-trip:
+
+```python
+for user in users:                       # e.g. 5,000 IAM users
+    neo4j_session.run(query, ...)        # 5,000 round-trips, 5,000 transactions
+```
+
+**The fix.** Describe the node once as a `CartographyNodeSchema`, then delete the loop:
+
+```python
+load(neo4j_session, IAMUserSchema(), users)   # 10 round-trips (500 rows each)
+```
+
+That single swap buys all three remediations at once, because `load()`
+(`cartography/client/core/tx.py:252`) already does them:
+
+| You get | From | Fixes |
+|---|---|---|
+| UNWIND batching, 500 rows/tx | `load_graph_data` (`tx.py:208`, batch at `:223`) | §1 |
+| Managed tx + `TransientError` retry | `session.execute_write` inside the batch loop | §2 |
+| Auto-created indexes for `id`, `lastupdated`, rel-target and `extra_index` fields | `ensure_indexes` (`tx.py:232`) → `build_create_index_queries` (`querybuilder.py:402`) | §3 |
+
+**The cost.** Per module: write the schema dataclass, replace the loop, keep behaviour
+identical. The module's existing integration test is the correctness check; the Phase 2
+EXPLAIN guard is the performance check (zero `*Scan` on the new ingestion query before
+merge — decision 12A). Copy any OCI module, e.g. `cartography/intel/oci/compute.py`.
+
+**Nothing is rewritten from scratch** — this is applying an existing, tested path to
+modules that predate it.
+
+### Phase 3 re-scope (2026-08-06)
+
+The original target list ("GCP compute, AWS iam/rds, Azure write-heavy modules") ranked
+modules by **count of raw `session.run()` calls**. That is the wrong metric: a raw
+`run()` whose query already says `UNWIND $DictList AS item` is *already batched* — it
+only lacks managed-tx retry, which is a §2 one-liner, not a §1 migration.
+
+Re-measured by AST scan (count `.run()` calls lexically inside a `for` loop = true
+per-item writes; count `UNWIND` occurrences = already-batched queries):
+
+| Module | raw `run()` | **inside a `for`** | uses `UNWIND` | Verdict |
+|---|---:|---:|---:|---|
+| `gcp/compute.py` | 23 | **11** | 7 | 🔴 P1 — worst offender |
+| `aws/iam.py` | 20 | **10** | 2 | 🔴 P1 |
+| `aws/redshift.py` | 7 | **5** | 3 | 🟠 P2 |
+| `aws/ec2/load_balancers.py` | 6 | **5** | 1 | 🟠 P2 |
+| `aws/ec2/security_groups.py` | 6 | **5** | 0 | 🟠 P2 |
+| `aws/ec2/load_balancer_v2s.py` | 5 | **4** | 1 | 🟠 P2 |
+| `github/repos.py` | 6 | 2 | 5 | 🟢 P3 |
+| `aws/rds.py` | 16 | 2 | 14 | 🟢 P3 |
+| `azure/subscription.py` | 1 | 1 | 0 | 🟢 P3 — trivial |
+| `digitalocean/compute.py` | 1 | 1 | 0 | 🟢 P3 — trivial |
+| `azure/sql.py` | 29 | 1 | 14 | ⚪ §2 only |
+| `aws/s3.py` | 10 | 1 | 7 | ⚪ §2 only |
+| `aws/route53.py` | 12 | 1 | 7 | ⚪ §2 only |
+| `azure/cosmosdb.py` | 22 | 0 | 16 | ⚪ §2 only |
+| `azure/storage.py` | 18 | 0 | 9 | ⚪ §2 only |
+| `gcp/spanner.py` | 5 | 0 | 5 | ⚪ §2 only |
+| `pagerduty/services.py` | 3 | 0 | 3 | ⚪ §2 only |
+
+**Corrections this forces:**
+
+- **Azure is not a Phase 3 target — but it is not clean either.** `cosmosdb.py`
+  (0 per-item), `storage.py` (0) and `sql.py` (1) already UNWIND, so the §1 per-row
+  problem Phase 3 exists to solve is absent; a schema migration would be re-plumbing, not
+  a speedup. Two real defects remain, both cheaper than migration:
+  1. **No retry** — raw `run()` is auto-commit (§2). Wrap in `execute_write`. Effort S.
+  2. **No 500-row chunk** — the whole list goes in one transaction, unlike
+     `load_graph_data` (`tx.py:223`). A large account can blow
+     `dbms.memory.transaction.total.max` — the CDX-INVENTORY-887 failure mode.
+  Same shape for `aws/s3.py`, `aws/route53.py`, `gcp/spanner.py`, `pagerduty/services.py`.
+- **Azure's UNWIND is per-parent, not global.** e.g. `cosmosdb.py:173` loops accounts and
+  calls `_load_database_account_write_locations` per account (`:263`), so round-trips scale
+  with **parent count**, not row count. Middle tier: better than per-row, worse than
+  `load()`. Fixing it is Phase 3.7, not a migration.
+- **`aws/rds.py` drops out of P1.** 14 of its 16 queries already UNWIND; only 2 per-item
+  writes remain.
+- **AWS ELB/SG modules move up.** `aws/ec2/load_balancers.py`, `load_balancer_v2s.py` and
+  `security_groups.py` are almost entirely per-item and are small files (≤257 LOC) — the
+  cheapest real wins after the two P1s. Note the old plan's paths `aws/load_balancers.py` /
+  `aws/load_balancer_v2s.py` no longer exist; both live under `aws/ec2/`.
+- **`gcp/compute.py` is worse than a flat count suggests** — some writes are *nested*
+  loops, e.g. `_attach_gcp_vpc_tags` (`gcp/compute.py:1427`) runs one query per
+  `instance × tag × network-interface`, so round-trips grow multiplicatively, not linearly.
+
+### Phase 3 checklist
+
+Chain-migrate whole dependency chains atomically (decisions 4, 8). Guard sweep green
+before each merge (12A).
+
+| # | Module | Per-item writes | Est. | Status |
+|---|--------|----------------:|------|--------|
+| 3.1 | `gcp/compute.py` (instance/NIC/subnet/VPC/tag chain) | 11 (incl. nested) | L | ⚪ |
+| 3.2 | `aws/iam.py` (user/group/role/policy/access-key chain) | 10 | L | ⚪ |
+| 3.3 | `aws/ec2/security_groups.py` | 5 | S | ⚪ |
+| 3.4 | `aws/ec2/load_balancers.py` + `load_balancer_v2s.py` | 9 | M | ⚪ |
+| 3.5 | `aws/redshift.py` | 5 | S | ⚪ |
+| 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ⚪ |
+| 3.7 | Already-UNWIND raw writes: wrap in `execute_write` **and** chunk the list at 500 (azure ×3, aws s3/route53, gcp spanner, pagerduty) — buys retry + OOM safety without a schema | n/a | M | ⚪ |
+
 ---
 
 ## How data flows today (baseline)
@@ -118,23 +230,45 @@ The modern, efficient path already exists and is the migration target:
 
 ```
 intel module
-  └─ tx.load(session, node_schema, dict_list)            cartography/client/core/tx.py:237
-        ├─ ensure_indexes(session, node_schema)           tx.py:218  → auto CREATE INDEX
-        └─ load_graph_data(session, query, dict_list)     tx.py:194
-              └─ for batch in batch(dict_list, size=500): tx.py:209
+  └─ tx.load(session, node_schema, dict_list)            cartography/client/core/tx.py:252
+        ├─ ensure_indexes(session, node_schema)           tx.py:232  → auto CREATE INDEX
+        └─ load_graph_data(session, query, dict_list)     tx.py:208
+              └─ for batch in batch(dict_list, size=500): tx.py:223
                     session.execute_write(write_list_of_dicts_tx, query, DictList=batch)
 ```
 
-- `build_ingestion_query()` (`cartography/graph/querybuilder.py:349`) generates a single
+- `build_ingestion_query()` (`cartography/graph/querybuilder.py:347`) generates a single
   `UNWIND $DictList AS item MERGE (...) SET ...` query — correct batched pattern.
-- `build_create_index_queries()` (`querybuilder.py:404`) auto-creates indexes for the
+- `build_create_index_queries()` (`querybuilder.py:402`) auto-creates indexes for the
   node's `id`, `lastupdated`, every relationship `TargetNodeMatcher` field, and any
   `PropertyRef(extra_index=True)`.
-- Static baseline indexes live in `cartography/data/indexes.cypher` (475 `CREATE INDEX`
+- Static baseline indexes live in `cartography/data/indexes.cypher` (494 `CREATE INDEX`
   statements), applied once before sync via `cartography/intel/create_indexes.py`.
 
-OCI is fully migrated to this path (10 modules). AWS, GCP, and Azure are largely **not**,
-and that is where the scaling cost concentrates.
+**Coverage as of 2026-08-06 (AST scan over `cartography/intel`, 223 files):**
+
+| Provider | files | use `load()` | raw `session.run()` | of which per-item |
+|---|---:|---:|---:|---:|
+| aws | 61 | 10 | 148 | 40 |
+| azure | 22 | **0** | 82 | 4 |
+| gcp | 34 | **0** | 42 | 16 |
+| oci | 18 | 10 | 28 | 6 |
+| pagerduty | 7 | 0 | 17 | 0 |
+| okta | 11 | 0 | 15 | 0 |
+| github | 7 | 1 | 8 | 2 |
+| duo | 8 | 7 | 0 | 0 |
+| *(others)* | 35 | 3 | 31 | 3 |
+| **TOTAL** | **223** | **31** | **371** | **71** |
+
+So **~14% of intel files** use the managed, chunked `load()` path. The other 371 raw
+`run()` calls fall into three tiers, and only the first is a Phase 3 migration:
+
+1. **Per-item (71 calls)** — one round-trip *per row*. §1 + §2 + §3 all broken. → Phase 3.1–3.6.
+2. **UNWIND, per-parent, unchunked (~300 calls)** — batched, but auto-commit (no retry)
+   and no 500-row cap. → Phase 3.7, effort S–M each.
+3. **Reads** — `run()` used to query, not write. Should use `execute_read` (§2 note).
+
+GCP and Azure have **zero** migrated modules; AWS is 10/61.
 
 ---
 
@@ -148,26 +282,29 @@ and that is where the scaling cost concentrates.
 These are the scaling bottleneck: a Python `for` loop calling `session.run()` once per
 item means N network round-trips and N transactions instead of `ceil(N/500)`.
 
-- **GCP compute** — many per-item `MERGE` loops:
-  `cartography/intel/gcp/compute.py` VPC, subnet, forwarding-rule, NIC, access-config,
-  service-account, firewall loaders (functions around lines 1216–1630). Highest row
-  counts in a typical org; top migration target.
-- **AWS** — per-item loops in `aws/iam.py`, `aws/rds.py`, `aws/redshift.py`,
-  `aws/load_balancers.py`, `aws/load_balancer_v2s.py`, `aws/security_groups.py`,
-  `aws/route53.py`, `aws/s3.py`.
-- **Azure** — per-item loops in `azure/subscription.py:101`, `azure/sql.py:336`,
-  plus cosmosdb/storage write-heavy modules.
-- **Misc** — `digitalocean/compute.py`, `pagerduty/services.py`, `github/repos.py`.
+Measured per module in the **Phase 3 re-scope** table above. Headline:
+
+- **GCP compute** — 11 per-item writes across the VPC / subnet / NIC / access-config /
+  service-account / firewall loaders, and `_attach_gcp_vpc_tags` (`gcp/compute.py:1427`)
+  is a *nested* loop (one query per instance × tag × NIC). Top migration target.
+- **AWS IAM** — 10 per-item writes: one per user (`iam.py:494`), group (`:651`),
+  role (`:735`), external principal (`:756`), trust-policy principal (`:766`),
+  group membership (`:794`), access key (`:904`).
+- **AWS ELB / security groups** — `aws/ec2/{load_balancers,load_balancer_v2s,security_groups}.py`
+  are almost entirely per-item, but small; cheap wins.
+- **Azure and most other write-heavy modules already UNWIND** — they need §2 (managed-tx
+  wrapping), not a §1 migration. See the re-scope table.
 
 ### Plan
-1. Rank modules by typical row volume (GCP compute, AWS iam/rds first).
+1. Rank by **measured per-item write count**, not raw `run()` count — see the Phase 3
+   re-scope table. Order: `gcp/compute.py` → `aws/iam.py` → AWS ELB/SG/redshift → misc.
 2. For each: define a `CartographyNodeSchema` (if missing) and replace the
    hand-written loop with `tx.load(...)`. This gets UNWIND batching, managed
    transactions, and auto-indexes in one move.
 3. Where a full schema migration is too large, intermediate win: rewrite the loop
    body as a single `UNWIND $DictList AS item ...` query and call `load_graph_data()`
    directly with the existing query string.
-4. Track migration in a checklist (one row per module) so coverage is visible.
+4. Coverage is tracked in the **Phase 3 checklist** above (one row per module/chain).
 
 Reference implementation to copy: any OCI module, e.g. `cartography/intel/oci/compute.py`.
 
@@ -184,7 +321,10 @@ Reference implementation to copy: any OCI module, e.g. `cartography/intel/oci/co
 ### Gaps — raw auto-commit `session.run()`
 Raw `neo4j_session.run(...)` is auto-commit with **no retry**. A transient error
 (leader switch, memory pressure) fails the whole sync stage. Largest clusters of raw
-writes: `azure/cosmosdb.py`, `azure/storage.py`, plus the per-item loaders in §1.
+writes: `azure/sql.py` (29), `azure/cosmosdb.py` (22), `azure/storage.py` (18),
+`gcp/compute.py` (23), `aws/iam.py` (20). Note the Azure three are **already UNWIND-batched**
+— for them this is the only defect, so they are cheap `execute_write` wraps (Phase 3.7),
+not migrations.
 
 One specific infra case worth fixing regardless of the broader migration:
 
@@ -230,24 +370,26 @@ Confirmed live instances:
 2. **Better:** mark the property `extra_index=True` on its `PropertyRef` in the node
    schema so the index travels with the model (only works once the module is migrated
    to a schema; otherwise use indexes.cypher).
-3. **Systematic:** write a lint/test that scans loader Cypher for `MATCH (x:Label{prop: ...})`
-   where `prop != id` and asserts a matching index exists in `indexes.cypher` or the
-   schema. This prevents the gap class from recurring. (See §4 tooling.)
+3. ✅ **Systematic:** done differently — decision 6A rejected a static Cypher lint as
+   brittle. The Phase 2 EXPLAIN guard enforces the same rule empirically: an unindexed
+   non-`id` `MATCH` shows up as `AllNodesScan` in the plan and fails CI.
 
 ---
 
 ## 4. EXPLAIN / inefficient APIs (AllNodesScan)
 
 ### Confirmed offenders
-- **AllNodesScan — label-less `MATCH`:**
-  - `cartography/intel/gcp/compute.py:1501` — `MATCH (nic{id: $NicId})` (no label).
-    Fix: `MATCH (nic:GCPNetworkInterface{id: $NicId})`.
-  - `cartography/intel/azure/compute.py:989` and `:999` —
-    `MATCH (node) WHERE node:AzureVirtualMachine OR node:AzureVirtualMachineScaleSet`.
-    Label-less scan then filter. Fix: run two labelled `MATCH`es / `UNION`, or anchor on
-    an indexed property.
-- **Full label scan on non-indexed property:** `gcp/spanner.py:157` (see §3).
-- **Cartesian-style linking:** `cartography/intel/aws/route53.py:119,128,137` —
+
+All three AllNodesScan/full-scan sites below were **fixed in Phase 1 and verified green in
+CI** (2026-08-06); line numbers updated to their post-fix locations.
+
+- ~~**AllNodesScan — label-less `MATCH`:**~~ ✅ fixed
+  - `cartography/intel/gcp/compute.py:1504` — now `MATCH (nic:GCPNetworkInterface{id: $NicId})`.
+  - `cartography/intel/azure/compute.py:998,1008` — now
+    `MATCH (c:AzureCluster {name: ..., resourcegroup: ...})`, one templated query per label.
+- ~~**Full label scan on non-indexed property:**~~ ✅ fixed — `gcp/spanner.py:157` still
+  matches on `config`, but `GCPSpannerInstance(config)` is now indexed.
+- **Cartesian-style linking (still open):** `cartography/intel/aws/route53.py:119,128,137` —
   `MATCH (n:AWSDNSRecord) WITH n MATCH (l:LoadBalancer{dnsname: n.value})`. The target
   match keys on `dnsname`; confirm those are indexed and that the planner isn't doing an
   n×m join. Rewrite as a single UNWIND + indexed lookup if the plan is bad.
@@ -258,12 +400,15 @@ Confirmed live instances:
   (which is indexed) rather than starting from a bare `MATCH (n:Label)`. Do **not** rewrite
   `<>`→`=` (different semantics).
 
-### No instrumentation today
-There is zero use of `EXPLAIN`/`PROFILE` in code or tests. Bad plans ship undetected.
+### Instrumentation
+~~There is zero use of `EXPLAIN`/`PROFILE` in code or tests.~~ Shipped in Phase 2:
+`tests/integration/cartography/graph/test_query_plans.py` + `plan_guard.py` run real
+`EXPLAIN` over every generated ingestion/cleanup query and fail on `AllNodesScan`.
+`PROFILE` is still unused — that is Phase 4.
 
 ### Plan
-1. Fix the three confirmed AllNodesScan/full-scan sites above (small, high value).
-2. Add a **plan-guard test**: a unit/integration test that runs `EXPLAIN <query>` against
+1. ✅ Fix the three confirmed AllNodesScan/full-scan sites above (Phase 1).
+2. ✅ Add a **plan-guard test** (Phase 2): a unit/integration test that runs `EXPLAIN <query>` against
    a test Neo4j for each generated ingestion/cleanup query (querybuilder + cleanupbuilder
    are the choke points — testing them covers most modules) and **fails if the plan
    contains `AllNodesScan`** (and optionally `NodeByLabelScan` without an index or a
@@ -277,19 +422,20 @@ There is zero use of `EXPLAIN`/`PROFILE` in code or tests. Bad plans ship undete
 
 ## Suggested execution order
 
-**Phase 1 — quick, high-value (days):**
-- Fix label-less/unindexed MATCHes: `gcp/compute.py:1501`, `azure/compute.py:989/999`,
-  `gcp/spanner.py:157` (+ index).
-- Wrap `ensure_indexes()` in `execute_write`.
+**Phase 1 — quick, high-value (days):** ✅ done
+- Fixed label-less/unindexed MATCHes in `gcp/compute.py`, `azure/compute.py`,
+  `gcp/spanner.py` (+ index); wrapped `ensure_indexes()` in `execute_write`.
 
-**Phase 2 — guardrails (days):**
+**Phase 2 — guardrails (days):** ✅ done
 - EXPLAIN plan-guard test over querybuilder + cleanupbuilder outputs.
-- Index-coverage lint for non-`id` loader MATCHes.
+- Index-coverage enforced by the guard (decision 6A — no separate static lint).
 
-**Phase 3 — migration (incremental, weeks):**
-- Migrate per-item loaders to `tx.load()`, volume-ranked: GCP compute → AWS iam/rds →
-  Azure write-heavy modules → misc. Each migration removes raw writes (§2) and gains
-  UNWIND batching (§1) + auto-indexes (§3) at once.
+**Phase 3 — migration (incremental, weeks):** ⚪ next
+- Migrate **per-item** loaders to `tx.load()`, ranked by measured per-item write count:
+  `gcp/compute.py` → `aws/iam.py` → AWS ELB/SG/redshift → misc. Then wrap the
+  already-batched raw writes (Azure, s3, route53, spanner, pagerduty) in `execute_write`.
+  Each migration removes raw writes (§2) and gains UNWIND batching (§1) + auto-indexes (§3)
+  at once. Full ranking and checklist: **Phase 3 re-scope** section above.
 
 **Phase 4 — cleanup-scan optimization (narrowed, after measurement):**
 - PROFILE only the generated `cleanupbuilder.py` queries + any unanchored hand-written job.
@@ -297,15 +443,131 @@ There is zero use of `EXPLAIN`/`PROFILE` in code or tests. Bad plans ship undete
 
 ---
 
+## Strategic options — what to do from here (2026-08-06)
+
+Question asked: *what is the best-performing ingestion path, even if it means a large
+codebase change?* Answered by measuring the fork, then measuring what upstream
+(`cartography-cncf/cartography`, tracked locally as `upstream/master`) actually does.
+
+### Upstream comparison
+
+Same AST scan run against `upstream/master` (`git ls-tree` + `git show`, no checkout):
+
+| Metric | This fork | Upstream | Ratio |
+|---|---:|---:|---|
+| `cartography/intel` files | 223 | 738 | — |
+| Files using `load()` | 31 (**14%**) | 582 (**79%**) | 5.6× |
+| Raw `session.run()` calls | 371 | 44 | 8.4× |
+| **Per-item writes (`run()` in a `for`)** | **71** | **2** | **35×** |
+| `load_matchlinks()` call sites | 0 | 87 | — |
+| `data/indexes.cypher` `CREATE INDEX` | 494 | 35 | 14× |
+| Default batch size | 500 (`load_graph_data`) | **10,000**, per-call tunable | 20× |
+
+Per provider:
+
+| Provider | Fork: files / `load()` / per-item | Upstream: files / `load()` / per-item |
+|---|---|---|
+| aws | 61 / 10 / **40** | 93 / 82 / **0** |
+| azure | 22 / **0** / 4 | 39 / 33 / **0** |
+| gcp | 34 / **0** / 16 | (no raw writes remaining) |
+| oci | 18 / 10 / 6 | — |
+
+**Conclusion: upstream already completed this plan's Phase 3.** The fork branched before
+that work landed and diverged. Phase 3 is not novel engineering — it is catching up to a
+migration that exists, is tested, and is running in production elsewhere.
+
+### What upstream does that the fork does not
+
+1. **`batch_size=10000`, tunable per call** (`tx.py` `load`/`load_graph_data`). The fork
+   hardcodes 500 (`tx.py:223`); `util.DEFAULT_BATCH_SIZE` is 1000 and unused by the load
+   path. 20× fewer commits for the same rows. Decision 14A ("leave 500") was made without
+   knowing upstream ships 10,000 by default — **that decision should be revisited**.
+2. **Real retry classification** (`_run_with_retry`, `execute_write_with_retry`). Retries
+   network errors, `TransientError`, `BufferError("cannot be re-sized")`, and — critically —
+   `Neo.ClientError.Statement.EntityNotFound`, which upstream documents as expected when
+   *"multiple providers sync concurrently"* and *"large batch sizes are used"*.
+3. **`load_matchlinks()` + `build_matchlink_query()`** — a relationship-only loader
+   (`MATCH from`, `MATCH to`, `MERGE rel`) for links that cannot be expressed as part of a
+   node load. 87 call sites upstream. This is the supported answer to every hand-written
+   "link A to B" query in the fork (e.g. the AKS and route53 linkers).
+4. **Indexes live in schemas, not a static file.** Upstream `indexes.cypher` is down to 35
+   entries; the fork's is 494 and growing. Every entry there is an index the querybuilder
+   cannot see, verify, or drop.
+5. **Empty-input short-circuit** (`if len(dict_list) == 0: return`) and per-label load
+   metrics (`stat_handler.incr(f"node.{label}.loaded")`). The fork has neither.
+
+### Where the fork is ahead of upstream
+
+- **Service-level write concurrency.** The fork runs providers' services in a
+  `ThreadPoolExecutor` (aws/gcp/azure/github/bitbucket `__init__.py`, 8 workers) with a
+  shared driver and `Session(neo4j_driver)` per worker. Upstream syncs on a single session
+  (`sync.py:281`). This is a genuine fork advantage — **and it is exactly the condition
+  upstream's `EntityNotFound` retry was written for.**
+- **Structured JSON timing logs** per service/subscription.
+- **EXPLAIN plan guard** (Phase 2) — upstream has no equivalent.
+
+### ⚠️ Correctness defect found during this analysis
+
+`cartography/graph/session.py:67` — the fork's `Session.run()` wrapper catches
+`Exception`, logs a warning, and **returns `self`**:
+
+```python
+except Exception as e:
+    logger.warning(f"Failed run neo4j cypher query. Error - {e}", ...)
+    return self
+```
+
+Every one of the 371 raw `run()` writes therefore fails **silently**: the sync reports
+success while rows are missing from the graph. Under the fork's 8-way write concurrency,
+`EntityNotFound` is expected (upstream documents it) — and here it is swallowed rather
+than retried. This is a bigger risk than any throughput number in this document and is
+independent of which option below is chosen.
+
+### The options
+
+| # | Option | Change size | Expected perf | Risk | Verdict |
+|---|---|---|---|---|---|
+| 1 | Migrate the 71 per-item sites to `load()` (Phase 3 as written) | L (weeks) | **20–100× on those sites** | Med | Do — but not first |
+| 2 | **Backport upstream `client/core/tx.py`** (batch 10k, retry classification, matchlinks, empty short-circuit) | **S–M (one file + call sites)** | 20× fewer commits on all migrated + future code; removes silent-failure class | Low | ✅ **Do first** |
+| 3 | Converge fork modules onto upstream module code where the fork has no custom logic | XL | Same as 1, but reviewed and tested upstream | Med–High (merge conflicts, fork-specific fields e.g. `consolelink`) | Do selectively, per module |
+| 4 | Chunk + wrap the ~300 UNWIND-per-parent raw writes (Phase 3.7) | M | Little throughput; removes OOM class | Low | Do alongside 1 |
+| 5 | Memoize `ensure_indexes()` per process | XS | Removes ~6–8 round-trips per `load()` call per region per account | Very low | Free win, take it |
+| 6 | Server-side batching via `apoc.periodic.iterate` (APOC is allowlisted in `docker-compose.yml:27`) | M | Saves only the per-batch RTT (~ms); commit cost dominates | Med (opaque to the EXPLAIN guard) | ❌ Reject |
+| 7 | Raise write concurrency further (more workers / parallel batches per schema) | M | Bounded — every row's rel-attach locks the same sub-resource node | High (deadlocks) | ❌ Not until 2 lands |
+
+### Recommended order
+
+1. **Option 2 + 5 + the `session.py` fix** — days, not weeks. Biggest ratio of benefit to
+   change size, and it makes everything after it safer and faster. Fixing the swallowed
+   exception is a prerequisite: without it, migrations cannot be verified.
+2. **Option 1**, module by module, taking upstream's schema definitions as the starting
+   point wherever the fork has not customised the module (Option 3 applied selectively).
+3. **Option 4** for the remaining already-UNWIND raw writes.
+
+### The measurement gap that ranks 1 vs 2
+
+The timing instrumentation (`docs/azure-timing-instrumentation.md`) records
+`duration_seconds` for a whole service sync — cloud API fetch **plus** transform **plus**
+graph write — with no split. `request_count` and `throttle_count` are recorded, so API
+pressure is visible, but **graph-write time is not separable from API time today**.
+
+Until that split exists, no one can say what fraction of sync wall-clock these options
+actually address. Adding it is ~a day using the existing `ServiceTimingContext`: wrap the
+load calls and emit `graph_write_seconds` alongside `duration_seconds`. Do it as part of
+Option 2, then re-rank with real numbers.
+
+---
+
 ## What already exists (reused, not rebuilt)
 
 | Sub-problem | Existing code reused | Verdict |
 |---|---|---|
-| UNWIND batching | `load_graph_data` (`tx.py:194`, batch=500) | Reuse — migration target |
+| UNWIND batching | `load_graph_data` (`tx.py:208`, batch=500) | Reuse — migration target |
 | Managed tx + retry | `execute_write`/`execute_read`, `GraphJob`/`GraphStatement` | Reuse |
-| Index auto-gen | `build_create_index_queries` (`querybuilder.py:404`) | Reuse |
-| Static index baseline | `data/indexes.cypher` (475 indexes) | Reuse |
-| Migration recipe | OCI modules (`intel/oci/*`, just-merged) | Copy pattern |
+| Index auto-gen | `build_create_index_queries` (`querybuilder.py:402`) | Reuse |
+| Static index baseline | `data/indexes.cypher` (494 indexes) | Reuse |
+| Migration recipe | OCI modules (`intel/oci/*`), Duo, migrated AWS modules | Copy pattern |
+| Bad-plan detection | `tests/integration/.../graph/plan_guard.py` (Phase 2) | Reuse as merge gate |
 | GCP NIC↔AccessConfig test | `tests/integration/.../gcp/test_compute.py:346` | Covers C1 already |
 
 No new services or classes are introduced. The plan is "apply the existing `tx.load()`
@@ -321,29 +583,38 @@ path to un-migrated modules" + 3 query/index fixes + 1 test harness.
 | Per-load batch-size parameter (14B/C) | Speculative knob; 500 is the conservative memory choice |
 | `ensure_indexes` retry unit test | Driver contract, trivial wrapper (decision 11) |
 | Bumping `dbms.memory.transaction.total.max` | Masks the cause; index-before-migrate is the real fix |
-| Phase 3 mass migration (now) | Deferred until Phase 2 guardrails land (decision 4) → TODOS.md |
+| Phase 3 mass migration (now) | Was deferred until Phase 2 guardrails landed (decision 4); guard green in CI as of 2026-08-06, so Phase 3 is now in scope → TODOS.md |
 
 ---
 
 ## Verification
 
 For every change, capture before/after `PROFILE` of the affected query (db hits, rows,
-operators) on a representative dataset. The Phase 2 plan-guard test then prevents
-regressions. Migrations are behavior-preserving — existing module integration tests must
-stay green.
+operators) on a representative dataset. The Phase 2 plan-guard test (green in CI since
+2026-08-06) then prevents regressions. Migrations are behavior-preserving — existing
+module integration tests must stay green, and the guard sweep must show zero `*Scan` on
+the new ingestion query before merge (decision 12A).
+
+**How the Phase 3 re-scope numbers were produced:** AST scan over each intel module —
+count `.run()` calls lexically nested inside a `for`/`async for` (true per-item writes)
+and count `UNWIND` occurrences in the module's query strings (already-batched queries).
+Re-run it before starting a module; the counts move as migrations land.
 
 ## Key file reference
 
 | Concern | File:line |
 |---------|-----------|
-| Batched load entrypoint | `cartography/client/core/tx.py:237` (`load`), `:194` (`load_graph_data`), `:209` (batch=500) |
-| Raw run in ensure_indexes | `cartography/client/core/tx.py:234` |
-| Ingestion query (UNWIND) | `cartography/graph/querybuilder.py:349` |
-| Auto index generation | `cartography/graph/querybuilder.py:404` |
-| Static indexes | `cartography/data/indexes.cypher` (475 indexes) |
+| Batched load entrypoint | `cartography/client/core/tx.py:252` (`load`), `:208` (`load_graph_data`), `:223` (batch=500) |
+| ~~Raw run in ensure_indexes~~ (now managed) | `cartography/client/core/tx.py:232` |
+| Ingestion query (UNWIND) | `cartography/graph/querybuilder.py:347` |
+| Auto index generation | `cartography/graph/querybuilder.py:402` |
+| Static indexes | `cartography/data/indexes.cypher` (494 indexes) |
 | Cleanup `<>` scans | `cartography/graph/cleanupbuilder.py:82,92,100` |
-| AllNodesScan (gcp nic) | `cartography/intel/gcp/compute.py:1501` |
-| AllNodesScan (azure vm) | `cartography/intel/azure/compute.py:989,999` |
-| Full label scan (spanner) | `cartography/intel/gcp/spanner.py:157` |
-| Cartesian linking (route53) | `cartography/intel/aws/route53.py:119,128,137` |
+| EXPLAIN guard (Phase 2) | `tests/integration/cartography/graph/plan_guard.py`, `test_query_plans.py` |
+| ✅ fixed — gcp nic label | `cartography/intel/gcp/compute.py:1504` |
+| ✅ fixed — azure AKS labels | `cartography/intel/azure/compute.py:998,1008` |
+| ✅ fixed — spanner config index | `cartography/intel/gcp/spanner.py:157` |
+| Worst per-item loop (nested) | `cartography/intel/gcp/compute.py:1427` (`_attach_gcp_vpc_tags`) |
+| Per-item IAM writes | `cartography/intel/aws/iam.py:494,651,735,756,766,794,904` |
+| Cartesian linking (route53, open) | `cartography/intel/aws/route53.py:119,128,137` |
 </content>

--- a/docs/perf-improvements/plan.md
+++ b/docs/perf-improvements/plan.md
@@ -253,6 +253,31 @@ definitions as donor code where the fork has no custom logic (Option 3, selectiv
 | 3.5 | `aws/redshift.py` | 5 | S | ✅ `dcfeb5caa` |
 | 3.6 | `github/repos.py`, `aws/rds.py`, `azure/subscription.py`, `digitalocean/compute.py` | 1–2 each | S | ✅ `dcd217064` |
 | 3.7 | Already-UNWIND raw writes → `load_graph_data` (10k chunks + retry) / `run_write_query` (azure ×3, aws s3/route53, gcp spanner, pagerduty) | n/a | M | ✅ `3f637d91c`, `affa89d32`, `05de80069` |
+| 3.8 | **Uniform neo4j interactions** (plan items 5+6): every remaining raw `session.run` in the in-scope providers → `load_graph_data` / `run_write_query` / `execute_read` | n/a | M | ✅ 8 commits, `249da0f8f`..`2408593c5` |
+
+> **Phase 3.8 — uniform interactions (2026-08-06).** Sweep over aws, gcp, azure, oci,
+> github, bitbucket, gitlab and azuredevops (okta and other low-priority providers left
+> alone). ~200 raw auto-commit calls converted, provider by provider, one commit per
+> module group:
+> - **writes with one row list** → `load_graph_data` (10k-row chunks + transient-error
+>   retry); the query's list parameter is renamed to `$DictList` and nothing else changes.
+> - **scalar writes** (including `MATCH … SET` queries with no MERGE) → `run_write_query`
+>   (managed tx + retry).
+> - **reads** → `execute_read(read_list_of_dicts_tx, …)`; record access (`r["field"]`)
+>   is unchanged because the helper returns dicts with the same keys.
+>
+> Loaders that already ran inside `session.execute_write(...)`/`tx.run` were left alone —
+> they are managed already. gitlab was verified to have no raw calls to begin with.
+>
+> An AST scan (`.run()` on a session receiver) now reports **zero** raw calls across all
+> eight providers. Two follow-on test updates were required and are part of the commits:
+> `test_repos`'s query-shape assertion and gcp `test_iam`'s deleted-member regression test
+> both asserted on the old raw-call path and now assert through the managed path.
+>
+> Full unit suite: 24 failures, all pre-existing (same set as before this work, minus
+> `test_principal_policies`, which this work fixed). Azure modules are compile+lint
+> validated only — their SDK packages are missing in the dev sandbox — so the azure
+> conversions still need the CI integration run.
 
 > **Phase 3 implementation notes (2026-08-06):** executed via the plan §1.3 "intermediate
 > win": each per-item loop rewritten as one UNWIND batch through `load_graph_data`

--- a/tests/data/graph/querybuilder/sample_models/matchlink.py
+++ b/tests/data/graph/querybuilder/sample_models/matchlink.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+# Test model for load_matchlinks(): (:FakeUser)-[:HAS_ROLE]->(:FakeRole) where both
+# nodes already exist in the graph.
+@dataclass(frozen=True)
+class FakeUserToRoleRelProps(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef('_sub_resource_label', set_in_kwargs=True)
+    _sub_resource_id: PropertyRef = PropertyRef('_sub_resource_id', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class FakeUserToRoleMatchLink(CartographyRelSchema):
+    source_node_label: str = 'FakeUser'
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {'id': PropertyRef('user_id')},
+    )
+    target_node_label: str = 'FakeRole'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'name': PropertyRef('role_name')},
+    )
+    rel_label: str = 'HAS_ROLE'
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: FakeUserToRoleRelProps = FakeUserToRoleRelProps()
+
+
+# Missing source_node_matcher/source_node_label: valid as a nested rel schema but
+# invalid for load_matchlinks().
+@dataclass(frozen=True)
+class FakeRelWithoutSource(CartographyRelSchema):
+    target_node_label: str = 'FakeRole'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'name': PropertyRef('role_name')},
+    )
+    rel_label: str = 'HAS_ROLE'
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: FakeUserToRoleRelProps = FakeUserToRoleRelProps()
+
+
+# Has a source matcher but lacks the _sub_resource_* rel properties required for
+# matchlink cleanup scoping.
+@dataclass(frozen=True)
+class FakeRelPropsNoSubResource(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class FakeMatchLinkMissingSubResourceProps(CartographyRelSchema):
+    source_node_label: str = 'FakeUser'
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {'id': PropertyRef('user_id')},
+    )
+    target_node_label: str = 'FakeRole'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'name': PropertyRef('role_name')},
+    )
+    rel_label: str = 'HAS_ROLE'
+    direction: LinkDirection = LinkDirection.INWARD
+    properties: FakeRelPropsNoSubResource = FakeRelPropsNoSubResource()

--- a/tests/data/graph/querybuilder/sample_models/matchlink.py
+++ b/tests/data/graph/querybuilder/sample_models/matchlink.py
@@ -34,6 +34,12 @@ class FakeUserToRoleMatchLink(CartographyRelSchema):
     properties: FakeUserToRoleRelProps = FakeUserToRoleRelProps()
 
 
+# Same link but INWARD: (:FakeUser)<-[:HAS_ROLE]-(:FakeRole)
+@dataclass(frozen=True)
+class FakeUserToRoleMatchLinkInward(FakeUserToRoleMatchLink):
+    direction: LinkDirection = LinkDirection.INWARD
+
+
 # Missing source_node_matcher/source_node_label: valid as a nested rel schema but
 # invalid for load_matchlinks().
 @dataclass(frozen=True)

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -5,6 +5,7 @@ import pytest
 
 from cartography.client.core.tx import ensure_indexes
 from cartography.client.core.tx import load
+from cartography.client.core.tx import load_graph_data
 from cartography.client.core.tx import write_query_tx
 
 
@@ -68,3 +69,47 @@ def test_load_nonempty_list_loads(mock_ensure, mock_build):
 
     mock_ensure.assert_called_once()
     assert session.execute_write.call_count == 1
+
+
+def test_load_graph_data_batches_at_batch_size():
+    session = MagicMock()
+    data = [{"id": i} for i in range(25)]
+
+    load_graph_data(session, "UNWIND $DictList AS item RETURN item", data, batch_size=10)
+
+    assert session.execute_write.call_count == 3  # 10 + 10 + 5
+    batch_sizes = [len(call.kwargs["DictList"]) for call in session.execute_write.call_args_list]
+    assert batch_sizes == [10, 10, 5]
+
+
+def test_load_graph_data_default_batch_size_is_10000():
+    session = MagicMock()
+    data = [{"id": i} for i in range(10001)]
+
+    load_graph_data(session, "UNWIND $DictList AS item RETURN item", data)
+
+    assert session.execute_write.call_count == 2
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_load_graph_data_rejects_nonpositive_batch_size(bad_size):
+    with pytest.raises(ValueError):
+        load_graph_data(MagicMock(), "q", [{"id": 1}], batch_size=bad_size)
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_load_rejects_nonpositive_batch_size(bad_size):
+    with pytest.raises(ValueError):
+        load(MagicMock(), MagicMock(), [{"id": 1}], batch_size=bad_size)
+
+
+@patch("cartography.client.core.tx.load_graph_data")
+@patch("cartography.client.core.tx.build_ingestion_query")
+@patch("cartography.client.core.tx.ensure_indexes")
+def test_load_passes_batch_size_through(mock_ensure, mock_build, mock_lgd):
+    session = MagicMock()
+    data = [{"id": 1}]
+
+    load(session, MagicMock(), data, batch_size=42, lastupdated=1)
+
+    mock_lgd.assert_called_once_with(session, mock_build.return_value, data, batch_size=42, lastupdated=1)

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from cartography.client.core.tx import ensure_indexes
+from cartography.client.core.tx import load
 from cartography.client.core.tx import write_query_tx
 
 
@@ -42,3 +43,28 @@ def test_ensure_indexes_rejects_non_create_index_query(mock_build):
         ensure_indexes(session, MagicMock())
 
     session.execute_write.assert_not_called()
+
+
+@patch("cartography.client.core.tx.build_ingestion_query")
+@patch("cartography.client.core.tx.ensure_indexes")
+def test_load_empty_list_short_circuits(mock_ensure, mock_build):
+    # No data -> no index creation, no query build, no writes.
+    session = MagicMock()
+
+    load(session, MagicMock(), [])
+
+    mock_ensure.assert_not_called()
+    mock_build.assert_not_called()
+    session.execute_write.assert_not_called()
+
+
+@patch("cartography.client.core.tx.build_ingestion_query")
+@patch("cartography.client.core.tx.ensure_indexes")
+def test_load_nonempty_list_loads(mock_ensure, mock_build):
+    session = MagicMock()
+    mock_build.return_value = "UNWIND $DictList AS item MERGE (n:Foo{id: item.id})"
+
+    load(session, MagicMock(), [{"id": 1}])
+
+    mock_ensure.assert_called_once()
+    assert session.execute_write.call_count == 1

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -60,6 +60,36 @@ def test_ensure_indexes_rejects_non_create_index_query(mock_build):
     session.execute_write.assert_not_called()
 
 
+@patch("cartography.client.core.tx.build_create_index_queries")
+def test_ensure_indexes_ignores_parallel_index_creation_race(mock_build):
+    # Two workers hitting CREATE INDEX IF NOT EXISTS concurrently can still race in
+    # Neo4j; the resulting EquivalentSchemaRuleAlreadyExists is the desired end state.
+    mock_build.return_value = [
+        "CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)",
+        "CREATE INDEX IF NOT EXISTS FOR (n:Bar) ON (n.id)",
+    ]
+    race = ClientError("already exists")
+    race.code = "Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists"
+    session = MagicMock()
+    session.execute_write.side_effect = [race, None]
+
+    ensure_indexes(session, MagicMock())  # must not raise
+
+    assert session.execute_write.call_count == 2
+
+
+@patch("cartography.client.core.tx.build_create_index_queries")
+def test_ensure_indexes_raises_other_client_errors(mock_build):
+    mock_build.return_value = ["CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)"]
+    err = ClientError("denied")
+    err.code = "Neo.ClientError.Security.Forbidden"
+    session = MagicMock()
+    session.execute_write.side_effect = err
+
+    with pytest.raises(ClientError):
+        ensure_indexes(session, MagicMock())
+
+
 @patch("cartography.client.core.tx.build_ingestion_query")
 @patch("cartography.client.core.tx.ensure_indexes")
 def test_load_empty_list_short_circuits(mock_ensure, mock_build):

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -2,11 +2,25 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from neo4j.exceptions import ClientError
+from neo4j.exceptions import ServiceUnavailable
+from neo4j.exceptions import TransientError
 
+from cartography.client.core.tx import _is_retryable_buffer_error
+from cartography.client.core.tx import _is_retryable_client_error
+from cartography.client.core.tx import _run_with_retry
 from cartography.client.core.tx import ensure_indexes
+from cartography.client.core.tx import execute_write_with_retry
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import write_query_tx
+
+
+def entity_not_found_error():
+    err = ClientError("entity gone")
+    err.code = "Neo.ClientError.Statement.EntityNotFound"
+    return err
 
 
 def test_write_query_tx_runs_query_without_params():
@@ -113,3 +127,112 @@ def test_load_passes_batch_size_through(mock_ensure, mock_build, mock_lgd):
     load(session, MagicMock(), data, batch_size=42, lastupdated=1)
 
     mock_lgd.assert_called_once_with(session, mock_build.return_value, data, batch_size=42, lastupdated=1)
+
+
+class TestRetryClassification:
+    def test_entity_not_found_is_retryable(self):
+        assert _is_retryable_client_error(entity_not_found_error())
+
+    def test_other_client_error_is_not_retryable(self):
+        err = ClientError("bad")
+        err.code = "Neo.ClientError.Statement.SyntaxError"
+        assert not _is_retryable_client_error(err)
+
+    def test_client_error_without_code_is_not_retryable(self):
+        assert not _is_retryable_client_error(ClientError("local"))
+
+    def test_non_client_error_is_not_retryable(self):
+        assert not _is_retryable_client_error(ValueError("nope"))
+
+    def test_resize_buffer_error_is_retryable(self):
+        assert _is_retryable_buffer_error(BufferError("Existing exports of data: object cannot be re-sized"))
+
+    def test_other_buffer_error_is_not_retryable(self):
+        assert not _is_retryable_buffer_error(BufferError("something else"))
+
+
+@patch("cartography.client.core.tx.time.sleep")
+class TestRunWithRetry:
+    def test_success_passthrough(self, mock_sleep):
+        op = MagicMock(return_value="ok")
+        assert _run_with_retry(op, "t") == "ok"
+        mock_sleep.assert_not_called()
+
+    def test_network_error_retried_then_succeeds(self, mock_sleep):
+        op = MagicMock(side_effect=[ServiceUnavailable("down"), TransientError("busy"), "ok"])
+        assert _run_with_retry(op, "t") == "ok"
+        assert op.call_count == 3
+
+    def test_network_error_exhaustion_raises(self, mock_sleep):
+        op = MagicMock(side_effect=ServiceUnavailable("down"))
+        with pytest.raises(ServiceUnavailable):
+            _run_with_retry(op, "t")
+        assert op.call_count == 5  # _MAX_NETWORK_RETRIES
+
+    def test_entity_not_found_retried_then_succeeds(self, mock_sleep):
+        op = MagicMock(side_effect=[entity_not_found_error(), "ok"])
+        assert _run_with_retry(op, "t") == "ok"
+        assert op.call_count == 2
+
+    def test_non_retryable_client_error_raises_immediately(self, mock_sleep):
+        err = ClientError("bad")
+        err.code = "Neo.ClientError.Statement.SyntaxError"
+        op = MagicMock(side_effect=err)
+        with pytest.raises(ClientError):
+            _run_with_retry(op, "t")
+        assert op.call_count == 1
+
+    def test_buffer_error_retried_then_succeeds(self, mock_sleep):
+        op = MagicMock(side_effect=[BufferError("x cannot be re-sized"), "ok"])
+        assert _run_with_retry(op, "t") == "ok"
+        assert op.call_count == 2
+
+    def test_unrelated_exception_raises_immediately(self, mock_sleep):
+        op = MagicMock(side_effect=KeyError("boom"))
+        with pytest.raises(KeyError):
+            _run_with_retry(op, "t")
+        assert op.call_count == 1
+
+
+class TestExecuteWriteWithRetry:
+    def test_passes_through_to_execute_write(self):
+        session = MagicMock()
+        tx_func = MagicMock()
+
+        result = execute_write_with_retry(session, tx_func, "a", k=1)
+
+        assert result is session.execute_write.return_value
+        session.execute_write.assert_called_once_with(tx_func, "a", k=1)
+
+    @patch("cartography.client.core.tx.time.sleep")
+    def test_retries_entity_not_found(self, mock_sleep):
+        session = MagicMock()
+        session.execute_write.side_effect = [entity_not_found_error(), "ok"]
+
+        assert execute_write_with_retry(session, MagicMock()) == "ok"
+        assert session.execute_write.call_count == 2
+
+
+class TestRunWriteQuery:
+    def test_runs_query_in_managed_tx(self):
+        session = MagicMock()
+
+        run_write_query(session, "MERGE (n:Foo{id: $id})", id=1)
+
+        session.execute_write.assert_called_once()
+        # Execute the captured tx function against a mock transaction and verify the
+        # query goes through tx.run with the given parameters.
+        tx_fn = session.execute_write.call_args.args[0]
+        tx = MagicMock()
+        tx_fn(tx)
+        tx.run.assert_called_once_with("MERGE (n:Foo{id: $id})", id=1)
+
+
+@patch("cartography.client.core.tx.time.sleep")
+def test_load_graph_data_retries_transient_batch_failure(mock_sleep):
+    session = MagicMock()
+    session.execute_write.side_effect = [entity_not_found_error(), None]
+
+    load_graph_data(session, "UNWIND $DictList AS item RETURN item", [{"id": 1}])
+
+    assert session.execute_write.call_count == 2

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -13,9 +13,11 @@ from cartography.client.core.tx import ensure_indexes
 from cartography.client.core.tx import execute_write_with_retry
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import reset_ensured_indexes_cache
 from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import write_query_tx
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeUserToRoleMatchLink
 
 
 @pytest.fixture(autouse=True)
@@ -332,3 +334,47 @@ class TestEnsureIndexesMemoization:
         ensure_indexes(session, FakeSchemaA())
 
         assert session.execute_write.call_count == 2
+
+
+class TestLoadMatchlinks:
+    def test_empty_list_short_circuits(self):
+        session = MagicMock()
+
+        load_matchlinks(session, FakeUserToRoleMatchLink(), [])
+
+        session.execute_write.assert_not_called()
+
+    def test_missing_sub_resource_kwargs_raise(self):
+        with pytest.raises(ValueError, match="_sub_resource_label"):
+            load_matchlinks(MagicMock(), FakeUserToRoleMatchLink(), [{"user_id": 1}])
+        with pytest.raises(ValueError, match="_sub_resource_id"):
+            load_matchlinks(
+                MagicMock(), FakeUserToRoleMatchLink(), [{"user_id": 1}],
+                _sub_resource_label="AWSAccount",
+            )
+
+    @pytest.mark.parametrize("bad_size", [0, -1])
+    def test_rejects_nonpositive_batch_size(self, bad_size):
+        with pytest.raises(ValueError):
+            load_matchlinks(
+                MagicMock(), FakeUserToRoleMatchLink(), [{"user_id": 1}], batch_size=bad_size,
+                _sub_resource_label="AWSAccount", _sub_resource_id="1234",
+            )
+
+    def test_ensures_indexes_and_writes_links(self):
+        session = MagicMock()
+        links = [{"user_id": 1, "role_name": "admin"}]
+
+        load_matchlinks(
+            session, FakeUserToRoleMatchLink(), links,
+            lastupdated=1, _sub_resource_label="AWSAccount", _sub_resource_id="1234",
+        )
+
+        # 3 index queries (source, target, rel composite) + 1 batched link write.
+        assert session.execute_write.call_count == 4
+        write_call = session.execute_write.call_args_list[-1]
+        assert write_call.kwargs["DictList"] == links
+        assert write_call.kwargs["_sub_resource_label"] == "AWSAccount"
+        assert write_call.kwargs["_sub_resource_id"] == "1234"
+        query = write_call.args[1]
+        assert "MERGE (from)-[r:HAS_ROLE]->(to)" in query

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -13,14 +13,31 @@ from cartography.client.core.tx import ensure_indexes
 from cartography.client.core.tx import execute_write_with_retry
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import reset_ensured_indexes_cache
 from cartography.client.core.tx import run_write_query
 from cartography.client.core.tx import write_query_tx
+
+
+@pytest.fixture(autouse=True)
+def _reset_index_cache():
+    # ensure_indexes memoizes per schema class per process; isolate tests from each other.
+    reset_ensured_indexes_cache()
+    yield
+    reset_ensured_indexes_cache()
 
 
 def entity_not_found_error():
     err = ClientError("entity gone")
     err.code = "Neo.ClientError.Statement.EntityNotFound"
     return err
+
+
+class FakeSchemaA:
+    pass
+
+
+class FakeSchemaB:
+    pass
 
 
 def test_write_query_tx_runs_query_without_params():
@@ -266,3 +283,52 @@ def test_load_graph_data_retries_transient_batch_failure(mock_sleep):
     load_graph_data(session, "UNWIND $DictList AS item RETURN item", [{"id": 1}])
 
     assert session.execute_write.call_count == 2
+
+
+class TestEnsureIndexesMemoization:
+    @patch("cartography.client.core.tx.build_create_index_queries")
+    def test_second_call_for_same_schema_class_is_skipped(self, mock_build):
+        mock_build.return_value = ["CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)"]
+        session = MagicMock()
+
+        ensure_indexes(session, FakeSchemaA())
+        ensure_indexes(session, FakeSchemaA())
+
+        mock_build.assert_called_once()
+        assert session.execute_write.call_count == 1
+
+    @patch("cartography.client.core.tx.build_create_index_queries")
+    def test_different_schema_classes_each_run(self, mock_build):
+        mock_build.return_value = ["CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)"]
+        session = MagicMock()
+
+        ensure_indexes(session, FakeSchemaA())
+        ensure_indexes(session, FakeSchemaB())
+
+        assert mock_build.call_count == 2
+        assert session.execute_write.call_count == 2
+
+    @patch("cartography.client.core.tx.build_create_index_queries")
+    def test_failed_run_is_not_memoized(self, mock_build):
+        mock_build.return_value = ["CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)"]
+        session = MagicMock()
+        err = ClientError("denied")
+        err.code = "Neo.ClientError.Security.Forbidden"
+        session.execute_write.side_effect = [err, None]
+
+        with pytest.raises(ClientError):
+            ensure_indexes(session, FakeSchemaA())
+        ensure_indexes(session, FakeSchemaA())  # retried, succeeds this time
+
+        assert session.execute_write.call_count == 2
+
+    @patch("cartography.client.core.tx.build_create_index_queries")
+    def test_reset_clears_memoization(self, mock_build):
+        mock_build.return_value = ["CREATE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.id)"]
+        session = MagicMock()
+
+        ensure_indexes(session, FakeSchemaA())
+        reset_ensured_indexes_cache()
+        ensure_indexes(session, FakeSchemaA())
+
+        assert session.execute_write.call_count == 2

--- a/tests/unit/cartography/graph/test_querybuilder_matchlink.py
+++ b/tests/unit/cartography/graph/test_querybuilder_matchlink.py
@@ -1,0 +1,53 @@
+import pytest
+
+from cartography.graph.querybuilder import build_create_index_queries_for_matchlink
+from cartography.graph.querybuilder import build_matchlink_query
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeMatchLinkMissingSubResourceProps
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeRelWithoutSource
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeUserToRoleMatchLink
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeUserToRoleMatchLinkInward
+from tests.unit.cartography.graph.helpers import remove_leading_whitespace_and_empty_lines as clean_query
+
+
+class TestBuildMatchlinkQuery:
+    def test_generates_expected_query(self):
+        query = build_matchlink_query(FakeUserToRoleMatchLink())
+
+        expected = """
+        UNWIND $DictList as item
+            MATCH (from:FakeUser{id: item.user_id})
+            MATCH (to:FakeRole{name: item.role_name})
+            MERGE (from)-[r:HAS_ROLE]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r.lastupdated = $lastupdated,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id
+        """
+        assert clean_query(query) == clean_query(expected)
+
+    def test_inward_direction_flips_arrow(self):
+        query = build_matchlink_query(FakeUserToRoleMatchLinkInward())
+        assert "MERGE (from)<-[r:HAS_ROLE]-(to)" in query
+
+    def test_missing_source_matcher_raises(self):
+        with pytest.raises(ValueError, match="source node matcher"):
+            build_matchlink_query(FakeRelWithoutSource())
+
+    def test_missing_sub_resource_props_raises(self):
+        with pytest.raises(ValueError, match="_sub_resource_label"):
+            build_matchlink_query(FakeMatchLinkMissingSubResourceProps())
+
+
+class TestBuildCreateIndexQueriesForMatchlink:
+    def test_generates_source_target_and_rel_indexes(self):
+        queries = build_create_index_queries_for_matchlink(FakeUserToRoleMatchLink())
+
+        assert queries == [
+            'CREATE INDEX IF NOT EXISTS FOR (n:FakeUser) ON (n.id);',
+            'CREATE INDEX IF NOT EXISTS FOR (n:FakeRole) ON (n.name);',
+            'CREATE INDEX IF NOT EXISTS FOR ()-[r:HAS_ROLE]-() ON (r._sub_resource_label, r._sub_resource_id);',
+        ]
+
+    def test_missing_source_matcher_returns_empty(self):
+        assert build_create_index_queries_for_matchlink(FakeRelWithoutSource()) == []

--- a/tests/unit/cartography/graph/test_session.py
+++ b/tests/unit/cartography/graph/test_session.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from neo4j.exceptions import ClientError
+from neo4j.exceptions import ServiceUnavailable
+from neo4j.exceptions import TransientError
+
+from cartography.graph.session import Session
+
+
+def make_session():
+    driver = MagicMock()
+    session = Session(driver)
+    return session, session.neo4j_session
+
+
+class TestRun:
+    def test_success_returns_driver_result(self):
+        session, inner = make_session()
+        result = session.run("MATCH (n) RETURN n", {"a": 1})
+        assert result is inner.run.return_value
+        inner.run.assert_called_once_with("MATCH (n) RETURN n", {"a": 1})
+
+    @patch("cartography.graph.session.time.sleep")
+    def test_transient_error_retries_then_succeeds(self, mock_sleep):
+        session, inner = make_session()
+        good = MagicMock()
+        inner.run.side_effect = [TransientError("deadlock"), TransientError("deadlock"), good]
+
+        result = session.run("q")
+
+        assert result is good
+        assert inner.run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("cartography.graph.session.time.sleep")
+    def test_transient_error_exhaustion_raises(self, mock_sleep):
+        session, inner = make_session()
+        inner.run.side_effect = TransientError("deadlock")
+
+        with pytest.raises(TransientError):
+            session.run("q", max_retries=3)
+
+        # initial attempt + 3 retries
+        assert inner.run.call_count == 4
+
+    def test_client_error_raises_without_retry(self):
+        session, inner = make_session()
+        inner.run.side_effect = ClientError("bad syntax")
+
+        with pytest.raises(ClientError):
+            session.run("q")
+
+        assert inner.run.call_count == 1
+
+    def test_service_unavailable_raises(self):
+        session, inner = make_session()
+        inner.run.side_effect = ServiceUnavailable("down")
+
+        with pytest.raises(ServiceUnavailable):
+            session.run("q")
+
+    def test_unexpected_exception_raises(self):
+        session, inner = make_session()
+        inner.run.side_effect = ValueError("boom")
+
+        with pytest.raises(ValueError):
+            session.run("q")

--- a/tests/unit/cartography/graph/test_session.py
+++ b/tests/unit/cartography/graph/test_session.py
@@ -67,3 +67,45 @@ class TestRun:
 
         with pytest.raises(ValueError):
             session.run("q")
+
+
+class TestExecuteWrite:
+    def test_success_returns_tx_result(self):
+        session, inner = make_session()
+        tx_fn = MagicMock()
+
+        result = session.execute_write(tx_fn, "arg", kw=1)
+
+        assert result is inner.execute_write.return_value
+        inner.execute_write.assert_called_once_with(tx_fn, "arg", kw=1)
+
+    def test_failure_raises(self):
+        session, inner = make_session()
+        inner.execute_write.side_effect = ServiceUnavailable("down")
+
+        with pytest.raises(ServiceUnavailable):
+            session.execute_write(MagicMock())
+
+    def test_unexpected_exception_raises(self):
+        session, inner = make_session()
+        inner.execute_write.side_effect = ValueError("boom")
+
+        with pytest.raises(ValueError):
+            session.execute_write(MagicMock())
+
+
+class TestExecuteRead:
+    def test_success_returns_tx_result(self):
+        session, inner = make_session()
+        tx_fn = MagicMock()
+
+        result = session.execute_read(tx_fn)
+
+        assert result is inner.execute_read.return_value
+
+    def test_failure_raises(self):
+        session, inner = make_session()
+        inner.execute_read.side_effect = ClientError("denied")
+
+        with pytest.raises(ClientError):
+            session.execute_read(MagicMock())

--- a/tests/unit/cartography/graph/test_write_timer.py
+++ b/tests/unit/cartography/graph/test_write_timer.py
@@ -1,0 +1,67 @@
+import threading
+
+from cartography.graph import write_timer
+from cartography.graph.session import Session
+from unittest.mock import MagicMock
+
+
+def test_total_starts_at_zero_per_thread():
+    results = []
+
+    def worker():
+        results.append(write_timer.total())
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert results == [0.0]
+
+
+def test_add_accumulates():
+    start = write_timer.total()
+    write_timer.add(1.5)
+    write_timer.add(0.5)
+    assert write_timer.total() - start == 2.0
+
+
+def test_timed_records_elapsed():
+    start = write_timer.total()
+    with write_timer.timed():
+        pass
+    assert write_timer.total() >= start
+
+
+def test_timed_records_on_exception():
+    start = write_timer.total()
+    try:
+        with write_timer.timed():
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    assert write_timer.total() >= start
+
+
+def test_threads_do_not_share_totals():
+    write_timer.add(5.0)
+    seen = []
+
+    def worker():
+        seen.append(write_timer.total())
+        write_timer.add(1.0)
+        seen.append(write_timer.total())
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert seen == [0.0, 1.0]
+
+
+def test_session_calls_feed_the_timer():
+    session = Session(MagicMock())
+    start = write_timer.total()
+
+    session.run("RETURN 1")
+    session.execute_write(MagicMock())
+    session.execute_read(MagicMock())
+
+    assert write_timer.total() > start

--- a/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for the batched (UNWIND $DictList) IAM loaders (perf plan Phase 3.2).
+A MagicMock session records the execute_write calls issued by load_graph_data.
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.aws import iam
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+
+USER = {
+    "Arn": "arn:aws:iam::1234:user/alice",
+    "UserId": "AIDA1",
+    "CreateDate": "2024-01-01",
+    "UserName": "alice",
+    "Path": "/",
+    "PasswordLastUsed": "2024-02-01",
+}
+
+GROUP = {
+    "Arn": "arn:aws:iam::1234:group/admins",
+    "GroupId": "AGPA1",
+    "CreateDate": "2024-01-01",
+    "GroupName": "admins",
+    "Path": "/",
+}
+
+
+class TestLoadUsers:
+    def test_single_batched_write(self):
+        session = MagicMock()
+
+        iam.load_users(session, [USER, {**USER, "Arn": "arn:aws:iam::1234:user/bob", "UserName": "bob"}],
+                       TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList AS item" in call.args[1]
+        rows = call.kwargs["DictList"]
+        assert len(rows) == 2
+        assert rows[0]["arn"] == USER["Arn"]
+        assert rows[0]["username"] == "alice"
+        assert rows[0]["passwordlastused"] == "2024-02-01"
+        assert call.kwargs["AWS_ACCOUNT_ID"] == TEST_ACCOUNT_ID
+        assert call.kwargs["aws_update_tag"] == TEST_UPDATE_TAG
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        iam.load_users(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
+class TestLoadServiceAccounts:
+    def test_single_batched_write(self):
+        session = MagicMock()
+
+        iam.load_service_accounts(session, [USER], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "AWSServiceAccount" in call.args[1]
+        assert call.kwargs["DictList"][0]["arn"] == USER["Arn"]
+
+
+class TestLoadGroups:
+    def test_single_batched_write(self):
+        session = MagicMock()
+
+        iam.load_groups(session, [GROUP], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList AS item" in call.args[1]
+        assert call.kwargs["DictList"] == [{
+            "arn": GROUP["Arn"],
+            "consolelink": call.kwargs["DictList"][0]["consolelink"],
+            "groupid": "AGPA1",
+            "createdate": "2024-01-01",
+            "groupname": "admins",
+            "path": "/",
+        }]
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        iam.load_groups(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
@@ -63,6 +63,62 @@ class TestLoadServiceAccounts:
         assert call.kwargs["DictList"][0]["arn"] == USER["Arn"]
 
 
+ROLE = {
+    "Arn": "arn:aws:iam::1234:role/app-role",
+    "RoleId": "AROA1",
+    "CreateDate": "2024-01-01",
+    "RoleName": "app-role",
+    "Path": "/",
+    "RoleLastUsed": {"LastUsedDate": "2024-03-01", "Region": "us-east-1"},
+    "ExternalAccountPrincipals": [
+        {"principal": "arn:aws:iam::9999:root", "access_type": "cross-account", "account_id": "9999"},
+    ],
+    "AssumeRolePolicyDocument": {
+        "Statement": [
+            {"Principal": {"Service": "ec2.amazonaws.com", "AWS": ["arn:aws:iam::1234:root"]}},
+        ],
+    },
+}
+
+
+class TestLoadRoles:
+    def test_three_batched_writes(self):
+        session = MagicMock()
+
+        iam.load_roles(session, [ROLE, ROLE], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        # roles + external principals + trust principals = 3 writes total,
+        # regardless of role count (was 1 + 1 + 2 writes PER role).
+        assert session.execute_write.call_count == 3
+        role_call, external_call, trust_call = session.execute_write.call_args_list
+
+        assert "AWSRole" in role_call.args[1]
+        assert len(role_call.kwargs["DictList"]) == 2
+        assert role_call.kwargs["DictList"][0]["lastuseddate"] == "2024-03-01"
+
+        assert "AWSExternalPrincipal" in external_call.args[1]
+        assert external_call.kwargs["DictList"] == [
+            {
+                "principal": "arn:aws:iam::9999:root", "access_type": "cross-account",
+                "account_id": "9999", "role_arn": ROLE["Arn"],
+            },
+        ] * 2
+
+        # 2 principal entries per role (Service + AWS list entry) x 2 roles
+        assert "TRUSTS_AWS_PRINCIPAL" in trust_call.args[1]
+        trust_rows = trust_call.kwargs["DictList"]
+        assert len(trust_rows) == 4
+        assert {(r["spn_type"], r["spn_arn"]) for r in trust_rows} == {
+            ("Service", "ec2.amazonaws.com"),
+            ("AWS", "arn:aws:iam::1234:root"),
+        }
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        iam.load_roles(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
 class TestLoadGroups:
     def test_single_batched_write(self):
         session = MagicMock()

--- a/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam_loaders.py
@@ -141,3 +141,58 @@ class TestLoadGroups:
         session = MagicMock()
         iam.load_groups(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
         session.execute_write.assert_not_called()
+
+
+class TestLoadGroupMemberships:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        memberships = {
+            "arn:aws:iam::1234:group/admins": {"Users": [{"Arn": "arn:aws:iam::1234:user/alice"}]},
+            "arn:aws:iam::1234:group/devs": {
+                "Users": [{"Arn": "arn:aws:iam::1234:user/alice"}, {"Arn": "arn:aws:iam::1234:user/bob"}],
+            },
+        }
+
+        iam.load_group_memberships(session, memberships, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        rows = session.execute_write.call_args.kwargs["DictList"]
+        assert len(rows) == 3
+        assert {"group_arn": "arn:aws:iam::1234:group/devs", "principal_arn": "arn:aws:iam::1234:user/bob"} in rows
+
+    def test_empty_memberships_write_nothing(self):
+        session = MagicMock()
+        iam.load_group_memberships(session, {}, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
+class TestLoadUserAccessKeys:
+    def test_single_batched_write_skips_keyless_entries(self):
+        session = MagicMock()
+        access_keys = {
+            "arn:aws:iam::1234:user/alice": {
+                "AccessKeyMetadata": [
+                    {"AccessKeyId": "AKIA1", "Status": "Active", "CreateDate": "2024-01-01"},
+                    {"Status": "Inactive"},  # no AccessKeyId -> skipped, as before
+                ],
+            },
+        }
+
+        iam.load_user_access_keys(session, access_keys, TEST_UPDATE_TAG, "https://console")
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert call.kwargs["DictList"] == [{
+            "arn": "arn:aws:iam::1234:user/alice",
+            "accesskeyid": "AKIA1",
+            "lastuseddate": "",
+            "createdate": "2024-01-01",
+            "keyage": "",
+            "status": "Active",
+        }]
+        assert call.kwargs["consolelink"] == "https://console"
+
+    def test_empty_keys_write_nothing(self):
+        session = MagicMock()
+        iam.load_user_access_keys(session, {}, TEST_UPDATE_TAG, "https://console")
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/aws/iam/test_principal_policies.py
+++ b/tests/unit/cartography/intel/aws/iam/test_principal_policies.py
@@ -1,61 +1,34 @@
 from unittest import mock
-from unittest.mock import call
 from unittest.mock import MagicMock
 
 import cartography.intel.aws.iam
-from cartography.intel.aws.iam import PolicyType
 from cartography.intel.aws.iam import sync_user_managed_policies
 from tests.data.aws.iam.user_policies import GET_USER_LIST_DATA
 from tests.data.aws.iam.user_policies import GET_USER_MANAGED_POLS_SAMPLE
 
 AWS_UPDATE_TAG = 111111
+AWS_ACCOUNT_ID = "1234"
 
 
-@mock.patch.object(cartography.intel.aws.iam, 'load_policy')
 @mock.patch.object(cartography.intel.aws.iam, 'get_user_managed_policy_data', return_value=GET_USER_MANAGED_POLS_SAMPLE)
-def test_sync_user_managed_policies(mock_get_user_pols: MagicMock, mock_load_pol: MagicMock):
+def test_sync_user_managed_policies(mock_get_user_pols: MagicMock):
     # Arrange
     boto3_session = mock.MagicMock()
     neo4j_session = mock.MagicMock()
 
     # Act
-    sync_user_managed_policies(boto3_session, GET_USER_LIST_DATA, neo4j_session, AWS_UPDATE_TAG)
+    sync_user_managed_policies(boto3_session, GET_USER_LIST_DATA, neo4j_session, AWS_ACCOUNT_ID, AWS_UPDATE_TAG)
 
-    # Assert that we attempt to create policies with expected values for ids.
-    mock_load_pol.assert_has_calls(
-        [
-            call(
-                neo4j_session,
-                'arn:aws:iam::1234:policy/user1-user-policy',
-                'user1-user-policy',
-                PolicyType.managed.value,
-                'arn:aws:iam::1234:user/user1',
-                AWS_UPDATE_TAG,
-            ),
-            call(
-                neo4j_session,
-                'arn:aws:iam::aws:policy/AmazonS3FullAccess',
-                'AmazonS3FullAccess',
-                PolicyType.managed.value,
-                'arn:aws:iam::1234:user/user1',
-                AWS_UPDATE_TAG,
-            ),
-            call(
-                neo4j_session,
-                'arn:aws:iam::aws:policy/AWSLambda_FullAccess',
-                'AWSLambda_FullAccess',
-                PolicyType.managed.value,
-                'arn:aws:iam::1234:user/user1',
-                AWS_UPDATE_TAG,
-            ),
-            call(
-                neo4j_session,
-                'arn:aws:iam::aws:policy/AdministratorAccess',
-                'AdministratorAccess',
-                PolicyType.managed.value,
-                'arn:aws:iam::1234:user/user3',
-                AWS_UPDATE_TAG,
-            ),
-        ],
-        any_order=False,
-    )
+    # Assert: policies land as UNWIND batches (arn-matched + sso id-matched) plus one
+    # statements batch = 3 writes total, with the expected policy ids in the rows.
+    assert neo4j_session.execute_write.call_count == 3
+    policy_call = neo4j_session.execute_write.call_args_list[0]
+    policy_ids = {row["policy_id"] for row in policy_call.kwargs["DictList"]}
+    assert policy_ids == {
+        '1234/managed_policy/arn:aws:iam::1234:policy/user1-user-policy',
+        '1234/managed_policy/arn:aws:iam::aws:policy/AmazonS3FullAccess',
+        '1234/managed_policy/arn:aws:iam::aws:policy/AWSLambda_FullAccess',
+        '1234/managed_policy/arn:aws:iam::aws:policy/AdministratorAccess',
+    }
+    principal_arns = {row["principal_arn"] for row in policy_call.kwargs["DictList"]}
+    assert principal_arns == {'arn:aws:iam::1234:user/user1', 'arn:aws:iam::1234:user/user3'}

--- a/tests/unit/cartography/intel/aws/test_load_balancers.py
+++ b/tests/unit/cartography/intel/aws/test_load_balancers.py
@@ -3,6 +3,7 @@ Unit tests for the batched classic ELB loaders (perf plan Phase 3.4).
 """
 from unittest.mock import MagicMock
 
+from cartography.intel.aws.ec2 import load_balancer_v2s
 from cartography.intel.aws.ec2 import load_balancers
 
 TEST_UPDATE_TAG = 123456789
@@ -66,3 +67,57 @@ class TestLoadLoadBalancers:
 
         # only the lb node batch writes; empty row lists short-circuit
         assert session.execute_write.call_count == 1
+
+
+ELBV2 = {
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:1234:loadbalancer/app/web/abc",
+    "DNSName": "web-alb.us-east-1.elb.amazonaws.com",
+    "LoadBalancerName": "web-alb",
+    "CreatedTime": "2024-01-01",
+    "CanonicalHostedZoneNameID": "Z123",
+    "Type": "application",
+    "Scheme": "internet-facing",
+    "region": "us-east-1",
+    "AvailabilityZones": [{"SubnetId": "subnet-1"}, {"SubnetId": "subnet-2"}],
+    "SecurityGroups": ["sg-1"],
+    "Listeners": [{"ListenerArn": "arn:listener/1", "Port": 443, "Protocol": "HTTPS"}],
+    "TargetGroups": [
+        {"TargetType": "instance", "TargetGroupArn": "arn:tg/1", "Port": 8080, "Protocol": "HTTP",
+         "Targets": ["i-1", "i-2"]},
+        {"TargetType": "ip", "TargetGroupArn": "arn:tg/2", "Targets": ["10.0.0.1"]},
+    ],
+}
+
+
+class TestLoadLoadBalancerV2s:
+    def test_batched_writes(self):
+        session = MagicMock()
+
+        load_balancer_v2s.load_load_balancer_v2s(session, [ELBV2, ELBV2], TEST_ACCOUNT_ID, TEST_UPDATE_TAG, "us-east-1")
+
+        # lbs + subnets + security groups + listeners + target instances = 5 writes total
+        assert session.execute_write.call_count == 5
+        lb_call, subnet_call, sg_call, listener_call, instance_call = session.execute_write.call_args_list
+        assert len(lb_call.kwargs["DictList"]) == 2
+        assert len(subnet_call.kwargs["DictList"]) == 4
+        assert len(sg_call.kwargs["DictList"]) == 2
+        assert len(listener_call.kwargs["DictList"]) == 2
+        # non-instance target groups are skipped, exactly as before
+        instance_rows = instance_call.kwargs["DictList"]
+        assert len(instance_rows) == 4
+        assert {r["instance_id"] for r in instance_rows} == {"i-1", "i-2"}
+        assert instance_rows[0]["target_group_arn"] == "arn:tg/1"
+
+    def test_per_lb_helpers_still_work(self):
+        session = MagicMock()
+
+        load_balancer_v2s.load_load_balancer_v2_listeners(session, "lb-1", ELBV2["Listeners"], TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        rows = session.execute_write.call_args.kwargs["DictList"]
+        assert rows == [{"load_balancer_id": "lb-1", "listeners": ELBV2["Listeners"]}]
+
+    def test_empty_data_writes_nothing(self):
+        session = MagicMock()
+        load_balancer_v2s.load_load_balancer_v2s(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG, "us-east-1")
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/aws/test_load_balancers.py
+++ b/tests/unit/cartography/intel/aws/test_load_balancers.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for the batched classic ELB loaders (perf plan Phase 3.4).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.aws.ec2 import load_balancers
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+
+ELB = {
+    "DNSName": "web-elb.us-east-1.elb.amazonaws.com",
+    "LoadBalancerName": "web-elb",
+    "CreatedTime": "2024-01-01",
+    "CanonicalHostedZoneName": "web-elb.us-east-1.elb.amazonaws.com",
+    "CanonicalHostedZoneNameID": "Z123",
+    "Scheme": "internet-facing",
+    "region": "us-east-1",
+    "Subnets": ["subnet-1", "subnet-2"],
+    "SecurityGroups": ["sg-1"],
+    "SourceSecurityGroup": {"GroupName": "default"},
+    "Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}],
+    "ListenerDescriptions": [{"Listener": {"LoadBalancerPort": 80, "Protocol": "HTTP"}}],
+}
+
+
+class TestLoadLoadBalancers:
+    def test_batched_writes(self):
+        session = MagicMock()
+
+        load_balancers.load_load_balancers(session, [ELB, ELB], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        # lbs + subnets + security groups + source security groups + instances +
+        # listeners = 6 writes total (was ~7+ writes PER load balancer).
+        assert session.execute_write.call_count == 6
+        lb_call, subnet_call, sg_call, source_sg_call, instance_call, listener_call = \
+            session.execute_write.call_args_list
+
+        assert len(lb_call.kwargs["DictList"]) == 2
+        assert lb_call.kwargs["DictList"][0]["arn"].endswith(f"loadbalancer/{ELB['DNSName']}")
+        assert len(subnet_call.kwargs["DictList"]) == 4  # 2 subnets x 2 lbs
+        assert len(sg_call.kwargs["DictList"]) == 2
+        assert source_sg_call.kwargs["DictList"][0]["group_name"] == "default"
+        assert len(instance_call.kwargs["DictList"]) == 4
+        listener_rows = listener_call.kwargs["DictList"]
+        assert listener_rows[0]["listeners"] == ELB["ListenerDescriptions"]
+        assert all("UNWIND $DictList" in c.args[1] for c in session.execute_write.call_args_list)
+
+    def test_empty_data_writes_nothing(self):
+        session = MagicMock()
+        load_balancers.load_load_balancers(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+    def test_missing_optional_fields_produce_no_rows(self):
+        session = MagicMock()
+        bare = {
+            **ELB,
+            "Subnets": [],
+            "SecurityGroups": [],
+            "SourceSecurityGroup": None,
+            "Instances": [],
+            "ListenerDescriptions": [],
+        }
+
+        load_balancers.load_load_balancers(session, [bare], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        # only the lb node batch writes; empty row lists short-circuit
+        assert session.execute_write.call_count == 1

--- a/tests/unit/cartography/intel/aws/test_redshift_loaders.py
+++ b/tests/unit/cartography/intel/aws/test_redshift_loaders.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for the batched Redshift loaders (perf plan Phase 3.5).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.aws import redshift
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+
+CLUSTER = {
+    "arn": "arn:aws:redshift:us-east-1:1234:cluster:c1",
+    "AvailabilityZone": "us-east-1a",
+    "ClusterIdentifier": "c1",
+    "ClusterStatus": "available",
+    "Endpoint": {"Address": "c1.redshift.amazonaws.com", "Port": 5439},
+    "VpcId": "vpc-1",
+    "region": "us-east-1",
+    "VpcSecurityGroups": [{"VpcSecurityGroupId": "sg-1", "GroupId": "sg-1", "region": "us-east-1"}],
+    "IamRoles": [{"IamRoleArn": "arn:aws:iam::1234:role/redshift"}],
+    "VpcEndpoints": [
+        {"NetworkInterfaces": [{"NetworkInterfaceId": "eni-1", "SubnetId": "subnet-1"}]},
+    ],
+}
+
+
+class TestLoadRedshiftClusterData:
+    def test_batched_writes(self):
+        session = MagicMock()
+
+        redshift.load_redshift_cluster_data(session, [CLUSTER, CLUSTER], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        # clusters + SGs + IAM roles + VPCs + NICs + subnets = 6 writes total
+        assert session.execute_write.call_count == 6
+        cluster_call, sg_call, role_call, vpc_call, nic_call, subnet_call = session.execute_write.call_args_list
+        assert len(cluster_call.kwargs["DictList"]) == 2
+        assert cluster_call.kwargs["DictList"][0]["endpoint_address"] == "c1.redshift.amazonaws.com"
+        assert sg_call.kwargs["DictList"][0]["group_id"] == "sg-1"
+        assert role_call.kwargs["DictList"][0]["role_arn"] == "arn:aws:iam::1234:role/redshift"
+        assert vpc_call.kwargs["DictList"][0]["vpc_id"] == "vpc-1"
+        assert nic_call.kwargs["DictList"][0]["network_interface_id"] == "eni-1"
+        assert subnet_call.kwargs["DictList"][0]["subnet_id"] == "subnet-1"
+        assert all("UNWIND $DictList" in c.args[1] for c in session.execute_write.call_args_list)
+
+    def test_cluster_without_optional_attachments(self):
+        session = MagicMock()
+        bare = {**CLUSTER, "VpcSecurityGroups": [], "IamRoles": [], "VpcId": None, "VpcEndpoints": [], "Endpoint": None}
+
+        redshift.load_redshift_cluster_data(session, [bare], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1  # only the cluster batch
+        assert session.execute_write.call_args.kwargs["DictList"][0]["endpoint_address"] == ""
+
+    def test_empty_data_writes_nothing(self):
+        session = MagicMock()
+        redshift.load_redshift_cluster_data(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/aws/test_security_groups.py
+++ b/tests/unit/cartography/intel/aws/test_security_groups.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for the batched EC2 security group loaders (perf plan Phase 3.3).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.aws.ec2 import security_groups
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+
+GROUP = {
+    "GroupId": "sg-1",
+    "GroupName": "web",
+    "Description": "web sg",
+    "VpcId": "vpc-1",
+    "region": "us-east-1",
+    "isDefault": False,
+    "IpPermissions": [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+            "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+        },
+        {
+            "IpProtocol": "-1",
+            "IpRanges": [],
+            "Ipv6Ranges": [],
+        },
+    ],
+    "IpPermissionsEgress": [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 443,
+            "ToPort": 443,
+            "IpRanges": [{"CidrIp": "10.0.0.0/8"}],
+            "Ipv6Ranges": [],
+        },
+    ],
+}
+
+
+class TestBuildRuleAndRangeRows:
+    def test_partitions_and_ids(self):
+        rule_rows, range_rows = security_groups._build_rule_and_range_rows([GROUP])
+
+        assert len(rule_rows["IpPermissionInbound"]) == 2
+        assert len(rule_rows["IpPermissionEgress"]) == 1
+        all_protocol_rule = rule_rows["IpPermissionInbound"][1]
+        # "-1" protocol expands to the full port range, exactly as before
+        assert all_protocol_rule["from_port"] == 0
+        assert all_protocol_rule["to_port"] == 65535
+        assert all_protocol_rule["ruleid"] == "sg-1/IpPermissions/065535-1"
+
+        assert range_rows["IpRange"] == [
+            {
+                "range_id": "IpRule/sg-1/IpPermissions/8080tcp/ipRange/0.0.0.0/0",
+                "range": "0.0.0.0/0",
+                "range_name": "0.0.0.0",
+                "ruleid": "sg-1/IpPermissions/8080tcp",
+            },
+            {
+                "range_id": "IpRule/sg-1/IpPermissionsEgress/443443tcp/ipRange/10.0.0.0/8",
+                "range": "10.0.0.0/8",
+                "range_name": "10.0.0.0",
+                "ruleid": "sg-1/IpPermissionsEgress/443443tcp",
+            },
+        ]
+        assert len(range_rows["Ipv6Range"]) == 1
+
+    def test_empty_groups(self):
+        rule_rows, range_rows = security_groups._build_rule_and_range_rows([])
+        assert all(not rows for rows in rule_rows.values())
+        assert all(not rows for rows in range_rows.values())
+
+
+class TestLoadEc2SecurityGroupInfo:
+    def test_batched_writes(self):
+        session = MagicMock()
+
+        security_groups.load_ec2_security_groupinfo(session, [GROUP], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        # 1 group batch + 2 rule-label batches + 1 rule-group-pair batch +
+        # 2 range-label batches = 6 writes, independent of group count.
+        assert session.execute_write.call_count == 6
+        group_call = session.execute_write.call_args_list[0]
+        assert group_call.kwargs["DictList"][0]["group_arn"] == \
+            "arn:aws:ec2:us-east-1:1234:security-group/sg-1"
+        assert group_call.kwargs["AWS_ACCOUNT_ID"] == TEST_ACCOUNT_ID
+        queries = [c.args[1] for c in session.execute_write.call_args_list]
+        assert all("UNWIND $DictList" in q for q in queries)
+
+    def test_empty_data_writes_nothing(self):
+        session = MagicMock()
+        security_groups.load_ec2_security_groupinfo(session, [], TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
+++ b/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
@@ -7,12 +7,15 @@ auto-commit session.run.
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from cartography.intel.aws import apigateway
 from cartography.intel.aws import config
 from cartography.intel.aws import ecr
 from cartography.intel.aws import eks
 from cartography.intel.aws import elasticache
+from cartography.intel.aws import ecs
 from cartography.intel.aws import elasticsearch
 from cartography.intel.aws import kms
+from cartography.intel.aws import lambda_function
 from cartography.intel.aws import organizations
 from cartography.intel.aws import secretsmanager
 from cartography.intel.aws import securityhub
@@ -186,3 +189,60 @@ class TestElasticsearch:
         # subnets batch writes; the empty security-group list short-circuits
         assert session.execute_write.call_count == 1
         assert session.execute_write.call_args.kwargs["DictList"] == ["subnet-1"]
+
+
+class TestApiGateway:
+    def test_rest_apis_and_stages_batched(self):
+        session = MagicMock()
+        apis = [{"id": "a1", "region": TEST_REGION, "createdDate": "2024-01-01"}]
+        stages = [{"apiId": "a1", "stageName": "prod", "region": TEST_REGION, "createdDate": "2024-01-01"}]
+
+        apigateway.load_apigateway_rest_apis(session, apis, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        apigateway._load_apigateway_stages(session, stages, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        for call in session.execute_write.call_args_list:
+            assert "UNWIND $DictList" in call.args[1]
+
+    def test_default_values_write_is_managed(self):
+        session = MagicMock()
+
+        apigateway._set_default_values(session, TEST_ACCOUNT_ID)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestEcs:
+    def test_clusters_and_services_batched(self):
+        session = MagicMock()
+        clusters = [{"clusterArn": "arn:aws:ecs:us-east-1:1234:cluster/c1"}]
+        services = [{"serviceArn": "arn:aws:ecs:us-east-1:1234:service/s1", "createdAt": None}]
+
+        ecs.load_ecs_clusters(session, clusters, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        ecs.load_ecs_services(
+            session, "arn:aws:ecs:us-east-1:1234:cluster/c1", services, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG,
+        )
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        assert_batched(session.execute_write.call_args_list[0], clusters)
+        service_call = session.execute_write.call_args_list[1]
+        assert_batched(service_call, services)
+        assert service_call.kwargs["ClusterARN"] == "arn:aws:ecs:us-east-1:1234:cluster/c1"
+
+
+class TestLambda:
+    def test_functions_and_aliases_batched(self):
+        session = MagicMock()
+        functions = [{"FunctionArn": "arn:aws:lambda:us-east-1:1234:function:f1", "FunctionName": "f1"}]
+        aliases = [{"AliasArn": "arn:aws:lambda:us-east-1:1234:function:f1:live", "FunctionArn": "f1"}]
+
+        lambda_function.load_lambda_functions(session, functions, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        lambda_function._load_lambda_function_aliases(session, aliases, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        assert_batched(session.execute_write.call_args_list[0], functions)
+        assert_batched(session.execute_write.call_args_list[1], aliases)

--- a/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
+++ b/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for uniform neo4j interactions in the AWS intel modules
+(perf plan Phase 3 items 5+6): every write goes through load_graph_data
+(batched UNWIND ingests) or run_write_query (scalar writes), never a raw
+auto-commit session.run.
+"""
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cartography.intel.aws import ecr
+from cartography.intel.aws import eks
+from cartography.intel.aws import organizations
+from cartography.intel.aws import secretsmanager
+from cartography.intel.aws import securityhub
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+TEST_REGION = "us-east-1"
+
+
+def assert_batched(call, rows):
+    assert "UNWIND $DictList" in call.args[1]
+    assert call.kwargs["DictList"] == rows
+
+
+class TestSecretsManager:
+    def test_secrets_batched(self):
+        session = MagicMock()
+        data = [{"ARN": "arn:aws:secretsmanager:us-east-1:1234:secret:s1", "Name": "s1"}]
+
+        secretsmanager.load_secrets(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_empty_secrets_write_nothing(self):
+        session = MagicMock()
+        secretsmanager.load_secrets(session, [], TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
+class TestSecurityHub:
+    def test_hub_write_is_managed(self):
+        session = MagicMock()
+
+        hub = {"HubArn": "arn:aws:securityhub:us-east-1:1234:hub/default", "SubscribedAt": None}
+
+        securityhub.load_hub(session, hub, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestEcr:
+    def test_repositories_batched(self):
+        session = MagicMock()
+        repos = [{"repositoryArn": "arn:aws:ecr:us-east-1:1234:repository/r1", "repositoryName": "r1"}]
+
+        ecr.load_ecr_repositories(session, repos, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, repos)
+
+
+class TestEks:
+    def test_autoscaling_groups_batched(self):
+        session = MagicMock()
+        asgs = [{"AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:1234:autoScalingGroup:g1"}]
+
+        eks.attact_autoscaling_groups_to_nodegroups(session, "arn:nodegroup", asgs, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert_batched(call, asgs)
+        assert call.kwargs["GROUPARN"] == "arn:nodegroup"
+
+
+class TestOrganizations:
+    @patch.object(organizations, "cleanup")
+    def test_account_writes_are_managed(self, mock_cleanup):
+        session = MagicMock()
+        common_job_parameters = {"WORKSPACE_ID": "ws-1", "WORKSPACE_NAME": "ws"}
+
+        organizations.load_aws_accounts(
+            session, {"acct-a": "1111", "acct-b": "2222"}, TEST_UPDATE_TAG, {"Id": "o-1"}, common_job_parameters,
+        )
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2

--- a/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
+++ b/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
@@ -7,11 +7,16 @@ auto-commit session.run.
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from cartography.intel.aws import config
 from cartography.intel.aws import ecr
 from cartography.intel.aws import eks
+from cartography.intel.aws import elasticache
+from cartography.intel.aws import elasticsearch
+from cartography.intel.aws import kms
 from cartography.intel.aws import organizations
 from cartography.intel.aws import secretsmanager
 from cartography.intel.aws import securityhub
+from cartography.intel.aws import sqs
 
 TEST_UPDATE_TAG = 123456789
 TEST_ACCOUNT_ID = "1234"
@@ -87,3 +92,97 @@ class TestOrganizations:
 
         session.run.assert_not_called()
         assert session.execute_write.call_count == 2
+
+
+class TestConfig:
+    def test_recorders_channels_rules_batched(self):
+        session = MagicMock()
+        recorders = [{"name": "default", "roleARN": "arn:aws:iam::1234:role/config"}]
+        channels = [{"name": "default", "s3BucketName": "b1"}]
+        rules = [{"ConfigRuleArn": "arn:aws:config:us-east-1:1234:config-rule/r1", "ConfigRuleName": "r1"}]
+
+        config.load_configuration_recorders(session, recorders, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        config.load_delivery_channels(session, channels, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        config.load_config_rules(session, rules, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 3
+        for call in session.execute_write.call_args_list:
+            assert "UNWIND $DictList" in call.args[1]
+            assert len(call.kwargs["DictList"]) == 1
+
+
+class TestElasticache:
+    def test_clusters_and_security_groups_batched(self):
+        session = MagicMock()
+        clusters = [{"ARN": "arn:aws:elasticache:us-east-1:1234:cluster:c1", "SecurityGroups": []}]
+
+        elasticache.load_elasticache_clusters(session, clusters, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+        elasticache.attach_elasticache_clusters_to_security_groups(session, clusters, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        for call in session.execute_write.call_args_list:
+            assert_batched(call, clusters)
+
+
+class TestSqs:
+    def test_queues_and_deadletter_links_batched(self):
+        session = MagicMock()
+        queue_arn = "arn:aws:sqs:us-east-1:1234:q1"
+        data = {
+            "https://sqs/q1": {
+                "QueueArn": queue_arn,
+                "CreatedTimestamp": "1700000000",
+                "LastModifiedTimestamp": "1700000000",
+                "RedrivePolicy": '{"deadLetterTargetArn": "arn:aws:sqs:us-east-1:1234:dlq"}',
+            },
+        }
+
+        sqs.load_sqs_queues(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        # one batch for queues, one for the dead-letter relationships
+        assert session.execute_write.call_count == 2
+        dlq_rows = session.execute_write.call_args_list[1].kwargs["DictList"]
+        assert dlq_rows == [{"arn": queue_arn, "dead_letter_arn": "arn:aws:sqs:us-east-1:1234:dlq"}]
+
+
+class TestKms:
+    def test_aliases_batched(self):
+        session = MagicMock()
+        aliases = [{"AliasArn": "arn:aws:kms:us-east-1:1234:alias/a1", "TargetKeyId": "k1"}]
+
+        kms._load_kms_key_aliases(session, aliases, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, aliases)
+
+    def test_default_values_write_is_managed(self):
+        session = MagicMock()
+
+        kms._set_default_values(session, TEST_ACCOUNT_ID)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestElasticsearch:
+    def test_access_policy_tag_write_is_managed(self):
+        session = MagicMock()
+
+        elasticsearch._process_access_policy(session, "domain-1", {"Endpoint": None})
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+    def test_vpc_links_batched_and_skipped_when_empty(self):
+        session = MagicMock()
+        domain = {"VPCOptions": {"SubnetIds": ["subnet-1"], "SecurityGroupIds": []}}
+
+        elasticsearch._link_es_domain_vpc(session, "domain-1", domain, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        # subnets batch writes; the empty security-group list short-circuits
+        assert session.execute_write.call_count == 1
+        assert session.execute_write.call_args.kwargs["DictList"] == ["subnet-1"]

--- a/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
+++ b/tests/unit/cartography/intel/aws/test_uniform_neo4j_aws.py
@@ -17,6 +17,7 @@ from cartography.intel.aws import elasticsearch
 from cartography.intel.aws import kms
 from cartography.intel.aws import lambda_function
 from cartography.intel.aws import organizations
+from cartography.intel.aws import rds
 from cartography.intel.aws import secretsmanager
 from cartography.intel.aws import securityhub
 from cartography.intel.aws import sqs
@@ -246,3 +247,60 @@ class TestLambda:
         assert session.execute_write.call_count == 2
         assert_batched(session.execute_write.call_args_list[0], functions)
         assert_batched(session.execute_write.call_args_list[1], aliases)
+
+
+class TestRds:
+    @patch.object(rds, "_attach_associate_roles")
+    @patch.object(rds, "_attach_db_subnet_group")
+    @patch.object(rds, "_attach_ec2_security_groups_cluster")
+    def test_clusters_batched(self, mock_sg, mock_subnet, mock_roles):
+        session = MagicMock()
+        clusters = [{
+            "DBClusterArn": "arn:aws:rds:us-east-1:1234:cluster:c1",
+            "DBClusterIdentifier": "c1",
+            "EarliestRestorableTime": None,
+            "LatestRestorableTime": None,
+            "ClusterCreateTime": None,
+            "EarliestBacktrackTime": None,
+        }]
+
+        rds.load_rds_clusters(session, clusters, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, clusters)
+
+    def test_cluster_security_group_attachment_batched(self):
+        session = MagicMock()
+        cluster = {
+            "DBClusterArn": "arn:aws:rds:us-east-1:1234:cluster:c1",
+            "VpcSecurityGroups": [{"VpcSecurityGroupId": "sg-1"}],
+        }
+
+        rds._attach_ec2_security_groups_cluster(session, cluster, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert_batched(call, cluster["VpcSecurityGroups"])
+        assert call.kwargs["DBClusterArn"] == cluster["DBClusterArn"]
+
+    def test_subnet_group_attachment_is_managed(self):
+        session = MagicMock()
+        cluster = {"DBClusterArn": "arn:aws:rds:us-east-1:1234:cluster:c1", "DBSubnetGroup": "sng-1"}
+
+        rds._attach_db_subnet_group(session, cluster, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+    def test_read_replica_and_cluster_member_links_batched(self):
+        session = MagicMock()
+        replicas = [{"DBInstanceArn": "arn:instance", "ReadReplicaSourceDBInstanceIdentifier": "src"}]
+        members = [{"DBInstanceArn": "arn:instance", "DBClusterIdentifier": "c1"}]
+
+        rds._attach_read_replicas(session, replicas, TEST_UPDATE_TAG)
+        rds._attach_clusters(session, members, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        assert_batched(session.execute_write.call_args_list[0], replicas)
+        assert_batched(session.execute_write.call_args_list[1], members)

--- a/tests/unit/cartography/intel/aws/test_uniform_neo4j_ec2.py
+++ b/tests/unit/cartography/intel/aws/test_uniform_neo4j_ec2.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for uniform neo4j interactions in the aws/ec2 intel modules
+(perf plan Phase 3 items 5+6).
+"""
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from cartography.intel.aws.ec2 import auto_scaling_groups
+from cartography.intel.aws.ec2 import elastic_ip_addresses
+from cartography.intel.aws.ec2 import images
+from cartography.intel.aws.ec2 import instances
+from cartography.intel.aws.ec2 import internet_gateways
+from cartography.intel.aws.ec2 import key_pairs
+from cartography.intel.aws.ec2 import launch_templates
+from cartography.intel.aws.ec2 import reserved_instances
+from cartography.intel.aws.ec2 import snapshots
+from cartography.intel.aws.ec2 import subnets
+from cartography.intel.aws.ec2 import tgw
+from cartography.intel.aws.ec2 import volumes
+from cartography.intel.aws.ec2 import vpc
+from cartography.intel.aws.ec2 import vpc_peerings
+
+TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "1234"
+TEST_REGION = "us-east-1"
+NOW = datetime(2024, 1, 1)
+
+
+def assert_batched(call, rows):
+    assert "UNWIND $DictList" in call.args[1]
+    assert call.kwargs["DictList"] == rows
+
+
+class TestBatchedLoaders:
+    def test_launch_configurations(self):
+        session = MagicMock()
+        data = [{
+            "LaunchConfigurationARN": "arn:aws:autoscaling:us-east-1:1234:launchConfiguration:lc-1",
+            "CreatedTime": NOW,
+        }]
+
+        auto_scaling_groups.load_launch_configurations(
+            session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG,
+        )
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_elastic_ip_addresses(self):
+        session = MagicMock()
+        data = [{"PublicIp": "1.2.3.4", "AllocationId": "eipalloc-1", "region": TEST_REGION}]
+
+        elastic_ip_addresses.load_elastic_ip_addresses(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_images(self):
+        session = MagicMock()
+        data = [{"ImageId": "ami-1", "region": TEST_REGION}]
+
+        images.load_images(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_internet_gateways(self):
+        session = MagicMock()
+        data = [{"InternetGatewayId": "igw-1", "Attachments": []}]
+
+        internet_gateways.load_internet_gateways(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_launch_templates(self):
+        session = MagicMock()
+        data = [{"LaunchTemplateId": "lt-1", "CreateTime": NOW}]
+
+        launch_templates.load_launch_templates(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_reserved_instances(self):
+        session = MagicMock()
+        data = [{"ReservedInstancesId": "ri-1", "Start": NOW, "End": NOW}]
+
+        reserved_instances.load_reserved_instances(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_volumes(self):
+        session = MagicMock()
+        data = [{"VolumeId": "vol-1", "region": TEST_REGION}]
+
+        volumes.load_volumes(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_snapshots(self):
+        session = MagicMock()
+        data = [{"SnapshotId": "snap-1", "StartTime": NOW, "region": TEST_REGION}]
+
+        snapshots.load_snapshots(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_subnets_writes_three_batches(self):
+        session = MagicMock()
+        data = [{"SubnetId": "subnet-1"}]
+
+        subnets.load_subnets(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        # subnet nodes, vpc relations, account relations
+        assert session.execute_write.call_count == 3
+        for call in session.execute_write.call_args_list:
+            assert_batched(call, data)
+
+    def test_vpc_peerings(self):
+        session = MagicMock()
+        data = [{
+            "VpcPeeringConnectionId": "pcx-1",
+            "AccepterVpcInfo": {"VpcId": "vpc-1", "CidrBlockSet": []},
+            "RequesterVpcInfo": {"VpcId": "vpc-2", "CidrBlockSet": []},
+        }]
+
+        vpc_peerings.load_vpc_peerings(session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, data)
+
+    def test_ec2_to_eks_links(self):
+        session = MagicMock()
+        instance_list = [{"InstanceId": "i-1", "EksClusterName": "c1", "EksNodeGroupName": "ng1"}]
+
+        instances.link_ec2_to_eks(session, instance_list, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        # cluster links + node group links
+        assert session.execute_write.call_count == 2
+        for call in session.execute_write.call_args_list:
+            assert_batched(call, instance_list)
+
+    def test_vpc_cidr_association_set(self):
+        session = MagicMock()
+        vpc_data = {"CidrBlockAssociationSet": [{"AssociationId": "a-1", "CidrBlock": "10.0.0.0/16"}]}
+
+        vpc.load_cidr_association_set(session, "vpc-1", vpc_data, "ipv4", TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert_batched(call, vpc_data["CidrBlockAssociationSet"])
+        assert call.kwargs["VpcId"] == "vpc-1"
+
+
+class TestManagedScalarWrites:
+    def test_key_pairs_write_per_key_is_managed(self):
+        session = MagicMock()
+        data = [{"KeyName": "k1", "KeyFingerprint": "fp", "region": TEST_REGION}]
+
+        key_pairs.load_ec2_key_pairs(session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+    def test_instance_image_relations_write_is_managed(self):
+        session = MagicMock()
+
+        images.link_ec2_instances_to_images(session, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+    def test_tgw_attachment_writes_are_managed(self):
+        session = MagicMock()
+        attachment = {"VpcId": "vpc-1", "TransitGatewayAttachmentId": "tgw-attach-1", "SubnetIds": ["subnet-1"]}
+
+        tgw._attach_tgw_vpc_attachment_to_vpc_subnets(
+            session, attachment, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG,
+        )
+
+        session.run.assert_not_called()
+        # one write for the vpc link, one per subnet
+        assert session.execute_write.call_count == 2
+
+
+class TestReads:
+    def test_get_images_in_use_uses_managed_read(self):
+        session = MagicMock()
+        session.execute_read.return_value = [{"images": ["ami-1", "ami-2"]}]
+
+        result = images.get_images_in_use(session, TEST_REGION, TEST_ACCOUNT_ID)
+
+        session.run.assert_not_called()
+        session.execute_read.assert_called_once()
+        assert result == ["ami-1", "ami-2"]

--- a/tests/unit/cartography/intel/azure/test_timing.py
+++ b/tests/unit/cartography/intel/azure/test_timing.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from cartography.graph import write_timer
 from cartography.intel.azure.util.timing import AzureTimingPolicy
 from cartography.intel.azure.util.timing import get_current_context
 from cartography.intel.azure.util.timing import get_timing_policy
@@ -37,7 +38,10 @@ class TestServiceTimingContext:
 
     def test_initial_counts_are_zero(self):
         with ServiceTimingContext("svc") as ctx:
-            assert ctx.to_dict() == {"request_count": 0, "throttle_count": 0, "retry_count": 0}
+            assert ctx.to_dict() == {
+                "request_count": 0, "throttle_count": 0, "retry_count": 0,
+                "graph_write_seconds": 0.0,
+            }
 
     def test_to_dict_reflects_mutations(self):
         with ServiceTimingContext("svc") as ctx:
@@ -45,7 +49,23 @@ class TestServiceTimingContext:
             ctx.throttle_count = 2
             ctx.retry_count = 1
             d = ctx.to_dict()
-        assert d == {"request_count": 5, "throttle_count": 2, "retry_count": 1}
+        assert d == {
+            "request_count": 5, "throttle_count": 2, "retry_count": 1,
+            "graph_write_seconds": 0.0,
+        }
+
+    def test_graph_write_seconds_measures_write_timer_delta(self):
+        write_timer.add(1.0)  # activity before the context must not count
+        with ServiceTimingContext("svc") as ctx:
+            write_timer.add(2.5)
+            assert ctx.graph_write_seconds == 2.5
+
+    def test_graph_write_seconds_frozen_at_exit(self):
+        with ServiceTimingContext("svc") as ctx:
+            write_timer.add(1.5)
+        write_timer.add(9.0)  # later activity on this thread must not leak in
+        assert ctx.graph_write_seconds == 1.5
+        assert ctx.to_dict()["graph_write_seconds"] == 1.5
 
     def test_nested_context_replaces_outer(self):
         with ServiceTimingContext("outer") as outer_ctx:

--- a/tests/unit/cartography/intel/azuredevops/test_uniform_neo4j.py
+++ b/tests/unit/cartography/intel/azuredevops/test_uniform_neo4j.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for uniform neo4j interactions in the azuredevops intel modules
+(perf plan Phase 3 items 5+6).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.azuredevops import members
+from cartography.intel.azuredevops import organization
+from cartography.intel.azuredevops import projects
+from cartography.intel.azuredevops import repos
+
+COMMON_JOB_PARAMS = {"UPDATE_TAG": 123456789, "WORKSPACE_ID": "ws-1"}
+
+
+class TestLoadUsers:
+    def test_batched_via_dictlist(self):
+        session = MagicMock()
+        user_data = [{"displayName": "Alice", "principalName": "alice"}]
+
+        members.load_users(session, user_data, "org-1", COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList" in call.args[1]
+        assert call.kwargs["DictList"] == user_data
+        assert call.kwargs["OrganizationName"] == "org-1"
+
+
+class TestLoadOrganization:
+    def test_goes_through_managed_tx(self):
+        session = MagicMock()
+        org_data = {"name": "org-1", "url": "https://dev.azure.com/org-1", "status": "active"}
+
+        organization.load_organization(session, org_data, COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestLoadProjects:
+    def test_batched_via_dictlist(self):
+        session = MagicMock()
+        project_data = [{"id": "p1", "name": "proj"}]
+
+        projects.load_projects(session, project_data, "org-1", COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList" in call.args[1]
+        assert call.kwargs["DictList"] == project_data
+
+
+class TestRepos:
+    def test_repositories_and_branches_batched(self):
+        session = MagicMock()
+
+        repos.load_repositories(session, [{"id": "r1"}], "p1", COMMON_JOB_PARAMS)
+        repos.load_branches_data(session, [{"id": "b1", "repo_id": "r1"}], COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        for call in session.execute_write.call_args_list:
+            assert "UNWIND $DictList" in call.args[1]
+
+    def test_last_activity_write_goes_through_managed_tx(self):
+        session = MagicMock()
+        branches = [{"name": "main", "commitDate": "2024-01-01T00:00:00+00:00"}]
+
+        repos._update_repo_last_activity(session, "r1", branches, "main")
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()

--- a/tests/unit/cartography/intel/bitbucket/test_uniform_neo4j.py
+++ b/tests/unit/cartography/intel/bitbucket/test_uniform_neo4j.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for uniform neo4j interactions in the bitbucket intel modules
+(perf plan Phase 3 items 5+6).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.bitbucket import repositories
+
+TEST_UPDATE_TAG = 123456789
+
+
+class TestLoadLanguages:
+    def test_batched_via_dictlist(self):
+        session = MagicMock()
+        langs = [{"primary_language": "python", "repo_id": "r1"}]
+
+        repositories.load_languages(session, TEST_UPDATE_TAG, langs)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList" in call.args[1]
+        assert call.kwargs["DictList"] == langs
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        repositories.load_languages(session, TEST_UPDATE_TAG, [])
+        session.execute_write.assert_not_called()
+
+
+class TestUpdateRepoLastActivity:
+    def test_goes_through_managed_tx(self):
+        session = MagicMock()
+        branches = [{"name": "main", "date": "2024-01-01T00:00:00+00:00"}]
+
+        repositories._update_repo_last_activity(session, "r1", branches, "main")
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+    def test_no_dates_no_write(self):
+        session = MagicMock()
+
+        repositories._update_repo_last_activity(session, "r1", [{"name": "main"}], "main")
+
+        session.execute_write.assert_not_called()
+        session.run.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_compute_loaders.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_loaders.py
@@ -123,3 +123,118 @@ class TestLoadGcpSubnets:
         session = MagicMock()
         compute.load_gcp_subnets(session, [], TEST_UPDATE_TAG)
         session.execute_write.assert_not_called()
+
+
+INSTANCE = {
+    "partial_uri": "projects/p1/zones/z1/instances/vm-1",
+    "project_id": "p1",
+    "region": "us-east1",
+    "tags": {"items": ["web", "db"]},
+    "networkInterfaces": [
+        {
+            "name": "nic0",
+            "network": "https://net/default",
+            "consolelink": "https://console/nic0",
+            "subnet_partial_uri": "projects/p1/regions/us-east1/subnetworks/default",
+            "vpc_partial_uri": "projects/p1/global/networks/default",
+            "accessConfigs": [
+                {"type": "ONE_TO_ONE_NAT", "name": "External NAT", "natIP": "34.1.2.3"},
+            ],
+        },
+    ],
+    "serviceAccounts": [{"email": "sa@p1.iam.gserviceaccount.com"}],
+    "gke_cluster_name": "prod",
+    "gke_node_pool_name": "pool-1",
+}
+
+NIC_ID = "projects/p1/zones/z1/instances/vm-1/networkinterfaces/nic0"
+
+
+class TestInstanceRowBuilders:
+    def test_tag_rows_are_instance_x_tag_x_nic(self):
+        rows = compute._build_instance_tag_rows([INSTANCE])
+        assert len(rows) == 2  # 2 tags x 1 nic
+        assert rows[0]["instance_id"] == INSTANCE["partial_uri"]
+        assert rows[0]["vpc_partial_uri"] == "projects/p1/global/networks/default"
+        assert {r["tag_value"] for r in rows} == {"web", "db"}
+        assert all(r["tag_id"] == f"projects/p1/global/networks/default/tags/{r['tag_value']}" for r in rows)
+
+    def test_nic_rows(self):
+        rows = compute._build_nic_rows([INSTANCE])
+        assert rows == [{
+            "instance_id": INSTANCE["partial_uri"],
+            "nic_id": NIC_ID,
+            "network": "https://net/default",
+            "name": "nic0",
+            "consolelink": "https://console/nic0",
+            "subnet_partial_uri": "projects/p1/regions/us-east1/subnetworks/default",
+        }]
+
+    def test_access_config_rows(self):
+        rows = compute._build_access_config_rows([INSTANCE])
+        assert rows == [{
+            "nic_id": NIC_ID,
+            "access_config_id": f"{NIC_ID}/accessconfigs/ONE_TO_ONE_NAT",
+            "type": "ONE_TO_ONE_NAT",
+            "name": "External NAT",
+            "consolelink": None,
+            "nat_ip": "34.1.2.3",
+            "set_public_ptr": None,
+            "public_ptr_domain_name": None,
+            "network_tier": None,
+        }]
+
+    def test_service_account_rows(self):
+        rows = compute._build_service_account_rows([INSTANCE])
+        assert rows == [{"instance_id": INSTANCE["partial_uri"], "email": "sa@p1.iam.gserviceaccount.com"}]
+
+    def test_gke_rows_only_for_gke_instances(self):
+        plain = {**INSTANCE, "gke_cluster_name": None, "gke_node_pool_name": None}
+        cluster_only = {**INSTANCE, "gke_node_pool_name": None}
+
+        cluster_rows = compute._build_gke_cluster_link_rows([INSTANCE, plain, cluster_only])
+        pool_rows = compute._build_gke_node_pool_link_rows([INSTANCE, plain, cluster_only])
+
+        assert len(cluster_rows) == 2
+        assert cluster_rows[0] == {
+            "cluster_id": "projects/p1/locations/us-east1/clusters/prod",
+            "instance_id": INSTANCE["partial_uri"],
+        }
+        assert pool_rows == [{
+            "node_pool_id": "projects/p1/locations/us-east1/clusters/prod/nodePools/pool-1",
+            "instance_id": INSTANCE["partial_uri"],
+        }]
+
+    def test_empty_instances_produce_no_rows(self):
+        assert compute._build_instance_tag_rows([]) == []
+        assert compute._build_nic_rows([]) == []
+        assert compute._build_access_config_rows([]) == []
+        assert compute._build_service_account_rows([]) == []
+        assert compute._build_gke_cluster_link_rows([]) == []
+        assert compute._build_gke_node_pool_link_rows([]) == []
+
+
+class TestLoadGcpInstancesBatching:
+    def test_attachments_are_batched_not_per_item(self):
+        session = MagicMock()
+        instances = [INSTANCE, {**INSTANCE, "partial_uri": "projects/p1/zones/z1/instances/vm-2"}]
+
+        compute.load_gcp_instances(session, instances, TEST_UPDATE_TAG)
+
+        # 1 instance batch + tags + nics + access configs + vpc membership +
+        # service accounts + gke cluster links + gke pool links + image relations
+        # = 9 writes total for ANY number of instances (was ~8 writes PER instance).
+        assert session.execute_write.call_count == 9
+        unwind_calls = [c for c in session.execute_write.call_args_list if "DictList" in c.kwargs]
+        for call in unwind_calls:
+            assert "UNWIND" in call.args[1]
+
+    def test_no_gke_instances_skips_gke_writes(self):
+        session = MagicMock()
+        plain = {**INSTANCE, "gke_cluster_name": None, "gke_node_pool_name": None}
+
+        compute.load_gcp_instances(session, [plain], TEST_UPDATE_TAG)
+
+        queries = [c.args[1] for c in session.execute_write.call_args_list if len(c.args) > 1]
+        assert not any("GKECluster" in q for q in queries)
+        assert not any("GKENodePool" in q for q in queries)

--- a/tests/unit/cartography/intel/gcp/test_compute_loaders.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_loaders.py
@@ -59,6 +59,53 @@ class TestLoadGcpVpcs:
         session.execute_write.assert_not_called()
 
 
+class TestLoadGcpForwardingRules:
+    def test_batches_and_partitions_attachments(self):
+        session = MagicMock()
+        subnet_rule = {
+            "partial_uri": "projects/p1/regions/us-east1/forwardingRules/a",
+            "ip_address": "10.0.0.9",
+            "ip_protocol": "TCP",
+            "load_balancing_scheme": "INTERNAL",
+            "name": "a",
+            "project_id": "p1",
+            "self_link": "https://selflink/a",
+            "target": "projects/p1/targets/t1",
+            "subnetwork": "https://subnet",
+            "subnetwork_partial_uri": "projects/p1/regions/us-east1/subnetworks/default",
+            "network": "https://net",
+            "network_partial_uri": "projects/p1/global/networks/default",
+        }
+        vpc_rule = {
+            "partial_uri": "projects/p1/regions/us-east1/forwardingRules/b",
+            "ip_address": "10.0.0.10",
+            "ip_protocol": "TCP",
+            "load_balancing_scheme": "EXTERNAL",
+            "name": "b",
+            "project_id": "p1",
+            "self_link": "https://selflink/b",
+            "target": "projects/p1/targets/t2",
+            "network": "https://net",
+            "network_partial_uri": "projects/p1/global/networks/default",
+        }
+
+        compute.load_gcp_forwarding_rules(session, [subnet_rule, vpc_rule], TEST_UPDATE_TAG)
+
+        # one write for the rules, one for the subnet attachment batch, one for the vpc batch
+        assert session.execute_write.call_count == 3
+        main, subnet_attach, vpc_attach = session.execute_write.call_args_list
+        assert main.kwargs["DictList"] == [subnet_rule, vpc_rule]
+        assert subnet_attach.kwargs["DictList"] == [subnet_rule]
+        assert "GCPSubnet" in subnet_attach.args[1]
+        assert vpc_attach.kwargs["DictList"] == [vpc_rule]
+        assert "GCPVpc" in vpc_attach.args[1]
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        compute.load_gcp_forwarding_rules(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
 class TestLoadGcpSubnets:
     def test_single_batched_write(self):
         session = MagicMock()

--- a/tests/unit/cartography/intel/gcp/test_compute_loaders.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_loaders.py
@@ -238,3 +238,79 @@ class TestLoadGcpInstancesBatching:
         queries = [c.args[1] for c in session.execute_write.call_args_list if len(c.args) > 1]
         assert not any("GKECluster" in q for q in queries)
         assert not any("GKENodePool" in q for q in queries)
+
+
+FIREWALL = {
+    "id": "projects/p1/global/firewalls/allow-web",
+    "direction": "INGRESS",
+    "disabled": False,
+    "name": "allow-web",
+    "priority": 1000,
+    "selfLink": "https://selflink/fw",
+    "vpc_partial_uri": "projects/p1/global/networks/default",
+    "has_target_service_accounts": False,
+    "consolelink": "https://console/fw",
+    "network": "https://net/default",
+    "sourceRanges": ["34.1.2.3/32", "10.0.0.0/8", "2001:db8::/32"],
+    "transformed_allow_list": [
+        {"ruleid": "fw/allow/tcp/80", "protocol": "tcp", "fromport": 80, "toport": 80},
+    ],
+    "transformed_deny_list": [
+        {"ruleid": "fw/deny/tcp/22", "protocol": "tcp", "fromport": 22, "toport": 22},
+    ],
+    "targetTags": ["web"],
+}
+
+
+class TestFirewallRowBuilders:
+    def test_rule_rows_partitioned_by_label_and_ip_type(self):
+        partitions = compute._build_firewall_rule_rows([FIREWALL])
+
+        # 1 allow rule x 3 ranges (2 v4 + 1 v6); same for deny
+        assert len(partitions[("ALLOWED_BY", "IPv4")]) == 2
+        assert len(partitions[("ALLOWED_BY", "IPv6")]) == 1
+        assert len(partitions[("DENIED_BY", "IPv4")]) == 2
+        assert len(partitions[("DENIED_BY", "IPv6")]) == 1
+        row = partitions[("ALLOWED_BY", "IPv4")][0]
+        assert row == {
+            "fw_id": FIREWALL["id"],
+            "ruleid": "fw/allow/tcp/80",
+            "protocol": "tcp",
+            "fromport": 80,
+            "toport": 80,
+            "range": "34.1.2.3/32",
+        }
+
+    def test_target_tag_rows(self):
+        rows = compute._build_target_tag_rows([FIREWALL])
+        assert rows == [{
+            "fw_id": FIREWALL["id"],
+            "tag_id": "projects/p1/global/networks/default/tags/web",
+            "tag_value": "web",
+        }]
+
+    def test_public_ip_rows_exclude_private_ranges(self):
+        rows = compute._build_firewall_public_ip_rows([FIREWALL])
+        # 10.0.0.0/8 is private; 2001:db8::/32 fails IPv4Network parsing and is skipped
+        assert rows == [{"fw_id": FIREWALL["id"], "ip": "34.1.2.3/32"}]
+
+
+class TestLoadGcpIngressFirewalls:
+    def test_batched_writes(self):
+        session = MagicMock()
+
+        compute.load_gcp_ingress_firewalls(session, [FIREWALL, FIREWALL], TEST_UPDATE_TAG)
+
+        # 1 firewall batch + 4 rule partitions + 1 target tags + 1 public ips = 7
+        # (independent of firewall count; was ~7+ writes PER firewall)
+        assert session.execute_write.call_count == 7
+        queries = [c.args[1] for c in session.execute_write.call_args_list]
+        assert sum("ALLOWED_BY" in q for q in queries) == 2  # v4 + v6 partitions
+        assert sum("DENIED_BY" in q for q in queries) == 2
+        assert sum("Ipv6Range" in q for q in queries) == 2
+        assert all("UNWIND $DictList" in q for q in queries)
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        compute.load_gcp_ingress_firewalls(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_compute_loaders.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_loaders.py
@@ -314,3 +314,24 @@ class TestLoadGcpIngressFirewalls:
         session = MagicMock()
         compute.load_gcp_ingress_firewalls(session, [], TEST_UPDATE_TAG)
         session.execute_write.assert_not_called()
+
+
+class TestAttachComputeDisksToInstances:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        rows = [
+            {"id": "projects/p1/disks/d1", "instance_id": "projects/p1/zones/z1/instances/vm-1"},
+            {"id": "projects/p1/disks/d2", "instance_id": "projects/p1/zones/z1/instances/vm-2"},
+        ]
+
+        compute.attach_compute_disks_to_instances(session, rows, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert call.kwargs["DictList"] == rows
+        assert "record.instance_id" in call.args[1]
+
+    def test_empty_rows_write_nothing(self):
+        session = MagicMock()
+        compute.attach_compute_disks_to_instances(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_compute_loaders.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_loaders.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for the batched (UNWIND $DictList) loaders in cartography.intel.gcp.compute.
+
+These verify the perf plan Phase 3.1 migration: one write transaction per batch instead
+of one per row, with row payloads built correctly. A MagicMock session records the
+execute_write calls issued by load_graph_data.
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.gcp import compute
+
+TEST_UPDATE_TAG = 123456789
+
+VPC_A = {
+    "partial_uri": "projects/p1/global/networks/default",
+    "name": "default",
+    "self_link": "https://www.googleapis.com/compute/v1/projects/p1/global/networks/default",
+    "project_id": "p1",
+    "auto_create_subnetworks": True,
+    "description": "Default VPC",
+    "routing_config_routing_mode": "REGIONAL",
+    "region": "us-east1",
+    "consolelink": "https://console.cloud.google.com/networking",
+    "isDefault": True,
+}
+
+SUBNET_A = {
+    "partial_uri": "projects/p1/regions/us-east1/subnetworks/default",
+    "name": "default",
+    "self_link": "https://www.googleapis.com/compute/v1/projects/p1/regions/us-east1/subnetworks/default",
+    "project_id": "p1",
+    "region": "us-east1",
+    "gateway_address": "10.0.0.1",
+    "ip_cidr_range": "10.0.0.0/20",
+    "private_ip_google_access": False,
+    "vpc_partial_uri": "projects/p1/global/networks/default",
+    "vpc_self_link": "https://www.googleapis.com/compute/v1/projects/p1/global/networks/default",
+    "consolelink": "https://console.cloud.google.com/networking",
+    "isDefault": True,
+}
+
+
+class TestLoadGcpVpcs:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        vpcs = [VPC_A, {**VPC_A, "partial_uri": "projects/p1/global/networks/other", "name": "other"}]
+
+        compute.load_gcp_vpcs(session, vpcs, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList AS item" in call.args[1]
+        assert call.kwargs["DictList"] == vpcs
+        assert call.kwargs["gcp_update_tag"] == TEST_UPDATE_TAG
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        compute.load_gcp_vpcs(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()
+
+
+class TestLoadGcpSubnets:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        subnets = [SUBNET_A]
+
+        compute.load_gcp_subnets(session, subnets, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList AS item" in call.args[1]
+        assert call.kwargs["DictList"] == subnets
+        assert call.kwargs["gcp_update_tag"] == TEST_UPDATE_TAG
+
+    def test_empty_list_writes_nothing(self):
+        session = MagicMock()
+        compute.load_gcp_subnets(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_iam.py
+++ b/tests/unit/cartography/intel/gcp/test_iam.py
@@ -1,11 +1,15 @@
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from cartography.intel.gcp import iam
 
 
-def test_load_bindings_deleted_members_have_consolelink():
+@patch.object(iam, 'run_write_query')
+def test_load_bindings_deleted_members_have_consolelink(mock_run_write_query):
     # Deleted members (deleted:group:..., deleted:user:..., deleted:domain:...) used to omit
     # "consolelink", making the attach_* helpers raise KeyError.
+    # The attach_* writes go through run_write_query (managed tx + retry), so the query
+    # parameters are asserted there rather than on a raw session.run.
     neo4j_session = MagicMock()
     bindings = [{
         'role': 'projects/p1/roles/custom1',
@@ -20,7 +24,7 @@ def test_load_bindings_deleted_members_have_consolelink():
 
     iam.load_bindings(neo4j_session, bindings, 'p1', 'organizations/1', 12345, {})
 
-    consolelinks = [call.kwargs['ConsoleLink'] for call in neo4j_session.run.call_args_list]
+    consolelinks = [call.kwargs['ConsoleLink'] for call in mock_run_write_query.call_args_list]
     assert len(consolelinks) == 3
     assert all(link for link in consolelinks)
 

--- a/tests/unit/cartography/intel/gcp/test_uniform_neo4j.py
+++ b/tests/unit/cartography/intel/gcp/test_uniform_neo4j.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for uniform neo4j interactions in the gcp intel modules
+(perf plan Phase 3 items 5+6).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.gcp import crm
+from cartography.intel.gcp import dns
+from cartography.intel.gcp import iam
+from cartography.intel.gcp import workspace
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = "project-1"
+
+
+def assert_batched(call, rows):
+    assert "UNWIND $DictList" in call.args[1]
+    assert call.kwargs["DictList"] == rows
+
+
+class TestDns:
+    def test_zones_records_policies_keys_batched(self):
+        session = MagicMock()
+        zones = [{"id": "z1", "name": "example.com"}]
+        rrs = [{"id": "rr1", "name": "www", "zone": "z1"}]
+        policies = [{"id": "p1", "name": "policy"}]
+        keys = [{"id": "k1", "keyTag": 1}]
+
+        dns.load_dns_zones(session, zones, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+        dns.load_rrs(session, rrs, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+        dns.load_dns_polices(session, policies, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+        dns.load_dns_keys(session, keys, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 4
+        for call, rows in zip(session.execute_write.call_args_list, [zones, rrs, policies, keys]):
+            assert_batched(call, rows)
+
+
+class TestIam:
+    def test_service_accounts_and_roles_batched(self):
+        session = MagicMock()
+        # email is left unset: _gcp_service_account_managed_type handles None.
+        service_accounts = [{"uniqueId": "sa-1", "email": None}]
+        roles = [{"id": "roles/viewer", "name": "roles/viewer"}]
+
+        iam.load_service_accounts(session, service_accounts, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+        iam.load_project_roles(session, roles, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        assert_batched(session.execute_write.call_args_list[0], service_accounts)
+        assert_batched(session.execute_write.call_args_list[1], roles)
+
+    def test_api_keys_batched(self):
+        session = MagicMock()
+        api_keys = [{"uid": "key-1", "name": "projects/p/keys/key-1"}]
+
+        iam.load_api_keys(session, api_keys, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args, api_keys)
+
+
+class TestCrmManagedWrites:
+    def test_organization_write_is_managed(self):
+        session = MagicMock()
+        orgs = [{"name": "organizations/1", "displayName": "acme", "lifecycleState": "ACTIVE"}]
+
+        crm.load_gcp_organizations(session, orgs, TEST_UPDATE_TAG, {"WORKSPACE_ID": "ws-1"})
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestWorkspace:
+    def test_group_members_batched(self):
+        session = MagicMock()
+        members = [{"id": "member-1", "type": "USER"}]
+
+        workspace.load_groups_members(session, {"id": "g1"}, members, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count >= 1
+        assert_batched(session.execute_write.call_args_list[0], members)

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -153,7 +153,8 @@ def test_transform_accepts_raw_rest_repo_shape() -> None:
 def test_load_github_repos_uses_is_private_field_in_query() -> None:
     neo4j_session = Mock()
 
-    repos.load_github_repos(neo4j_session, 123, [])
+    repos.load_github_repos(neo4j_session, 123, [{"id": "r1"}])
 
-    query = neo4j_session.run.call_args.args[0]
+    # writes now go through load_graph_data -> execute_write(tx_fn, query, ...)
+    query = neo4j_session.execute_write.call_args.args[1]
     assert "repo.is_private = repository.is_private" in query

--- a/tests/unit/cartography/intel/github/test_uniform_neo4j.py
+++ b/tests/unit/cartography/intel/github/test_uniform_neo4j.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for uniform neo4j interactions in the github intel modules
+(perf plan Phase 3 items 5+6): writes go through load_graph_data /
+run_write_query, never raw session.run.
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.github import organization
+from cartography.intel.github import repos
+from cartography.intel.github import users
+
+TEST_UPDATE_TAG = 123456789
+COMMON_JOB_PARAMS = {"UPDATE_TAG": TEST_UPDATE_TAG, "WORKSPACE_ID": "ws-1"}
+
+ORG_DATA = {
+    "login": "acme", "url": "https://github.com/acme", "email": None, "id": "O1",
+    "name": "Acme", "description": "", "createdAt": "2020-01-01", "isVerified": True,
+    "location": "", "websiteUrl": "", "requiresTwoFactorAuthentication": True,
+}
+
+
+class TestLoadOrganization:
+    def test_write_goes_through_managed_tx(self):
+        session = MagicMock()
+
+        organization.load_organization(session, ORG_DATA, COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        session.execute_write.assert_called_once()
+
+
+class TestLoadOrganizationUsers:
+    def test_users_batched_via_dictlist(self):
+        session = MagicMock()
+        user_data = [{"node": {"url": "https://github.com/u1", "login": "u1"}, "role": "MEMBER"}]
+
+        users.load_organization_users(session, user_data, ORG_DATA, COMMON_JOB_PARAMS)
+
+        session.run.assert_not_called()
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList" in call.args[1]
+        assert call.kwargs["DictList"] == user_data
+        assert call.kwargs["workspace_id"] == "ws-1"
+
+
+class TestReposLoaders:
+    def test_repos_languages_branches_requirements_batched(self):
+        session = MagicMock()
+        repos.load_github_repos(session, TEST_UPDATE_TAG, [{"id": "r1"}])
+        repos.load_github_languages(session, TEST_UPDATE_TAG, [{"language_name": "python", "repo_id": "r1"}])
+        repos.load_github_branches(session, TEST_UPDATE_TAG, [{"id": "b1", "repo_id": "r1"}])
+        repos.load_python_requirements(session, TEST_UPDATE_TAG, [{"id": "req|1", "name": "req"}])
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 4
+        for call in session.execute_write.call_args_list:
+            assert "UNWIND $DictList" in call.args[1]
+            assert len(call.kwargs["DictList"]) == 1
+
+    def test_collaborators_batched_per_type(self):
+        session = MagicMock()
+        collaborators = {
+            "WRITE": [{"url": "https://github.com/u1", "repo_url": "r1"}],
+            "READ": [{"url": "https://github.com/u2", "repo_url": "r1"}],
+        }
+
+        repos.load_collaborators(session, TEST_UPDATE_TAG, collaborators)
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count == 2
+        queries = [c.args[1] for c in session.execute_write.call_args_list]
+        assert any("OUTSIDE_COLLAB_WRITE" in q for q in queries)
+        assert any("OUTSIDE_COLLAB_READ" in q for q in queries)
+        assert all("UNWIND $DictList" in q for q in queries)

--- a/tests/unit/cartography/intel/oci/test_uniform_neo4j.py
+++ b/tests/unit/cartography/intel/oci/test_uniform_neo4j.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for uniform neo4j interactions in the oci intel modules
+(perf plan Phase 3 items 5+6).
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.oci import containerregistry
+from cartography.intel.oci import database
+from cartography.intel.oci import utils
+
+TEST_UPDATE_TAG = 123456789
+TEST_COMPARTMENT_ID = "ocid1.compartment.oc1..aaaa"
+TEST_TENANCY_ID = "ocid1.tenancy.oc1..bbbb"
+
+
+def assert_batched(call, rows):
+    assert "UNWIND $DictList" in call.args[1]
+    assert call.kwargs["DictList"] == rows
+
+
+class TestDatabaseBatchedLoaders:
+    def test_autonomous_databases_batched(self):
+        session = MagicMock()
+        adbs = [{"id": "ocid1.autonomousdatabase.oc1..cccc", "compartment-id": TEST_COMPARTMENT_ID}]
+
+        database.load_autonomous_databases(session, adbs, TEST_COMPARTMENT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args_list[0], adbs)
+
+    def test_db_systems_batched(self):
+        session = MagicMock()
+        systems = [{"id": "ocid1.dbsystem.oc1..dddd", "compartment-id": TEST_COMPARTMENT_ID}]
+
+        database.load_db_systems(session, systems, TEST_COMPARTMENT_ID, TEST_UPDATE_TAG)
+
+        session.run.assert_not_called()
+        assert_batched(session.execute_write.call_args_list[0], systems)
+
+
+class TestManagedScalarWrites:
+    def test_container_repository_write_is_managed(self):
+        session = MagicMock()
+        repos = [{"id": "ocid1.containerrepo.oc1..eeee", "display-name": "repo"}]
+
+        containerregistry.load_container_repositories(
+            session, repos, TEST_TENANCY_ID, TEST_COMPARTMENT_ID, "us-ashburn-1", TEST_UPDATE_TAG,
+        )
+
+        session.run.assert_not_called()
+        assert session.execute_write.call_count >= 1
+
+
+class TestReads:
+    def test_tenancy_lookups_use_managed_reads(self):
+        session = MagicMock()
+        session.execute_read.return_value = [{"compartment.ocid": TEST_COMPARTMENT_ID}]
+
+        result = utils.get_compartments_in_tenancy(session, TEST_TENANCY_ID)
+
+        session.run.assert_not_called()
+        session.execute_read.assert_called_once()
+        assert result == [{"compartment.ocid": TEST_COMPARTMENT_ID}]

--- a/tests/unit/cartography/intel/test_misc_batched_loaders.py
+++ b/tests/unit/cartography/intel/test_misc_batched_loaders.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for the Phase 3.6 batched loaders in the small intel modules:
+github/repos, aws/rds, azure/subscription, digitalocean/compute.
+"""
+from unittest.mock import MagicMock
+
+from cartography.intel.aws import rds
+from cartography.intel.digitalocean import compute as do_compute
+from cartography.intel.github import repos
+
+TEST_UPDATE_TAG = 123456789
+
+
+class TestGithubOwners:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        owners = [
+            {"type": "Organization", "owner": "acme", "repo_id": "https://github.com/acme/a"},
+            {"type": "Organization", "owner": "acme", "repo_id": "https://github.com/acme/b"},
+        ]
+
+        repos.load_github_owners(session, TEST_UPDATE_TAG, owners)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "GitHubOrganization" in call.args[1]
+        assert call.kwargs["DictList"] == [
+            {"owner": "acme", "repo_id": "https://github.com/acme/a"},
+            {"owner": "acme", "repo_id": "https://github.com/acme/b"},
+        ]
+
+    def test_empty_owners_write_nothing(self):
+        session = MagicMock()
+        repos.load_github_owners(session, TEST_UPDATE_TAG, [])
+        session.execute_write.assert_not_called()
+
+
+class TestRdsBatchedAttachments:
+    def test_db_security_groups_flattened(self):
+        session = MagicMock()
+        db_sgs = [
+            {
+                "DBSecurityGroupArn": "arn:dbsg/1",
+                "EC2SecurityGroups": [{"EC2SecurityGroupId": "sg-1"}, {"EC2SecurityGroupId": "sg-2"}],
+            },
+            {"DBSecurityGroupArn": "arn:dbsg/2", "EC2SecurityGroups": []},
+        ]
+
+        rds.attach_db_security_groups_to_ec2_security_groups(session, db_sgs, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        rows = session.execute_write.call_args.kwargs["DictList"]
+        assert rows == [
+            {"db_sg_id": "arn:dbsg/1", "ec2_sg_id": "sg-1"},
+            {"db_sg_id": "arn:dbsg/1", "ec2_sg_id": "sg-2"},
+        ]
+
+    def test_associated_roles_flattened(self):
+        session = MagicMock()
+        clusters = [
+            {"DBClusterArn": "arn:cluster/1", "AssociatedRoles": [{"RoleArn": "arn:role/1"}]},
+            {"DBClusterArn": "arn:cluster/2", "AssociatedRoles": []},
+        ]
+
+        rds._attach_associate_roles(session, clusters, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        rows = session.execute_write.call_args.kwargs["DictList"]
+        assert rows == [{"cluster_arn": "arn:cluster/1", "role_arn": "arn:role/1"}]
+
+
+# NOTE azure/subscription.py's batched loader is validated by py_compile/flake8 here and
+# integration in CI: the azure package __init__ imports SDK modules unavailable in the
+# dev sandbox, so it cannot be imported by unit tests (same as azure/compute.py).
+
+
+class TestDigitaloceanDroplets:
+    def test_single_batched_write(self):
+        session = MagicMock()
+        droplets = [{"id": "d1", "project_id": "p1", "name": "web"}]
+
+        do_compute.load_droplets(session, droplets, TEST_UPDATE_TAG)
+
+        assert session.execute_write.call_count == 1
+        call = session.execute_write.call_args
+        assert "UNWIND $DictList" in call.args[1]
+        assert call.kwargs["DictList"] == droplets
+
+    def test_empty_droplets_write_nothing(self):
+        session = MagicMock()
+        do_compute.load_droplets(session, [], TEST_UPDATE_TAG)
+        session.execute_write.assert_not_called()

--- a/tests/unit/cartography/models/test_relationships.py
+++ b/tests/unit/cartography/models/test_relationships.py
@@ -1,0 +1,36 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeRelWithoutSource
+from tests.data.graph.querybuilder.sample_models.matchlink import FakeUserToRoleMatchLink
+
+
+def test_make_source_node_matcher_exposes_property_refs():
+    ref = PropertyRef('user_id')
+    matcher = make_source_node_matcher({'id': ref})
+
+    assert isinstance(matcher, SourceNodeMatcher) or type(matcher).__name__ == SourceNodeMatcher.__name__
+    assert matcher.id is ref
+
+
+def test_source_node_matcher_is_frozen():
+    matcher = make_source_node_matcher({'id': PropertyRef('user_id')})
+    with pytest.raises(FrozenInstanceError):
+        matcher.id = PropertyRef('other')
+
+
+def test_rel_schema_source_fields_default_to_none():
+    rel = FakeRelWithoutSource()
+    assert rel.source_node_label is None
+    assert rel.source_node_matcher is None
+
+
+def test_matchlink_schema_declares_source_fields():
+    rel = FakeUserToRoleMatchLink()
+    assert rel.source_node_label == 'FakeUser'
+    assert rel.source_node_matcher is not None
+    assert rel.source_node_matcher.id.name == 'user_id'


### PR DESCRIPTION
Implements the Neo4j scaling plan in `docs/perf-improvements/plan.md` — Phase 3.0 (foundation), Phases 3.1–3.7 (batching), and Phase 3.8 (uniform interactions).

Every graph write in the eight in-scope providers (aws, gcp, azure, oci, github, bitbucket, gitlab, azuredevops) now runs through one managed, retried, chunked path. An AST scan for raw `session.run` across those providers returns nothing.

## Why

The fork had drifted badly from upstream on ingestion:

| | This fork (before) | Upstream |
|---|---:|---:|
| Per-item writes (`run()` inside a `for`) | 71 | 2 |
| Raw `session.run()` calls | 371 | 44 |
| Default batch size | 500 | 10,000 |

Upstream had already completed this migration; most of this PR is catching up to work that is tested and running in production elsewhere.

## What changed

**Phase 3.0 — foundation (the part that matters most)**

- **`Session.run` no longer swallows failures.** It logged a warning and returned `self`, so a failed write reported a successful sync while rows silently went missing from the graph. `execute_write`/`execute_read` had the same defect and additionally returned `None`, which surfaced later as a confusing `AttributeError` in `GraphStatement._run_iterative`. All three now log and re-raise.
- Backported upstream's `tx.py`: retry classification (network errors, `EntityNotFound` — expected under this fork's 8-worker write concurrency, `BufferError` "cannot be re-sized"), `batch_size=10000` tunable per call (was hardcoded 500), empty-input short-circuit, and index-creation race tolerance.
- Backported `load_matchlinks()` / `build_matchlink_query()` — the supported replacement for hand-written "link A to B" queries.
- `ensure_indexes()` memoized per schema class per process (it re-issued 6–8 no-op `CREATE INDEX` round-trips on every `load()`).
- New `graph/write_timer.py` emits `graph_write_seconds` alongside `duration_seconds` in aws/gcp/azure timing events, so graph-write time is finally separable from cloud-API time.

**Phases 3.1–3.7 — batching.** Per-item write loops rewritten as UNWIND batches through `load_graph_data`. Worst case was `gcp/compute.py`, which issued ~8 writes *per instance* (including a nested instance × tag × NIC loop) and now issues 9 writes per sync regardless of instance count. Same treatment for `aws/iam.py`, security groups, ELB/ELBv2, Redshift, and the smaller modules.

**Phase 3.8 — uniform interactions.** Remaining raw calls converted by three rules: row-list writes → `load_graph_data`; scalar writes (including `MATCH … SET` with no MERGE) → `run_write_query`; reads → `execute_read(read_list_of_dicts_tx, …)`. Loaders already inside `session.execute_write`/`tx.run` were left alone.

Query text is unchanged throughout, apart from renaming each ingest query's row-list parameter to `$DictList`. Public loader signatures used by integration tests are preserved.

## Behaviour change to expect on deploy

Writes that previously failed silently will now fail the sync stage loudly. **Expect error counts to rise in Sentry.** Those were always failures — they were just invisible.

## Validation

- ~90 new unit tests covering row builders, batch counts, managed-write and managed-read behaviour per provider.
- Full unit suite: 24 failures, all pre-existing (identical set to the pre-branch baseline, minus `test_principal_policies`, which this branch fixes). Two existing tests that asserted on the old raw-call path were updated in place: `test_repos`' query-shape assertion and gcp `test_iam`'s deleted-member regression test.
- **Azure modules are compile + lint validated only** — their SDK packages are unavailable in the dev sandbox. The azure conversions need the CI integration run before merge.
- Phase 2's EXPLAIN plan guard (`KNOWN_OFFENDERS = set()`) is the merge gate for the ingestion queries; `make test_integration` has not been run locally (no Neo4j in the sandbox).

## Review notes

- Commits are granular (one per module group) so individual conversions can be reviewed or reverted independently.
- Worth a close look: `rds.py`. A bulk rename initially hit `UNWIND $Instances` inside `_load_rds_reserved_db_instances_tx`, which runs via `execute_write` and still passed `Instances=data` — caught and reverted, and the two RDS managed-tx loaders keep their original parameter names. It is the kind of thing a mechanical pass can get wrong elsewhere.
- Not included, deliberately: full schema migrations to `tx.load()` with upstream donor models. Phase 3's UNWIND batching captured most of the throughput win; the remaining migration is Option 1 in the plan and should be re-ranked once `graph_write_seconds` produces real numbers.

---
https://claude.ai/code/session_01UmHH3zgSy7zq7d9KBFM7Py
