### PR TITLE
fix(github): preserve original exception in retry logic

### DIFF
--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -98,10 +98,10 @@ def fetch_all(
             retry += 1
             last_exception = sys.exc_info()
 
-        if retry >= retries:
+        if last_exception and retry >= retries:
             logger.error(
                 f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error.",
-                exc_info=True,
+                exc_info=last_exception,
             )
             raise last_exception[1].with_traceback(last_exception[2])
         elif retry > 0:

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 import time
 from typing import Dict
 from typing import List
@@ -81,23 +82,28 @@ def fetch_all(
     has_next_page = True
     data: List[Dict] = []
     retry = 0
+    last_exception = None
     while has_next_page:
         try:
             resp = fetch_page(token, api_url, organization, query, cursor)
             retry = 0
+            last_exception = None
         except requests.exceptions.Timeout:
             retry += 1
+            last_exception = sys.exc_info()
         except requests.exceptions.HTTPError:
             retry += 1
+            last_exception = sys.exc_info()
         except requests.exceptions.ChunkedEncodingError:
             retry += 1
+            last_exception = sys.exc_info()
 
         if retry >= retries:
             logger.error(
                 f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error.",
                 exc_info=True,
             )
-            raise
+            raise last_exception[1].with_traceback(last_exception[2])
         elif retry > 0:
             time.sleep(1 * retry)
             continue

--- a/tests/unit/cartography/intel/github/test_util.py
+++ b/tests/unit/cartography/intel/github/test_util.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from cartography.intel.github.util import fetch_all
+
+
+@patch("cartography.intel.github.util.time.sleep")
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_re_raises_original_timeout(mock_fetch_page, mock_sleep):
+    mock_fetch_page.side_effect = requests.exceptions.Timeout("Connection timed out")
+
+    with pytest.raises(requests.exceptions.Timeout) as exc_info:
+        fetch_all(
+            token="dummy_token",
+            api_url="https://api.github.com/graphql",
+            organization="test_org",
+            query="test_query",
+            resource_type="repositories",
+            field_name="nodes",
+            retries=3,
+        )
+
+    assert "Connection timed out" in str(exc_info.value)
+    assert mock_fetch_page.call_count == 3
+
+
+@patch("cartography.intel.github.util.time.sleep")
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_re_raises_original_http_error(mock_fetch_page, mock_sleep):
+    mock_fetch_page.side_effect = requests.exceptions.HTTPError("403 Client Error: Forbidden")
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        fetch_all(
+            token="dummy_token",
+            api_url="https://api.github.com/graphql",
+            organization="test_org",
+            query="test_query",
+            resource_type="repositories",
+            field_name="nodes",
+            retries=2,
+        )
+
+    assert "403 Client Error: Forbidden" in str(exc_info.value)
+    assert mock_fetch_page.call_count == 2
+
+
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_success_with_zero_retries(mock_fetch_page):
+    mock_fetch_page.return_value = {
+        "data": {
+            "organization": {
+                "url": "https://github.com/test_org",
+                "login": "test_org",
+                "repositories": {
+                    "nodes": [{"name": "repo1"}],
+                    "pageInfo": {
+                        "endCursor": "cursor1",
+                        "hasNextPage": False,
+                    },
+                },
+            },
+        },
+    }
+
+    data, org_data = fetch_all(
+        token="dummy_token",
+        api_url="https://api.github.com/graphql",
+        organization="test_org",
+        query="test_query",
+        resource_type="repositories",
+        field_name="nodes",
+        retries=0,
+    )
+
+    assert len(data) == 1
+    assert data[0]["name"] == "repo1"
+    assert org_data["login"] == "test_org"


### PR DESCRIPTION
### Description

In `cartography/intel/github/util.py`, the `fetch_all()` pagination helper catches transient HTTP exceptions (`Timeout`, `HTTPError`, `ChunkedEncodingError`) to perform retries against the GitHub API. 

However, when retry attempts are exhausted, the function attempts to re-raise via a bare `raise` outside of the `except` blocks:

```python
while has_next_page:
    try:
        resp = fetch_page(...)
        retry = 0
    except requests.exceptions.Timeout:
        retry += 1
    ...
    if retry >= retries:
        logger.error(...)
        raise  # <--- Bare raise outside except context
```

### Impact & Root Cause

Because the `raise` statement is evaluated in the `while` loop body after the `try/except` has already exited, Python 3 treats this as having no active exception context and throws:

```text
RuntimeError: No active exception to re-raise
```

This masks the actual underlying root cause (such as rate limiting `403`, timeouts, or server errors `502`/`504`), making automated error tracking and debugging GitHub sync failures difficult.

This PR preserves the original `sys.exc_info()` during retries and re-raises the actual exception instance with its original traceback intact when retries are exhausted.

---

### How this was tested

- Verified that exhausting retries now raises the original exception (e.g. `requests.exceptions.HTTPError`) with its full stack trace instead of a generic `RuntimeError`.
- Verified that successful responses clear retry state as expected and pagination continues normally.
